### PR TITLE
Fix style-guide css watch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ node_modules/
 .DS_Store
 _sass/
 assets/
+/*.ico
+/*.png
+/*.svg
+/browserconfig.xml
+/manifest.json

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "make-dirs": "mkdir -p ./assets/stylesheets/build && mkdir -p ./assets/js && mkdir -p ./assets/img && mkdir -p ./assets/fonts && mkdir -p ./assets/documents",
     "rebuild": "npm run clean && npm run build",
     "start": "npm run build && bundle exec jekyll serve --incremental",
-    "watch-guide": "onchange './node_modules/identity-style-guide/src/css/*.scss' './node_modules/identity-style-guide/src/js/*.js' './node_modules/identity-style-guide/src/img/*' -v -- npm run build",
+    "watch-guide": "onchange './node_modules/identity-style-guide/src/css/**/*.scss' './node_modules/identity-style-guide/src/js/**/*.js' './node_modules/identity-style-guide/src/img/**/*' -v -- npm run build",
     "watch-webpack": "webpack -w --progress --colors",
     "webpack": "webpack --progress --colors"
   },


### PR DESCRIPTION
- Only changes to the root css folder of the identity-style-guide were being picked up when developing with both repos locally, this expands it to all css components. (Edit: Also noticed the same was true for images and js, so expanded the paths for those as well)
- Additions to .gitignore to avoid committing shared assets.