### PR TITLE
Revert "Remove links to secure.login.gov (#32)"

### DIFF
--- a/_data/help.yml
+++ b/_data/help.yml
@@ -70,8 +70,8 @@
         Alternatively, you may have accidentally mistyped your email address. If
         so, you can always make another account with your correct email address.
 
-        -   If you mistyped your address, you can create a new
-            account.
+        -   If you mistyped your address, you can [create a new
+            account](https://secure.login.gov/sign_up/enter_email){:target="_blank"}.
         -   If you are certain you entered the correct address, choose “Send
             again” to get a new confirmation email.
     - question: Why didn't I receive a security code to confirm my phone?
@@ -80,8 +80,8 @@
         If you didn't receive a security code, check whether you entered your
         phone number correctly.
 
-        -   If you entered the wrong phone number, you can update your phone
-            number in your account settings.
+        -   If you entered the wrong phone number, you can [update your phone
+            number here](https://secure.login.gov/sign_up/enter_email/manage/phone){:target="_blank"}.
         -   If you entered your phone number correctly, you can [resend the
             confirmation SMS](#). Select if you want to receive the security
             code by text message if you have a mobile phone or through a phone
@@ -228,7 +228,7 @@
     - question: How do I change my password?
       anchor: "how-do-i-change-my-password"
       content: |
-        To change your password, sign in at login.gov and go
+        To change your password, sign in at [login.gov](https://secure.login.gov/){:target="_blank"} and go
         to your Profile page. If you want to change your password, select Edit next to
         password, enter the new password and submit your change. Passwords must be at
         least 8 characters but otherwise there are no restrictions. You can even use

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -22,8 +22,11 @@
     <li class="sm-mr3">
       <a href="https://pages.18f.gov/identity-dev-docs/" class="blue caps text-decoration-none" target="_blank">Developers</a>
     </li>
-    <li>
+    <li class="sm-mr3">
       <a href="{{ '/help/' | relative_url }}" class="blue caps text-decoration-none {% if page.url == '/help/' %}active{% endif %}">Help Center</a>
+    </li>
+    <li>
+      <a href="https://secure.login.gov" class="blue caps text-decoration-none">Sign in</a>
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
This reverts commit b09c19d543faf15938be346642b353fd645ea353.

**Why**:
secure.login.gov is up now

---

I took a guess at where "sign in" would go in the nav -- is all the way on the right correct?