### PR TITLE
Set the canonical domain name as www.login.gov

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Site settings
 title: login.gov
 description: login.gov, the consumer identity platform
+canonical_domain: www.login.gov
 
 # Pages
 collections:

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -5,7 +5,7 @@
 <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 <meta name="description" content="{{ site.description }}">
 
-<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+<link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.canonical_domain | replace: '//', '/' | prepend: 'https://' }}">
 
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/apple-touch-icon.png' | relative_url }}">
 <link rel="icon" type="image/png" href="{{ '/favicon-32x32.png' | relative_url }}" sizes="32x32">


### PR DESCRIPTION
This sets the `<link rel="canonical">` tag to be "www.login.gov"
