### PR TITLE
Add spec that watches for the same copy as NewRelic

### DIFF
--- a/spec/_pages/index.md_spec.rb
+++ b/spec/_pages/index.md_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe 'index.md' do
   it 'links to valid internal pages' do
     expect(doc).to link_to_valid_internal_pages
   end
+
+  it 'contains specific copy that NewRelic checks for' do
+    expect(doc.text).to include('secure access to government services')
+  end
 end


### PR DESCRIPTION
**Why**:
It's OK to change the copy, but we need to remember to update
NewRelic to check for the right thing when we deploy