### PR TITLE
Link to Contact page from Homepage

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -79,7 +79,7 @@ index:
   footer:
     heading: Contact us
     p_1: |
-        Have a question or a problem? Call [844-875-6446](tel:1-844-875-6446) between 8:00 am to 8:00 pm ET, Monday to Friday except federal holidays.
+      Have a question or problem? [Get in touch](site.baseurl/contact).
 policy_page:
   content:
     p_1: |

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -87,7 +87,7 @@ index:
       Dirigido por el [Servicio Digital de EE. UU. (en inglés)](https://www.usds.gov){:target="_blank"} y [18F (en inglés)](https://18f.gsa.gov){:target="_blank"}, login.gov construye sobre las bases establecidas por el [Instituto Nacional de Estándares en Tecnología (en inglés)](http://www.nist.gov/){:target="_blank"}, el [Plan Nacional de Acción de Seguridad Cibernética (en inglés)](https://www.whitehouse.gov/the-press-office/2016/02/09/fact-sheet-cybersecurity-national-action-plan){:target="_blank"}, y el [Servicio Federal de Adquisición (en inglés)](http://www.gsa.gov/portal/content/105080){:target="_blank"}.
   footer:
     heading: Aprenda más
-    p_1: '¿Tiene alguna pregunta o problema? Llámenos al [844-875-6446](tel:1-844-875-6446) entre las 8:00 AM y las 8:00 PM (hora del Este) de lunes a viernes, excepto feriados federales'
+    p_1: '¿Tiene alguna pregunta o problema? [Contáctenos](site.baseurl/contact).'
 policy_page:
   content:
     p_1: |-

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -47,7 +47,7 @@ image: /assets/img/login-gov-600x314.png
     <h3 class="inline align-middle">{% t index.footer.heading %}</h3>
     <span class="inline-block sm-px1 h1 blue align-middle line-height-1">▸</span>
     <p class="m0 fs-20p inline align-middle" markdown="1">
-      {% t index.footer.p_1 %}
+      {{ site.translations[site.lang]["index"]["footer"]["p_1"] | replace: 'site.baseurl', site.baseurl }}
     </p>
   </div>
 </div>


### PR DESCRIPTION
Direct users to the Contact page from the homepage, rather than listing the phone number directly on the homepage.