### PR TITLE
Properly translate help page titles

### DIFF
--- a/_includes/help/nav_page_bottom.html
+++ b/_includes/help/nav_page_bottom.html
@@ -8,7 +8,7 @@
         {% capture is_initially_expanded %}{% if page.url contains subpage_slug %}true{% else %}false{% endif %}{% endcapture %}
         {% capture is_initially_hidden %}{% if page.url contains subpage_slug %}false{% else %}true{% endif %}{% endcapture %}
         <button class="btn-transparent border-bottom {% if forloop.first %}border-top{% endif %} flex flex-center w-100pc left-align p2" aria-expanded="{{ is_initially_expanded }}">
-          <span class="w-100pc">{{ subpage }}</span>
+          <span class="w-100pc">{{ site["translations"][site.lang]["help_subpages"][subpage] }}</span>
           <span class="svg-wrapper svg-gray">{% include svg/carat-down.svg %}</span>
         </button>
 

--- a/_includes/help/nav_page_top_small.html
+++ b/_includes/help/nav_page_top_small.html
@@ -6,7 +6,7 @@
         {% assign subpage_slug = subpage | slugify %}
         {% assign subpage_link = site.help | where_exp: "item", "item.url contains subpage_slug" | where: 'order', 1 | first %}
         {% if parent_url contains subpage_slug %}
-          {% assign this_page_parent = subpage %}
+          {% assign this_page_parent = site["translations"][site.lang]["help_subpages"][subpage] %}
           <a class="dropdown-links active white py1 pl1 pr2" href="{{ subpage_link.url | prepend: site.baseurl }}">
             <li class="block bold">
               <img height="8" alt="" src="{{ site.baseurl }}/assets/img/check-mobile.svg"> {{ site["translations"][site.lang]["help_subpages"][subpage] }}


### PR DESCRIPTION
Looks like we forgot to fix some translations on mobile:

<img width="363" alt="screen_shot_2017-06-20_at_12_52_42_pm" src="https://user-images.githubusercontent.com/458784/27345438-b2c90f24-55b7-11e7-8827-7da498b32d97.png">

<img width="333" alt="login_gov___how_does_login_gov_protect_my_data__" src="https://user-images.githubusercontent.com/458784/27345443-b4787ad0-55b7-11e7-85a6-2d9ac9422c9e.png">
