### PR TITLE
Add playbook overview link to dropdown

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,6 +10,7 @@
     <li class="sm-mr2 dropdown">
       <a href="{{ '/playbook/' | relative_url }}" class="blue caps text-decoration-none {% if page.url contains '/playbook/' %}active{% endif %}">Playbook<span class="dropdown-arrow"> &#9662;</span></a>
         <ul class="sm-show">
+          <li><a href="{{ '/playbook/' | relative_url }}">Overview</a></li>
           <li><a href="{{ '/playbook/principles/' | relative_url }}">Principles</a></li>
           <li><a href="{{ '/playbook/implementation/' | relative_url }}">Implementation</a></li>
         </ul>


### PR DESCRIPTION
Based off our conversation during the design review, seems very easy to miss that "Playbook" is actually a link and not just a trigger for the dropdown, so added Overview as a link.

![screen shot 2017-03-24 at 4 15 20 pm](https://cloud.githubusercontent.com/assets/1178494/24312023/1ac8c704-10ad-11e7-83d5-08e29cdc3ca3.png)
