### PR TITLE
Update index and developer contact us footers

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -53,9 +53,9 @@ index:
 
         Led by the [U.S. Digital Service](https://www.usds.gov){:target="_blank"} and [18F](https://18f.gsa.gov){:target="_blank"}, login.gov builds on groundwork laid by the [National Institute for Standards in Technology](https://www.nist.gov/){:target="_blank"}, the [Cybersecurity National Action Plan](https://www.whitehouse.gov/the-press-office/2016/02/09/fact-sheet-cybersecurity-national-action-plan){:target="_blank"}, and the [Federal Acquisition Service](href="https://www.gsa.gov/portal/content/105080){:target="_blank"}.
   footer:
-    heading: Learn more
+    heading: Contact us
     p_1: |
-      If you’re interested in learning more about this platform, please send us a note at [login-contact@gsa.gov](mailto:login-contact@gsa.gov).
+        Have a question or a problem? Call [844-875-6446](tel:1-844-875-6446) between 8:00 am to 8:00 pm ET, Monday to Friday except federal holidays.
 policy_page:
   content:
     p_1: |
@@ -142,8 +142,7 @@ developers_page:
       p_1: Follow ongoing feature development, user experience improvement, and security reviews in our [open source repository](https://github.com/18F/identity-idp){:target="_blank"}.
   footer:
     heading: Contact us
-    p_1: If you’re interested in learning more about the platform, please
-    a_1: contact us
+    p_1: If you’re interested in learning more about the platform, please email [partners@login.gov](mailto:partners@login.gov).
 help_page:
   p_1: Browse common topics
 implementation_page:

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -47,6 +47,8 @@ bg_color: bg-lightest-blue
   <div class="container cntnr-wide px2 py3 center">
     <h3 class="inline align-middle">{% t developers_page.footer.heading %}</h3>
     <span class="inline-block sm-px1 h1 blue align-middle line-height-1">▸</span>
-    <p class="m0 fs-20p inline align-middle">{% t developers_page.footer.p_1 %} <a class="nowrap" href="{{ '/contact/' | relative_url }}">{% t developers_page.footer.a_1 %}</a>.</p>
+    <p class="m0 fs-20p inline align-middle" markdown="1">
+      {% t developers_page.footer.p_1 %}
+    </p>
   </div>
 </div>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -55,18 +55,12 @@ image: /assets/img/login-gov-600x314.png
   </div>
 </div>
 
-<div class="bg-light-blue">
-  <div class="container cntnr-wide px2 py3">
-    <div class="clearfix">
-      <div class="col-12 sm-col-10 mx-auto">
-        <h2 class="mt1 mb2 red">{% t index.footer.heading %}</h2>
-        <p class="mt0 fs-20p serif line-height-3" markdown="1">
-          {{ site.translations[site.lang]["index"]["footer"]["p_1"] | replace: 'site.baseurl', site.baseurl }}
-        </p>
-        <div class="center">
-          <a href="{{ site.baseurl }}/contact" class="btn btn-primary btn-wide mb2">{% t pages.contact_us %}</a>
-        </div>
-      </div>
-    </div>
+<div class="bg-lightest-blue">
+  <div class="container cntnr-wide px2 py3 center">
+    <h3 class="inline align-middle">{% t index.footer.heading %}</h3>
+    <span class="inline-block sm-px1 h1 blue align-middle line-height-1">▸</span>
+    <p class="m0 fs-20p inline align-middle" markdown="1">
+      {{ t.index.footer.p_1 | replace: 'site.baseurl', site.baseurl }}
+    </p>
   </div>
 </div>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -60,7 +60,7 @@ image: /assets/img/login-gov-600x314.png
     <h3 class="inline align-middle">{% t index.footer.heading %}</h3>
     <span class="inline-block sm-px1 h1 blue align-middle line-height-1">▸</span>
     <p class="m0 fs-20p inline align-middle" markdown="1">
-      {{ t.index.footer.p_1 | replace: 'site.baseurl', site.baseurl }}
+      {% t index.footer.p_1 %}
     </p>
   </div>
 </div>


### PR DESCRIPTION
**Why**: To consolidate and organize the various email addresses, phone
numbers, and contact us CTAs across the site. Now that we have a call
center, we want them to handle most requests from the public. We want to
direct agencies interested in integrating to email partners@login.gov.