### PR TITLE
Update link text for policy page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <div class="sm-col-right center caps pb2 sm-pb0">
         <a href="{{ '/help/' | relative_url }}" class="white text-decoration-none mr3 {% if page.url == '/help/' %}bold{% endif %}">Help</a>
         <a href="{{ '/contact/' | relative_url }}" class="white text-decoration-none mr3 {% if page.url == '/contact/' %}bold{% endif %}">Contact</a>
-        <a href="{{ '/policy/' | relative_url }}" class="white text-decoration-none {% if page.url == '/policy/' %}bold{% endif %}">Privacy Policy</a>
+        <a href="{{ '/policy/' | relative_url }}" class="white text-decoration-none {% if page.url == '/policy/' %}bold{% endif %}">Privacy and security</a>
       </div>
       <div class="sm-col pt2 sm-pt0 center border-top sm-border-none border-blue">
         U.S. General Services Administration


### PR DESCRIPTION
Why: clearer link name and consistency with `identity-idp`