### PR TITLE
Remove npm link from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-run: npm-link
+run:
 	make -f Makefile.server -j4 run
 
 clean:
@@ -10,15 +10,11 @@ node_modules/.touch: package.json
 
 setup: node_modules/.touch
 	bundle check || bundle install
-	npm link identity-style-guide
 
 test: build
 	bundle exec rspec spec
 
-npm-link:
-	npm link identity-style-guide
-
-build: npm-link
+build:
 	npm run build && bundle exec jekyll build
 
 .PHONY: setup


### PR DESCRIPTION
npm linking strategy needs to be reworked, removing for now so folks can get the site running locally without the `identity-style-guide` dependency.