### PR TITLE
Update out-of-date table of contents spec by checking anchors

### DIFF
--- a/_data/help.yml
+++ b/_data/help.yml
@@ -82,8 +82,8 @@
 
         -   If you entered the wrong phone number, you can update your phone
             number in your account settings.
-        -   If you entered your phone number correctly, you can [resend the
-            confirmation SMS](#). Select if you want to receive the security
+        -   If you entered your phone number correctly, you can resend the
+            confirmation SMS. Select if you want to receive the security
             code by text message if you have a mobile phone or through a phone
             call if you have either a landline or a mobile phone.
     - question: Do I need a mobile phone to use login.gov?

--- a/spec/_pages/help.md_spec.rb
+++ b/spec/_pages/help.md_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe 'help.md' do
   it 'escapes html correctly' do
     expect(doc).to properly_escape_html
   end
+
+  it 'links to valid headings' do
+    expect(doc).to link_to_valid_headers
+  end
 end

--- a/spec/_pages/playbook_spec.rb
+++ b/spec/_pages/playbook_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe '/playbook' do
     it 'escapes html correctly' do
       expect(doc).to properly_escape_html
     end
+
+    it 'links to valid headings' do
+      expect(doc).to link_to_valid_headers
+    end
   end
 
   describe '/implementation' do
@@ -23,6 +27,10 @@ RSpec.describe '/playbook' do
     it 'escapes html correctly' do
       expect(doc).to properly_escape_html
     end
+
+    it 'links to valid headings' do
+      expect(doc).to link_to_valid_headers
+    end
   end
 
   describe '/principles' do
@@ -34,6 +42,10 @@ RSpec.describe '/playbook' do
 
     it 'escapes html correctly' do
       expect(doc).to properly_escape_html
+    end
+
+    it 'links to valid headings' do
+      expect(doc).to link_to_valid_headers
     end
   end
 end

--- a/spec/_pages/policy.md_spec.rb
+++ b/spec/_pages/policy.md_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe 'policy.md' do
   it 'escapes html correctly' do
     expect(doc).to properly_escape_html
   end
+
+  it 'links to valid headings' do
+    expect(doc).to link_to_valid_headers
+  end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -18,39 +18,30 @@ RSpec::Matchers.define :open_external_links_in_new_window do
   end
 end
 
-RSpec::Matchers.define :include_a_valid_table_of_contents do
-  error = nil
+RSpec::Matchers.define :link_to_valid_headers do
   missing_headers = []
 
   match do |actual|
     doc = actual
-    toc_comment = doc.at("//comment()[contains(.,'MarkdownTOC')]")
 
-    toc = toc_comment.next_sibling
-    until toc.name == 'ul'
-      toc = toc.next_sibling
-    end
-
-    error = :no_toc if toc.nil?
-    expect(toc).to be
-
-    toc.css('a').each do |a|
+    doc.css('a[href^="#"]').each do |a|
       target = a[:href]
 
-      anchor = doc.at(target)
-      missing_headers << target if anchor.nil?
+      next if a[:id] == 'js-mobile-nav-toggle'
+
+      if target == '#'
+        missing_headers << a.to_s
+      else
+        anchor = doc.at(target)
+        missing_headers << target if anchor.nil?
+      end
     end
 
     expect(missing_headers).to be_empty
   end
 
   failure_message do |actual|
-    case error
-    when :no_toc
-      "expected that #{actual.url} would have a table of contents (MarkdownTOC)"
-    else
-      "expected that #{actual.url} would link to valid headers:\n#{missing_headers.join("\n")}"
-    end
+    "expected that #{actual.url} would link to valid headers:\n#{missing_headers.join("\n")}"
   end
 end
 


### PR DESCRIPTION
-  Also fix a broken anchor

---

I noticed we changed how we're doing tables of contents, so the old specs didn't work so I updated this to check for broken links, and even found one