### PR TITLE
Remove outdated help references

### DIFF
--- a/_data/help.yml
+++ b/_data/help.yml
@@ -261,7 +261,7 @@
         help protect your account against password compromises.
 
         Your information will stay secure. For more information, read our
-        [security and privacy policy](site.baseurl/privacy).
+        [security and privacy policy](site.baseurl/policy).
     - question: Will login.gov share my information?
       anchor: "will-logingov-share-my-information"
       content: |

--- a/spec/_pages/contact.md_spec.rb
+++ b/spec/_pages/contact.md_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe 'contact.md' do
   it 'escapes html correctly' do
     expect(doc).to properly_escape_html
   end
+
+  it 'links to valid internal pages' do
+    expect(doc).to link_to_valid_internal_pages
+  end
 end

--- a/spec/_pages/help.md_spec.rb
+++ b/spec/_pages/help.md_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe 'help.md' do
   it 'links to valid headings' do
     expect(doc).to link_to_valid_headers
   end
+
+  it 'links to valid internal pages' do
+    expect(doc).to link_to_valid_internal_pages
+  end
 end

--- a/spec/_pages/index.md_spec.rb
+++ b/spec/_pages/index.md_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe 'index.md' do
   it 'escapes html correctly' do
     expect(doc).to properly_escape_html
   end
+
+  it 'links to valid internal pages' do
+    expect(doc).to link_to_valid_internal_pages
+  end
 end

--- a/spec/_pages/playbook_spec.rb
+++ b/spec/_pages/playbook_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe '/playbook' do
     it 'links to valid headings' do
       expect(doc).to link_to_valid_headers
     end
+
+    it 'links to valid internal pages' do
+      expect(doc).to link_to_valid_internal_pages
+    end
   end
 
   describe '/implementation' do
@@ -31,6 +35,10 @@ RSpec.describe '/playbook' do
     it 'links to valid headings' do
       expect(doc).to link_to_valid_headers
     end
+
+    it 'links to valid internal pages' do
+      expect(doc).to link_to_valid_internal_pages
+    end
   end
 
   describe '/principles' do
@@ -46,6 +54,10 @@ RSpec.describe '/playbook' do
 
     it 'links to valid headings' do
       expect(doc).to link_to_valid_headers
+    end
+
+    it 'links to valid internal pages' do
+      expect(doc).to link_to_valid_internal_pages
     end
   end
 end

--- a/spec/_pages/policy.md_spec.rb
+++ b/spec/_pages/policy.md_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe 'policy.md' do
   it 'links to valid headings' do
     expect(doc).to link_to_valid_headers
   end
+
+  it 'links to valid internal pages' do
+    expect(doc).to link_to_valid_internal_pages
+  end
 end

--- a/spec/_pages/security.md_spec.rb
+++ b/spec/_pages/security.md_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe 'security.md' do
   it 'escapes html correctly' do
     expect(doc).to properly_escape_html
   end
+
+  it 'links to valid internal pages' do
+    expect(doc).to link_to_valid_internal_pages
+  end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -45,6 +45,30 @@ RSpec::Matchers.define :link_to_valid_headers do
   end
 end
 
+RSpec::Matchers.define :link_to_valid_internal_pages do
+  missing_pages = []
+
+  match do |actual|
+    doc = actual
+
+    doc.css('a[href^="/"]').each do |a|
+      page = a[:href]
+
+      begin
+        file_at(page)
+      rescue
+        missing_pages << page
+      end
+    end
+
+    expect(missing_pages).to be_empty
+  end
+
+  failure_message do |actual|
+    "expected that #{actual.url} would link to valid pages:\n#{missing_pages.join("\n")}"
+  end
+end
+
 RSpec::Matchers.define :properly_escape_html do
   escaped_html_tags = nil
 


### PR DESCRIPTION
We don't offer support via email or phone.