### PR TITLE
Link to app with correct locale

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -39,7 +39,11 @@
       </ul>
     </li>
     <li>
-      <a href="https://secure.login.gov/" class="blue caps text-decoration-none">{% t nav.manage %}</a>
+      {% if site.lang != 'en' %}
+        <a href="https://secure.login.gov/{{site.lang}}/" class="blue caps text-decoration-none">{% t nav.manage %}</a>
+      {% else %}
+        <a href="https://secure.login.gov/" class="blue caps text-decoration-none">{% t nav.manage %}</a>
+      {% endif %}
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
When viewing the static site in a language other than English, provide a link to secure.login.gov with the correct locale.