### PR TITLE
Fix formatting of multiple links

### DIFF
--- a/_data/help.yml
+++ b/_data/help.yml
@@ -282,7 +282,7 @@
         help protect your account against password compromises.
 
         Your information will stay secure. For more information, read our
-        [security and privacy policy]({{ site.baseurl }}/privacy). Please email
+        [security and privacy policy](site.baseurl/privacy). Please email
         [info@login.gov](mailto:info@login.gov)
         to learn more about how our protection works.
     - question: Will login.gov share my information?
@@ -336,5 +336,5 @@
       content: |
         Please let us know what's working and what you'd like to see in the
         future - we're actively improving login.gov, and we base our
-        improvements on feedback from users like you! Please [contact us]
-        ({{site.baseurl}}/contact) with your questions or feedback.
+        improvements on feedback from users like you! Please [contact us](site.baseurl/contact)
+        with your questions or feedback.

--- a/_data/policy.yml
+++ b/_data/policy.yml
@@ -60,3 +60,8 @@
     agency. It may also assist in determining your eligibility for a
     requested benefit in accordance with the approved routine uses, as
     described in the associated [systems of records notices](https://www.federalregister.gov/documents/2017/01/19/2017-01174/privacy-act-of-1974-notice-of-a-new-system-of-records){:target="_blank"}.
+    
+    #### For more information
+    
+    For more information, please visit the login.gov [Help Center](site.baseurl/help) or
+    [contact us](site.baseurl/contact).

--- a/_pages/help.md
+++ b/_pages/help.md
@@ -50,7 +50,7 @@ class: relative
 {% for question in section.content %}
 <h3 id="{{ question.anchor }}">{{ question.question }}</h3>
 <div markdown="1">
-{{ question.content }}
+{{ question.content | replace: 'site.baseurl', site.baseurl }}
 </div>
 {% endfor %}
             </div>

--- a/_pages/policy.md
+++ b/_pages/policy.md
@@ -29,13 +29,10 @@ class: relative
             {{ section.section }}
             </h2><img alt="hr" class="mb3" src="{{ '/assets/img/hr-red-2.svg' | prepend: site.baseurl }}">
 <div markdown="1">
-{{ section.content }}
+{{ section.content | replace: 'site.baseurl', site.baseurl }}
 </div>
           </div>
         {% endfor %}
-        <h4>For more information</h4>
-        <p markdown="1">For more information, please visit the login.gov [Help
-Center]({{site.baseurl}}/help) or [contact us]({{site.baseurl}}/contact).</p>
       </div>
     </div>
   </div>

--- a/_pages/security.md
+++ b/_pages/security.md
@@ -54,8 +54,7 @@ class: bg-light-blue
             <div class='sm-show'>
               <img class="col col-6 mb1" src="{{ site.baseurl }}/assets/img/logo.svg" alt="login.gov logo">
             </div>
-            <p class="col col-12">For more information, please visit the login.gov [Help
-Center]({{site.baseurl}}/help) or [contact us]({{site.baseurl}}/contact). You can also visit our <a target="_blank" href="https://github.com/18F/identity-idp">open-source repository</a>.</p>
+            <p class="col col-12">For more information, please visit the login.gov <a href="{{site.baseurl}}/help">Help Center</a> or <a href="{{site.baseurl}}/contact">contact us</a>. You can also visit our <a target="_blank" href="https://github.com/18F/identity-idp">open-source repository</a>.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Liquid variables cannot be parsed when the are included in data files, so several of the links embedded within the content were not rendering properly.  This fixes that issue, as well as some other markdown/html issues.