### PR TITLE
Adjust text size of nav on spanish menu

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,7 +3,7 @@
   <img src="{{ site.baseurl }}/assets/img/close.svg" width="13" alt="Close" class="display-none mx-auto">
 </a>
 
-<nav class="sm-flex flex-center z2">
+<nav class="sm-flex flex-center z2 {{ site.lang }}-nav">
   <ul class="list-reset m0 sm-mt1">
     <li class="sm-mr3">
       <a href="{{ '/' | relative_url }}" class="blue caps text-decoration-none {% if page.url == '/' %}active{% endif %}">{% t nav.home %}</a>


### PR DESCRIPTION
**Why**:
Text was wrapping on spanish text before it
collapsed to the mobile menu. Adjust text size
just for dimensions where it would wrap.