### PR TITLE
Add French translations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ canonical_domain: www.login.gov
 languages:
   - en
   - es
+  - fr
+
 exclude_from_localizations: ["javascript", "images", "css"]
 
 # Pages

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1,8 +1,10 @@
+---
 global:
   language: Language
   locales:
     en: English
     es: Español
+    fr: Français
 meta:
   contact:
     title: Contact
@@ -18,7 +20,8 @@ meta:
     description: Simple, secure access to government services online
     title: Home
   implementation:
-    description: Determine whether your agency or organization needs a consumer identity management system.
+    description: Determine whether your agency or organization needs a consumer identity
+      management system.
     title: Implementation
   not_found:
     title: '404'
@@ -31,7 +34,8 @@ meta:
   privacy_policy:
     title: Privacy policy
   playbook:
-    description: Helping developers and technologists in government agencies build usable, secure, and privacy-protecting consumer identity management systems.
+    description: Helping developers and technologists in government agencies build
+      usable, secure, and privacy-protecting consumer identity management systems.
     title: Identity Playbook
   security:
     description: Learn how login.gov keeps personal information private.
@@ -60,29 +64,33 @@ footer:
 index:
   intro:
     heading: Simple, secure access to government services online
-    content: |
-      login.gov offers the public secure and private online access to participating government programs. With one login.gov account, users can sign in to multiple government agencies. Our goal is to make managing federal benefits, services and applications easier and more secure.
+    content: login.gov offers the public secure and private online access to participating
+      government programs. With one login.gov account, users can sign in to multiple
+      government agencies. Our goal is to make managing federal benefits, services
+      and applications easier and more secure.
   column_1:
     heading: Simple and secure for the public
-    p_1: |
-      Because login.gov is a shared service, users need fewer passwords and learn fewer interfaces. Also, security experts protect one service instead of many. Dedicated teams of design and security experts also will continuously improve it.
+    p_1: Because login.gov is a shared service, users need fewer passwords and learn
+      fewer interfaces. Also, security experts protect one service instead of many.
+      Dedicated teams of design and security experts also will continuously improve
+      it.
   column_2:
     heading: Saving time and <br class="sm-show" />money
-    p_1: |
-      login.gov handles software development, security operations, and customer support. This frees up government departments to focus on their missions while reducing costs and improving security.
+    p_1: login.gov handles software development, security operations, and customer
+      support. This frees up government departments to focus on their missions while
+      reducing costs and improving security.
   column_3:
     heading: Built <br class="sm-show"/>cooperatively
-    p_1: |
+    p_1: |-
       login.gov works with the private sector and nonprofits to identify and implement best practices and new standards.
 
       login.gov builds on groundwork laid by the [National Institute for Standards in Technology](https://www.nist.gov/){:target="_blank"}, the [Cybersecurity National Action Plan](https://www.whitehouse.gov/the-press-office/2016/02/09/fact-sheet-cybersecurity-national-action-plan){:target="_blank"}, and the [Federal Acquisition Service](href="https://www.gsa.gov/portal/content/105080){:target="_blank"}.
   footer:
     heading: Contact us
-    p_1: |
-      Have a question or problem? [Get in touch](site.baseurl/contact).
+    p_1: Have a question or problem? [Get in touch](site.baseurl/contact).
 policy_page:
   content:
-    p_1: |
+    p_1: |-
       Your privacy is very important to us. We’re providing you with
       our privacy policy so you are aware of what information we collect,
       why we collect it, and what we do with it. login.gov does not collect
@@ -91,7 +99,7 @@ policy_page:
       who read or browse information from our site. We do this to better
       understand how the site is being used and how we can make it more
       helpful.
-    p_2: |
+    p_2: |-
       If you create an account, login.gov collects personally identifiable
       information (PII) from you, including your email address and phone
       number. We collect your email address and with your consent share it
@@ -107,7 +115,7 @@ policy_page:
 security_page:
   heading: How login.gov keeps personal information private
   content:
-    p_1: |
+    p_1: |-
       login.gov encrypts the personal information of each user separately,
       using a unique value generated from each user’s password. Our
       encryption method works like a safe deposit box in a bank vault.
@@ -116,36 +124,38 @@ security_page:
       decrypt their information.
   column_1:
     heading: The vault
-    p_1: |
-      It's hard to break into the “vault” or database. login.gov implements the latest [National Institute of Standards and Technology (NIST)](https://www.nist.gov/){:target="_blank"} standards for secure authentication and verification. Our plans for ongoing security include regular penetration testing and external security reviews.
+    p_1: It's hard to break into the “vault” or database. login.gov implements the
+      latest [National Institute of Standards and Technology (NIST)](https://www.nist.gov/){:target="_blank"}
+      standards for secure authentication and verification. Our plans for ongoing
+      security include regular penetration testing and external security reviews.
   column_2:
     heading: The safe deposit box
-    p_1: |
+    p_1: |-
       Individual accounts get a double layer of security. We require
       two-factor authentication as well as strong passwords that meet
       new NIST requirements. Two factor authentication requires that
       you login with your password and a code that we send to your phone.
-    p_2: |
+    p_2: |-
       We will evaluate and implement new authentication methods as they
       become widely available to make sure that login.gov remains
       accessible and secure.
   column_3:
     heading: Your personal key
-    p_1: |
+    p_1: |-
       Encrypting personal data separately means that login.gov cannot
       share any information with other government entities without
       users’ permission. Not even database administrators can decrypt
       a user’s personal information without the user’s password.
   footer:
-    p_1: |
+    p_1: |-
       We welcome external review of our privacy-protection measures.
       All of our code is available for public inspection in an open-source
       repository. Our goal: make sure that at every step users know their
       privacy is being protected by design.
-    p_2: |
-      For more information, please visit [Help](site.baseurl/help) or [contact us](site.baseurl/contact). You can also visit our [open-source repository](https://github.com/18F/identity-idp){:target="_blank"}.
+    p_2: For more information, please visit [Help](site.baseurl/help) or [contact
+      us](site.baseurl/contact). You can also visit our [open-source repository](https://github.com/18F/identity-idp){:target="_blank"}.
 contact_page:
-  content: |
+  content: |-
     ## Find help using login.gov
 
     First, check out answers to [common questions](site.baseurl/help). Still have a question or a problem? Call <span class="bold nowrap">844-875-6446</span> toll-free for more answers and to speak with an information specialist.
@@ -170,20 +180,29 @@ contact_page:
 developers_page:
   intro:
     heading: Easy integration and flexibility
-    p_1: Standard protocols, reusable libraries, and continuous open reviews speed up development and help you stay compliant.
+    p_1: Standard protocols, reusable libraries, and continuous open reviews speed
+      up development and help you stay compliant.
     a_1: See the documentation
   column_1:
     heading: Comply with changing guidance
     content:
-      p_1: Choose between [LOA1 and LOA3](https://developers.login.gov/attributes/){:target="_blank"} for [NIST 800-63-2](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf){:target="_blank"}. When [policies](https://pages.nist.gov/800-63-3/){:target="_blank"} change, we do the work to ensure compliance.
+      p_1: Choose between [LOA1 and LOA3](https://developers.login.gov/attributes/){:target="_blank"}
+        for [NIST 800-63-2](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf){:target="_blank"}.
+        When [policies](https://pages.nist.gov/800-63-3/){:target="_blank"} change,
+        we do the work to ensure compliance.
   column_2:
     heading: Reduce the time to launch
     content:
-      p_1: Take advantage of reusable code libraries. We support both [OpenID Connect](https://developers.login.gov/openid-connect/){:target="_blank"} and [SAML](https://developers.login.gov/saml/){:target="_blank"}. Get started fast with example integration code in [Java](https://github.com/18F/identity-sp-java){:target="_blank"}, [Ruby](https://github.com/18F/identity-sp-sinatra){:target="_blank"}, [Python](https://github.com/18F/identity-sp-python){:target="_blank"} and [iOS](https://github.com/18F/identity-openidconnect-ios-client){:target="_blank"}.
+      p_1: Take advantage of reusable code libraries. We support both [OpenID Connect](https://developers.login.gov/openid-connect/){:target="_blank"}
+        and [SAML](https://developers.login.gov/saml/){:target="_blank"}. Get started
+        fast with example integration code in [Java](https://github.com/18F/identity-sp-java){:target="_blank"},
+        [Ruby](https://github.com/18F/identity-sp-sinatra){:target="_blank"}, [Python](https://github.com/18F/identity-sp-python){:target="_blank"}
+        and [iOS](https://github.com/18F/identity-openidconnect-ios-client){:target="_blank"}.
   column_3:
     heading: Check out the <br class="sm-show">code
     content:
-      p_1: Follow ongoing feature development, user experience improvement, and security reviews in our [open source repository](https://github.com/18F/identity-idp){:target="_blank"}.
+      p_1: Follow ongoing feature development, user experience improvement, and security
+        reviews in our [open source repository](https://github.com/18F/identity-idp){:target="_blank"}.
   footer:
     heading: Contact us
     p_1: If you’re interested in learning more about the platform, please email [partners@login.gov](mailto:partners@login.gov).
@@ -203,8 +222,12 @@ implementation_page:
         a_1: Resources
   section_2:
     heading_1: What are you protecting?
-    p_1: It’s worth assessing what you really need before beginning implementation. Not all information requires an identity system to manage access. You can protect the privacy of users and reduce the security risk to your systems by avoiding any unnecessary collection of personally identifiable information — this even includes contact details.
-    heading_2: "You might not need to implement an identity system if:"
+    p_1: It’s worth assessing what you really need before beginning implementation.
+      Not all information requires an identity system to manage access. You can protect
+      the privacy of users and reduce the security risk to your systems by avoiding
+      any unnecessary collection of personally identifiable information — this even
+      includes contact details.
+    heading_2: 'You might not need to implement an identity system if:'
     ul_1:
       li_1: You do not need to have an ongoing relationship with users.
       li_2: Transactions don’t depend upon personal information being accurate.
@@ -213,42 +236,88 @@ implementation_page:
     ul_2:
       li_1:
         content: What transactions will users need?
-        p_1: Will the transactions be ongoing, as when users bookmark benefits or grant applications to fill out later, then return repeatedly to check the application status? Or will they be a one-time or infrequent, as when people download medical or financial records?
+        p_1: Will the transactions be ongoing, as when users bookmark benefits or
+          grant applications to fill out later, then return repeatedly to check the
+          application status? Or will they be a one-time or infrequent, as when people
+          download medical or financial records?
       li_2:
         content: What kind of information do you need to protect your customers?
-        p_1: Do you need full name and other personal information so that users can access private information? Or do you only need to verify that a user fits in certain categories, such as the veterans category or the senior citizens category?
+        p_1: Do you need full name and other personal information so that users can
+          access private information? Or do you only need to verify that a user fits
+          in certain categories, such as the veterans category or the senior citizens
+          category?
       li_3:
         content: What sort of crime might access to this information make possible?
-        p_1: Information that seems innocent on its own might still be valuable to fraudsters and other criminals in combination with other easily accessed information.
+        p_1: Information that seems innocent on its own might still be valuable to
+          fraudsters and other criminals in combination with other easily accessed
+          information.
       li_4:
         content: What other means of security are available?
-        p_1: Postal tracking numbers, for example, are not secrets because the package will only be delivered to a specific address. The safety of the delivery rests on the security of the building and the conduct of the delivery person, not on the secrecy of the number itself.
+        p_1: Postal tracking numbers, for example, are not secrets because the package
+          will only be delivered to a specific address. The safety of the delivery
+          rests on the security of the building and the conduct of the delivery person,
+          not on the secrecy of the number itself.
     heading_4: What kinds of resources do you already have to identify customers?
-    p_2: Your agency may already have mission-specific information and resources that can be used to identify customers. By integrating resources you know and trust, you can increase the reliability of identification.
+    p_2: Your agency may already have mission-specific information and resources that
+      can be used to identify customers. By integrating resources you know and trust,
+      you can increase the reliability of identification.
     heading_5: To answer this, ask
     ul_3:
       li_1:
         content: What resources are unique to your agency?
-        p_1: Individuals’ confidential interactions with government agencies can generate a trail of metadata. Used carefully, that metadata can facilitate identity verification based on knowledge of those activities. Other government organizations serve as authoritative repositories of biometric data available for internal use. Some agencies may have physical locations that customers can visit.
+        p_1: Individuals’ confidential interactions with government agencies can generate
+          a trail of metadata. Used carefully, that metadata can facilitate identity
+          verification based on knowledge of those activities. Other government organizations
+          serve as authoritative repositories of biometric data available for internal
+          use. Some agencies may have physical locations that customers can visit.
     heading_6: What is a consumer identity management system?
-    p_3: When you’re at home and someone knocks at your door it’s easy enough to decide whether or not to answer. Based on your knowledge of who’s outside, you can decide whether to open the door. Is the person outside a friend? A mail carrier or other expected service provider? A complete stranger? Online, the question of deciding “who’s there” is much harder. Consumer identity management systems make it easier for system administrators to decide whether or not to open the door, and how wide.
+    p_3: When you’re at home and someone knocks at your door it’s easy enough to decide
+      whether or not to answer. Based on your knowledge of who’s outside, you can
+      decide whether to open the door. Is the person outside a friend? A mail carrier
+      or other expected service provider? A complete stranger? Online, the question
+      of deciding “who’s there” is much harder. Consumer identity management systems
+      make it easier for system administrators to decide whether or not to open the
+      door, and how wide.
     heading_7: What is an identity?
-    p_4: In the world of security, “identity” has a very specific technical meaning that differs from a plain English sense. An “identity” in technical terms is a special kind of record — a bundle of different types of data that together describes only one system user [NIST 800-63-3]. That data can include references to official government records, such as driver’s license numbers and registered birth dates, as well as more mutable data such as email addresses and usernames. Physical attributes such as fingerprints and DNA can also be part of an identity record.
+    p_4: In the world of security, “identity” has a very specific technical meaning
+      that differs from a plain English sense. An “identity” in technical terms is
+      a special kind of record — a bundle of different types of data that together
+      describes only one system user [NIST 800-63-3]. That data can include references
+      to official government records, such as driver’s license numbers and registered
+      birth dates, as well as more mutable data such as email addresses and usernames.
+      Physical attributes such as fingerprints and DNA can also be part of an identity
+      record.
     heading_8: How does identity and access management work?
-    p_5: System administrators assign access privileges to each identity record. These privileges authorize certain activities and forbid others. To “open the door” safely, however, administrators need confidence that the users knocking at the door are who they say they are.
-    p_6: To give the system and its administrators confidence in their identities, users need to prove their identities through an activity called authentication. Users authenticate themselves by presenting evidence linking themselves to records. To do that, users first help the system validate their record — for example, by typing in a username. Then users hand over the evidence — often, passwords or other information only the real person would know.
+    p_5: System administrators assign access privileges to each identity record. These
+      privileges authorize certain activities and forbid others. To “open the door”
+      safely, however, administrators need confidence that the users knocking at the
+      door are who they say they are.
+    p_6: To give the system and its administrators confidence in their identities,
+      users need to prove their identities through an activity called authentication.
+      Users authenticate themselves by presenting evidence linking themselves to records.
+      To do that, users first help the system validate their record — for example,
+      by typing in a username. Then users hand over the evidence — often, passwords
+      or other information only the real person would know.
     heading_9: What does having an identity record enable?
-    p_7: "Identity systems don’t just benefit system administrators. Users can do some very handy things with an authenticated digital identity. Here’s a small list:"
+    p_7: 'Identity systems don’t just benefit system administrators. Users can do
+      some very handy things with an authenticated digital identity. Here’s a small
+      list:'
     ul_4:
       li_1:
-        span_1: Pre-filling online forms with verified information speeds up application processing.
-        span_2: There’s less redundant effort, and users don’t need to worry about basic errors.
+        span_1: Pre-filling online forms with verified information speeds up application
+          processing.
+        span_2: There’s less redundant effort, and users don’t need to worry about
+          basic errors.
       li_2:
-        span_1: Authenticated users can access and download data the system holds about them, such as account activity.
-        span_2: With a verified legal identity, the user can access very sensitive medical or financial records and even download them.
+        span_1: Authenticated users can access and download data the system holds
+          about them, such as account activity.
+        span_2: With a verified legal identity, the user can access very sensitive
+          medical or financial records and even download them.
       li_3:
         span_1: Identity systems can protect your privacy.
-        span_2: If you need to be 21 or older to access a service, you can authorize an identity system to confirm your age without sharing your exact birth date.
+        span_2: If you need to be 21 or older to access a service, you can authorize
+          an identity system to confirm your age without sharing your exact birth
+          date.
     heading_10: Implementation
     ul_5:
       li_1:
@@ -257,23 +326,31 @@ implementation_page:
     ul_6:
       li_1:
         a_1: National Institute of Standards in Technology
-        content:  (NIST 800-63-3)
+        content: "(NIST 800-63-3)"
       li_2:
         a_1: Digital Services Playbook
       li_3:
         a_1: GitHub repo for login.gov
       li_4:
-        a_1: "On the Internet, nobody knows you're a dog"
+        a_1: On the Internet, nobody knows you're a dog
 playbook_page:
   section_1:
-    p_1: Identity management — or making sure that only the correct people get access to systems — is central to delivering public services online. We are sharing these principles to help developers and technologists in government agencies build usable, secure, and privacy-protecting consumer identity management systems.
+    p_1: Identity management — or making sure that only the correct people get access
+      to systems — is central to delivering public services online. We are sharing
+      these principles to help developers and technologists in government agencies
+      build usable, secure, and privacy-protecting consumer identity management systems.
   section_2:
     heading_1: The principles
-    p_1: Building this system includes taking recommendations and best practices from policy experts, system architects, and people focused on creating a great user experience. Our research and our progress so far has led us to identify five major principles that we believe will help us make the best system possible.
+    p_1: Building this system includes taking recommendations and best practices from
+      policy experts, system architects, and people focused on creating a great user
+      experience. Our research and our progress so far has led us to identify five
+      major principles that we believe will help us make the best system possible.
     p_2:
       a_1: See the principles
     heading_2: Implementation
-    p_3: Before implementing login.gov or any other consumer identity management system, you should determine whether your agency or organization needs one. Below is a list of questions to ask and things to consider to help you figure that out.
+    p_3: Before implementing login.gov or any other consumer identity management system,
+      you should determine whether your agency or organization needs one. Below is
+      a list of questions to ask and things to consider to help you figure that out.
     p_4:
       a_1: Learn about implementation
 principles_page:
@@ -284,8 +361,9 @@ principles_page:
     li_2: Understand the login experiences and identity needs of your audiences
     li_3: Conduct research before building or implementing a system
     li_4: Test your product to identify blind spots or areas for improvement
-    li_5: When the current best practices aren’t good enough for your users, test new solutions and help guide adoption
-  p_1: |
+    li_5: When the current best practices aren’t good enough for your users, test
+      new solutions and help guide adoption
+  p_1: |-
     Solving real problems for potential users should be the focus for any system, and is doubly important when building an identity management system. Throughout this playbook, you’ll see how satisfying user needs is a guiding principle in every decision made.
 
     One of the first steps you should take is identifying your core users. For login.gov, we’ve identified two groups as our core users: the general public and tech people inside government agencies. The goal for the system itself is to support and address the needs of the general public. To put it plainly, we want to make sure that our system makes people comfortable with logging in to government services. The public needs to feel confident that login.gov behaves as expected and will not disappoint them. The system also needs to address users’ entire experience as they try to accomplish their goals. Because identity verification and authentication is technologically complex, it’s not unlikely that even the most tech-savvy people could get stuck if their phone is lost or a system has errors. So in support of each agency’s mission, architects and designers of consumer identity management systems need to anticipate likely sticking points so that people don’t lose access to the services and benefits.
@@ -301,7 +379,7 @@ principles_page:
     li_2: Explain how and why you’re collecting, sharing, and storing data
     li_3: Create a privacy policy that regular people can access and understand
     li_4: Create a privacy policy that is inclusive and informative
-  p_2: |
+  p_2: |-
     [Working transparently](https://playbook.cio.gov/#play13){:target="_blank"} and creating a transparent system should be the way any agency works when building or implementing an identity management system. To execute this principle with login.gov, we’re building the platform so that interested parties can advise us on best practices and so that we remain accountable to the public and to our partners across the government. Further, it means building a system that tells users what it does with their information to create accountability and build trust. We’re engaging users and other interested parties through our [GitHub repo](https://github.com/18F/identity-idp){:target="_blank"} and working on creating public forums where people can discuss our work.
 
     To make an identity management system transparent for end users, the system you build should include features that educate people about how the system works, why it works that way, and how they can control what’s happening with their data. You should also let users know what information is needed by an agency when logging in to a service. It’s also important to tell users what information your systems will store and if any data is shared with other agencies. If people using the system aren’t comfortable with information sharing, they shouldn’t be forced to participate.
@@ -310,11 +388,13 @@ principles_page:
   heading_4: Build a flexible product
   ul_3:
     li_1: Develop the product in sprints and evaluate effectiveness after each sprint
-    li_2: Continually talk with stakeholders and experts to evaluate needs and success metrics
-    li_3: Test your product with users continuously as you add new features and refine old ones
+    li_2: Continually talk with stakeholders and experts to evaluate needs and success
+      metrics
+    li_3: Test your product with users continuously as you add new features and refine
+      old ones
     li_4: Define what a minimal viable product is for your identity management needs
     li_5: Plan to evolve based on changing technology and changing standards
-  p_3: |
+  p_3: |-
     Technology and standards for identity verification and authentication can change rapidly. Consumer identity management systems should readily adapt to changing standards and react to new security threats. To make adapting to new policies and capabilities possible, it’s a good practice to build products using agile methods and with changing versions in mind. In other words, plan for modifications to help your identity service be as up-to-date as possible and compliant with current standards and policies.
 
     We’re embracing this principle for every aspect of the project in building login.gov.
@@ -325,7 +405,7 @@ principles_page:
     li_1: Store as little personally identifying data as possible
     li_2: Give users other means of accomplishing their goals
     li_3: Give users control over their data
-  p_4: |
+  p_4: |-
     Consumer identity management systems store personal information about users so that people don’t have to repeat the verification and authentication processes over and over again. However, collecting and storing personal information raises ethical and legal questions that system designers and developers need to consider. Often, what comes to mind first are technical questions about security: protecting information from unauthorized or illegal access and uses. However, we also need to worry about authorized, legal uses of personal information that violate users’ expectations of privacy. Users of login.gov need to be sure that we’re handling their personal information respectfully and appropriately.
 
     The first step is only collecting the information you absolutely need. And that’s what login.gov is doing. High-assurance identity verification for sensitive tasks does require extensive information collection. However, many activities don’t require high levels of assurance (LOA) and login.gov supports different LOA so agencies can clearly delineate their users who need lower levels of security from those with more sensitive needs while ensuring usability and data security. Minimizing the amount of information collected and stored not only lowers the security risk; it also reduces worries about re-use and disclosure for users.
@@ -341,7 +421,7 @@ principles_page:
     li_4: Use modern encryption techniques throughout the technology stack
     li_5: Only store the absolute minimum data necessary
     li_6: Help users understand the security measures they are required to carry out
-  p_5: |
+  p_5: |-
     Figuring out who is trying to access personal information and making sure only authorized users can gain access to that information are the keys to consumer identity management. The reason systems like this exist is to secure the user’s identity from those looking to commit theft or fraud.
 
     Being deliberate about security means focusing our attention on what needs to be protected. It means thinking carefully about how to balance protection and accessibility. Doing this successfully includes educating users about how they can protect themselves or mitigate the effects of crime.
@@ -353,128 +433,141 @@ help:
   changing-settings:
     how-do-i-change-my-email-address: How do I change my email address?
     how-do-i-change-my-password: How do I change my password?
-    how-do-i-change-the-phone-number-i-am-using-with-my-account: How do I change the phone number I am using with my account?
+    how-do-i-change-the-phone-number-i-am-using-with-my-account: How do I change the
+      phone number I am using with my account?
   creating-an-account:
     do-i-need-a-mobile-phone-to-use-logingov: Do I need a mobile phone to use login.gov?
     how-do-i-create-an-account-with-logingov: How do I create an account with login.gov?
-    i-didnt-receive-a-confirmation-email-from-logingov: "I didn't receive a confirmation email from login.gov."
-    what-do-i-do-if-an-account-already-exists-under-my-email-address: What do I do if an account already exists under my email address?
+    i-didnt-receive-a-confirmation-email-from-logingov: I didn't receive a confirmation
+      email from login.gov.
+    what-do-i-do-if-an-account-already-exists-under-my-email-address: What do I do
+      if an account already exists under my email address?
     what-is-two-factor-authentication: What is two factor authentication?
-    why-didnt-i-receive-a-security-code-to-confirm-my-phone: "Why didn't I receive a security code to confirm my phone?"
-    why-do-i-need-to-confirm-my-email-address-and-my-phone-number: Why do I need to confirm my email address and my phone number?
-    why-do-i-need-to-use-logingov-to-access-government-services-online: Why do I need to use login.gov to access government services online?
+    why-didnt-i-receive-a-security-code-to-confirm-my-phone: Why didn't I receive
+      a security code to confirm my phone?
+    why-do-i-need-to-confirm-my-email-address-and-my-phone-number: Why do I need to
+      confirm my email address and my phone number?
+    why-do-i-need-to-use-logingov-to-access-government-services-online: Why do I need
+      to use login.gov to access government services online?
   privacy-and-security:
-    can-i-remove-a-saved-password-or-login-information-from-my-browser: Can I remove a saved password or login information from my browser?
+    can-i-remove-a-saved-password-or-login-information-from-my-browser: Can I remove
+      a saved password or login information from my browser?
     how-do-i-make-my-password-strong: How do I make my password strong?
     how-does-logingov-protect-my-data: How does login.gov protect my data?
     will-logingov-share-my-information: Will login.gov share my information?
   signing-in:
-    i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me: "I can't remember where my personal key is and I dont have my phone with me."
-    i-forgot-which-email-address-i-used-to-create-an-account: I forgot which email address I used to create an account.
-    if-i-dont-have-my-phone-with-me-can-i-still-sign-in: "If I don't have my phone with me can I still sign in?"
-    what-do-i-do-if-my-password-doesnt-work-or-i-forget-it: What do I do if my password doesnt work or I forget it?
-    what-do-i-need-to-have-in-order-to-sign-in: What do I need to have in order to sign in?
-    what-happens-if-i-miss-the-phone-call-or-the-text-message-with-my-one-time-security-code: What happens if I miss the phone call or the text message with my one time security code?
+    i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me: I can't
+      remember where my personal key is and I dont have my phone with me.
+    i-forgot-which-email-address-i-used-to-create-an-account: I forgot which email
+      address I used to create an account.
+    if-i-dont-have-my-phone-with-me-can-i-still-sign-in: If I don't have my phone
+      with me can I still sign in?
+    what-do-i-do-if-my-password-doesnt-work-or-i-forget-it: What do I do if my password
+      doesnt work or I forget it?
+    what-do-i-need-to-have-in-order-to-sign-in: What do I need to have in order to
+      sign in?
+    what-happens-if-i-miss-the-phone-call-or-the-text-message-with-my-one-time-security-code: What
+      happens if I miss the phone call or the text message with my one time security
+      code?
     what-is-an-authenticator-app: What is an authenticator app?
     why-does-the-system-log-me-out: Why does the system log me out?
 policies:
-  - section: Our privacy practices
-    anchor: "our-privacy-practices"
-    content: |
-      This privacy notice describes how we ask for, use, retain, and protect
-      your personal information, as well as your obligation to disclose it.
+- section: Our privacy practices
+  anchor: our-privacy-practices
+  content: |-
+    This privacy notice describes how we ask for, use, retain, and protect
+    your personal information, as well as your obligation to disclose it.
 
-      Our goal is to protect your personal information, and we will not share
-      it without your permission. For example, we will encrypt your personal
-      information in transit and at rest and ask you before sharing your data
-      with a partner agency. However, there may be circumstances where we are
-      required to share certain data. For example: if the information is relevant
-      and necessary for an authorized law enforcement purpose; in order to
-      respond to a breach; or to assist another agency as it responds to a
-      breach. For additional information, see the [system of record notice number GSA/TTS-1](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"}
-      that GSA’s Technology Transformation Service (TTS) published on August 10, 2017.
+    Our goal is to protect your personal information, and we will not share
+    it without your permission. For example, we will encrypt your personal
+    information in transit and at rest and ask you before sharing your data
+    with a partner agency. However, there may be circumstances where we are
+    required to share certain data. For example: if the information is relevant
+    and necessary for an authorized law enforcement purpose; in order to
+    respond to a breach; or to assist another agency as it responds to a
+    breach. For additional information, see the [system of record notice number GSA/TTS-1](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"}
+    that GSA’s Technology Transformation Service (TTS) published on August 10, 2017.
 
-      ### Privacy Act statement
+    ### Privacy Act statement
 
-      #### Authorities
+    #### Authorities
 
-      The information you provide to access your login.gov account is
-      collected pursuant to 6 USC § 1523 (b)(1)(A)-(E), the [E-Government Act of 2002 (44 USC § 3501)](https://www.gpo.gov/fdsys/pkg/PLAW-107publ347/html/PLAW-107publ347.htm){:target="_blank"},
-      and 40 USC § 501.
+    The information you provide to access your login.gov account is
+    collected pursuant to 6 USC § 1523 (b)(1)(A)-(E), the [E-Government Act of 2002 (44 USC § 3501)](https://www.gpo.gov/fdsys/pkg/PLAW-107publ347/html/PLAW-107publ347.htm){:target="_blank"},
+    and 40 USC § 501.
 
-      #### Purpose
+    #### Purpose
 
-      The information that you submit is used to create or update your
-      login.gov account. Once you create an account, with
-      your consent, login.gov will share your email address with the partner agency to
-      provide online access to government information and services.
+    The information that you submit is used to create or update your
+    login.gov account. Once you create an account, with
+    your consent, login.gov will share your email address with the partner agency to
+    provide online access to government information and services.
 
-      #### Disclosure
+    #### Disclosure
 
-      You decide what information to give us. However, failure to provide
-      complete and accurate information may delay access to the partner agency.
-      The information you give login.gov will be shared with the applicable
-      federal agency to provide access to information about you held by that
-      agency as described in the associated [systems of records notices](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"}.
-      Please note that the login.gov system will record certain session-level information
-      about your use of the service, including but not limited to, web browser
-      type and version, and the length of your session. This information allows
-      login.gov better understand how the site is being used and how it can be
-      made more helpful.
+    You decide what information to give us. However, failure to provide
+    complete and accurate information may delay access to the partner agency.
+    The information you give login.gov will be shared with the applicable
+    federal agency to provide access to information about you held by that
+    agency as described in the associated [systems of records notices](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"}.
+    Please note that the login.gov system will record certain session-level information
+    about your use of the service, including but not limited to, web browser
+    type and version, and the length of your session. This information allows
+    login.gov better understand how the site is being used and how it can be
+    made more helpful.
 
-      #### Storage
+    #### Storage
 
-      All records are stored electronically in a database in GSA’s
-      [Amazon Web Services (AWS) environment](https://aws.amazon.com/){:target="_blank"}.
-      You can modify, or amend, either your email address or phone number
-      by accessing it in your account. You should choose an email address
-      through which you would like to receive correspondence from any partner
-      agency whose services or information you might access. Changing that
-      address will redirect all email correspondence with any partner agency.
+    All records are stored electronically in a database in GSA’s
+    [Amazon Web Services (AWS) environment](https://aws.amazon.com/){:target="_blank"}.
+    You can modify, or amend, either your email address or phone number
+    by accessing it in your account. You should choose an email address
+    through which you would like to receive correspondence from any partner
+    agency whose services or information you might access. Changing that
+    address will redirect all email correspondence with any partner agency.
 
-      Similarly, you should choose the number of a phone that you have access
-      to in order to receive and respond with the one-time password(s) that
-      are sent to that number.
+    Similarly, you should choose the number of a phone that you have access
+    to in order to receive and respond with the one-time password(s) that
+    are sent to that number.
 
-      Your email address and phone number will be maintained for at least six
-      years in accordance with National Archives and Records Administration
-      (NARA) guidance. However, GSA is authorized to maintain the information
-      for longer if it is required for business use. login.gov must be able
-      to provide users access to information and services at partner agencies
-      and therefore may have a business need to retain the information longer
-      than the six-year retention period.
+    Your email address and phone number will be maintained for at least six
+    years in accordance with National Archives and Records Administration
+    (NARA) guidance. However, GSA is authorized to maintain the information
+    for longer if it is required for business use. login.gov must be able
+    to provide users access to information and services at partner agencies
+    and therefore may have a business need to retain the information longer
+    than the six-year retention period.
 
-      ### Privacy Impact Assessment
+    ### Privacy Impact Assessment
 
-      View our [Privacy Impact Assessment](site.baseurl/docs/privacy-impact-assessment.pdf).
+    View our [Privacy Impact Assessment](site.baseurl/docs/privacy-impact-assessment.pdf).
+- section: Our security practices
+  anchor: our-security-practices
+  content: |-
+    login.gov uses a variety of security methods to protect this U.S.
+    government service and your data, and to ensure the service remains
+    available to all users. These methods include monitoring and recording
+    network traffic (any data going in and out of login.gov) to identify
+    unauthorized attempts to change information, or otherwise cause damage.
 
-  - section: Our security practices
-    anchor: "our-security-practices"
-    content: |
-      login.gov uses a variety of security methods to protect this U.S.
-      government service and your data, and to ensure the service remains
-      available to all users. These methods include monitoring and recording
-      network traffic (any data going in and out of login.gov) to identify
-      unauthorized attempts to change information, or otherwise cause damage.
+    Unauthorized access or use of login.gov (e.g. use for criminal purposes,
+    or to cause damage, etc) is against the law, and may subject you to
+    criminal prosecution and penalties.
 
-      Unauthorized access or use of login.gov (e.g. use for criminal purposes,
-      or to cause damage, etc) is against the law, and may subject you to
-      criminal prosecution and penalties.
+    ### Vulnerability Disclosure Policy
 
-      ### Vulnerability Disclosure Policy
+    login.gov authorizes the outside security community to perform security
+    research for the intent of reporting discovered security vulnerabilities
+    in the login.gov platform.
 
-      login.gov authorizes the outside security community to perform security
-      research for the intent of reporting discovered security vulnerabilities
-      in the login.gov platform.
+    View our [Vulnerability Disclosure Policy](https://18f.gsa.gov/vulnerability-disclosure-policy/){:target="_blank"}
+    for details on this policy and how to report discovered vulnerabilities.
 
-      View our [Vulnerability Disclosure Policy](https://18f.gsa.gov/vulnerability-disclosure-policy/){:target="_blank"}
-      for details on this policy and how to report discovered vulnerabilities.
+    ### For more information
 
-      ### For more information
-
-      We are happy to answer questions about our security and privacy practices.
-      For more information, please visit [Help](site.baseurl/help)
-      or [contact us](site.baseurl/contact).
+    We are happy to answer questions about our security and privacy practices.
+    For more information, please visit [Help](site.baseurl/help)
+    or [contact us](site.baseurl/contact).
 help_pages:
   changing-settings:
     how-do-i-change-my-email-address: To change your email address, select Edit next

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1,8 +1,10 @@
+---
 global:
   language: Idioma
   locales:
     en: English
     es: Español
+    fr: Français
 meta:
   contact:
     title: Contacto
@@ -18,8 +20,9 @@ meta:
     description: Simple, secure access to government services online
     title: Inicio
   implementation:
-    description: Determine whether your agency or organization needs a consumer identity management system.
-    title: 'Implementación'
+    description: Determine whether your agency or organization needs a consumer identity
+      management system.
+    title: Implementación
   not_found:
     title: '404'
   principles:
@@ -31,32 +34,27 @@ meta:
   privacy_policy:
     title: Política de privacidad
   playbook:
-    description: Helping developers and technologists in government agencies build usable, secure, and privacy-protecting consumer identity management systems.
+    description: Helping developers and technologists in government agencies build
+      usable, secure, and privacy-protecting consumer identity management systems.
     title: Manual de identidad
   security:
     description: Learn how login.gov keeps personal information private.
     title: Seguridad
 banner:
-  text: |2-
-
-    Un sitio oficial del Gobierno de Estados Unidos
+  text: Un sitio oficial del Gobierno de Estados Unidos
 help_subpages:
   changing-settings: Cambiando las configuraciones
   creating-an-account: Creando una cuenta
   privacy-and-security: Privacidad y seguridad
-  signing-in: |2-
-
-    Iniciando sesión
+  signing-in: Iniciando sesión
 nav:
   overview: Resumen
   menu: Menú
   home: Inicio
   playbook: Manual
   principles: Principios
-  implementation: 'Implementación'
-  security: |2-
-
-    Seguridad
+  implementation: Implementación
+  security: Seguridad
   developers: Desarrolladores
   help: Ayuda
   manage: Administrar cuenta
@@ -73,12 +71,14 @@ index:
       federales sea más fácil y más seguro.
   column_1:
     heading: Servicio compartido
-    p_1: |
-      Debido a que login.gov es un servicio compartido, los usuarios necesitan menos contraseñas y menos interfaces que aprender. Además, los expertos en seguridad protegen un solo servicio en lugar de muchos. Los equipos de expertos se dedican a mejorar el diseño y la seguridad continuamente.
+    p_1: Debido a que login.gov es un servicio compartido, los usuarios necesitan
+      menos contraseñas y menos interfaces que aprender. Además, los expertos en seguridad
+      protegen un solo servicio en lugar de muchos. Los equipos de expertos se dedican
+      a mejorar el diseño y la seguridad continuamente.
   column_2:
     heading: Conveniencia y eficacia
-    p_1: |-
-      Esto permite ahorro de tiempo y dinero en el Gobierno, quitando una tarea común que no distraiga la concentración de las agencias en sus funciones principales.
+    p_1: Esto permite ahorro de tiempo y dinero en el Gobierno, quitando una tarea
+      común que no distraiga la concentración de las agencias en sus funciones principales.
   column_3:
     heading: Mayor cooperación
     p_1: |-
@@ -87,7 +87,7 @@ index:
       login.gov construye sobre las bases establecidas por el Instituto [Nacional de Estándares en Tecnología (en inglés)](https://www.nist.gov/){:target="_blank"}, el [Plan Nacional de Acción de Seguridad Cibernética (en inglés)](https://www.whitehouse.gov/the-press-office/2016/02/09/fact-sheet-cybersecurity-national-action-plan){:target="_blank"}, y el [Servicio Federal de Adquisición (en inglés)](href="https://www.gsa.gov/portal/content/105080){:target="_blank"}.
   footer:
     heading: Aprenda más
-    p_1: '¿Tiene alguna pregunta o problema? [Contáctenos](site.baseurl/contact).'
+    p_1: "¿Tiene alguna pregunta o problema? [Contáctenos](site.baseurl/contact)."
 policy_page:
   content:
     p_1: |-
@@ -101,12 +101,9 @@ policy_page:
   content:
     p_1: Es posible que desee comprobar su enlace e intentar nuevamente. (404)
 security_page:
-  heading: |2-
-
-    Cómo login.gov mantiene la información personal en privado
+  heading: Cómo login.gov mantiene la información personal en privado
   content:
-    p_1: |2-
-
+    p_1: |-
       Login.gov encripta la información personal de cada usuario por separado, usando un valor único generado a partir de la contraseña de cada usuario. Nuestro método de encripción funciona como una caja de seguridad en una bóveda del banco.
       Sólo el usuario tiene la clave. Sólo el usuario puede abrir la caja para revelar los contenidos. Sólo el usuario conoce la contraseña y sólo el usuario puede descifrar su información.
   column_1:
@@ -117,9 +114,7 @@ security_page:
       Nuestros planes de seguridad continua incluyen pruebas de penetración regulares
       y revisiones de seguridad externas.
   column_2:
-    heading: |2-
-
-      La caja fuerte
+    heading: La caja fuerte
     p_1: Las cuentas individuales obtienen dos niveles de seguridad. Requerimos la
       autenticación de dos factores, así como contraseñas seguras que cumplan con
       los nuevos requisitos del NIST. La autenticación de dos factores requiere que
@@ -140,11 +135,11 @@ security_page:
       un repositorio de código abierto. Nuestra meta: asegurarnos de que en cada paso
       los usuarios tengan conocimiento de que su privacidad está siendo protegida
       de la manera que diseñamos la plataforma.'
-    p_2: 'Para obtener más información, visite el sitio web de login.gov [Centro de
-      ayuda](site.baseurl/help) o [contáctenos](site.baseurl/contact). También
-      puede visitar nuestro [repositorio de código abierto](https://github.com/18F/identity-idp){:target="_blank"}.'
+    p_2: Para obtener más información, visite el sitio web de login.gov [Centro de
+      ayuda](site.baseurl/help) o [contáctenos](site.baseurl/contact). También puede
+      visitar nuestro [repositorio de código abierto](https://github.com/18F/identity-idp){:target="_blank"}.
 contact_page:
-  content: |
+  content: |-
     ## Encuentre ayuda para usar login.gov
 
     Revise las respuestas a las [preguntas comunes](site.baseurl/ayuda) primero. ¿Aún tiene alguna pregunta o problema? Llámenos a la línea telefónica gratuita 844-875-6446 para recibir más respuestas o para hablar con un operador.
@@ -212,18 +207,16 @@ implementation_page:
       li_4:
         a_1: Recursos
   section_2:
-    heading_1: |2-
-
-      ¿Qué está protegiendo?
-    p_1: |2-
-
-      Vale la pena evaluar lo que realmente necesita antes de comenzar la implementación. No toda la información requiere un sistema de identidad para administrar el acceso. Puede proteger la privacidad de los usuarios y reducir el riesgo de seguridad en sus sistemas, evitando cualquier recopilación innecesaria de información personal identificable—incluso los detalles de contacto.
+    heading_1: "¿Qué está protegiendo?"
+    p_1: Vale la pena evaluar lo que realmente necesita antes de comenzar la implementación.
+      No toda la información requiere un sistema de identidad para administrar el
+      acceso. Puede proteger la privacidad de los usuarios y reducir el riesgo de
+      seguridad en sus sistemas, evitando cualquier recopilación innecesaria de información
+      personal identificable—incluso los detalles de contacto.
     heading_2: 'Es posible que no necesite implementar un sistema de identidad si:'
     ul_1:
       li_1: No es necesario tener una relación continua con los usuarios.
-      li_2: |2-
-
-        Las transacciones no dependen de que la información personal sea exacta.
+      li_2: Las transacciones no dependen de que la información personal sea exacta.
       li_3: Puede contar con otras formas de seguridad.
     heading_3: Para responder a esto, pregunte
     ul_2:
@@ -235,17 +228,13 @@ implementation_page:
           solicitud? ¿O será que sus usuarios regresarán una vez o infrecuentemente
           como cuando la gente descarga registros médicos o financieros?"
       li_2:
-        content: |2-
-
-          ¿Qué tipo de información necesita para proteger a sus clientes?
+        content: "¿Qué tipo de información necesita para proteger a sus clientes?"
         p_1: "¿Necesita el nombre completo y otra información personal para que los
           usuarios puedan acceder a la información privada? ¿O sólo necesita verificar
           que un usuario encaja en ciertas categorías como la categoría de veteranos
           o la categoría de jubilados?"
       li_3:
-        content: |2-
-
-          ¿Qué tipo de delito se podría cometer con el acceso a esta información?
+        content: "¿Qué tipo de delito se podría cometer con el acceso a esta información?"
         p_1: La información que parece simple por sí misma puede ser valiosa para
           los estafadores y otros criminales en combinación con otra información de
           fácil acceso.
@@ -269,9 +258,7 @@ implementation_page:
           de esas actividades. Otras organizaciones gubernamentales sirven como repositorios
           autorizados de datos biométricos disponibles para uso interno. Algunas agencias
           pueden tener lugares para que los clientes puedan visitarlos en persona.
-    heading_6: |2-
-
-      ¿Qué es un sistema de gestión de la identidad del consumidor?
+    heading_6: "¿Qué es un sistema de gestión de la identidad del consumidor?"
     p_3: Cuando está en su casa y alguien toca la puerta es bastante fácil decidir
       si responder o no. Fundado en su conocimiento de quién está afuera, usted puede
       decidir si abre la puerta. ¿La persona que está afuera es un amigo? ¿Un repartidor
@@ -307,9 +294,8 @@ implementation_page:
       autenticada. Aquí hay una pequeña lista:'
     ul_4:
       li_1:
-        span_1: |2-
-
-          Llenar con anticipación formularios en línea con información verificada acelera el procesamiento de solicitudes.
+        span_1: Llenar con anticipación formularios en línea con información verificada
+          acelera el procesamiento de solicitudes.
         span_2: Hay menos esfuerzo redundante, y los usuarios no necesitan preocuparse
           por errores básicos.
       li_2:
@@ -334,24 +320,22 @@ implementation_page:
       li_2:
         a_1: Manual de servicios digitales
       li_3:
-        a_1: |2-
-
-          Acuerdo de recompra de GitHub para login.gov
+        a_1: Acuerdo de recompra de GitHub para login.gov
       li_4:
         a_1: En internet nadie sabe que eres un perro
 playbook_page:
   section_1:
-    p_1: 'El manejo de identidades —o asegurarse de que sólo las personas apropiadas
+    p_1: El manejo de identidades —o asegurarse de que sólo las personas apropiadas
       tengan acceso a los sistemas— es fundamental para la prestación de servicios
       públicos en línea. Estamos compartiendo estos principios para ayudar a los desarrolladores
       y tecnólogos en agencias gubernamentales a crear sistemas de manejo de identidad
-      que sean utilizables, seguros y protejan la privacidad del consumidor. '
+      que sean utilizables, seguros y protejan la privacidad del consumidor.
   section_2:
     heading_1: Los principios
     p_1: La construcción de este sistema incluye tomar recomendaciones y mejores prácticas
-      de expertos en política, arquitectos de sistemas y personas enfocadas crear una experiencia
-      excepcional para el usuario. Hasta ahora nuestra investigación y
-      nuestro progreso nos ha llevado a identificar cinco principios fundamentales
+      de expertos en política, arquitectos de sistemas y personas enfocadas crear
+      una experiencia excepcional para el usuario. Hasta ahora nuestra investigación
+      y nuestro progreso nos ha llevado a identificar cinco principios fundamentales
       que creemos que nos ayudarán a establecer el mejor sistema posible.
     p_2:
       a_1: Ver los principios
@@ -366,14 +350,11 @@ principles_page:
   heading_1: Los principios del manual de identidad
   heading_2: Concéntrese en las necesidades de los usuarios
   ul_1:
-    li_1: |2-
-
-      Identifique sus audiencias potenciales
-    li_2: 'Comprenda las experiencias de acceso y las necesidades de identidad de
-      sus audiencias '
+    li_1: Identifique sus audiencias potenciales
+    li_2: Comprenda las experiencias de acceso y las necesidades de identidad de sus
+      audiencias
     li_3: Realice investigaciones antes de crear o implementar un sistema
-    li_4: "\nHaga pruebas de su producto para identificar puntos ciegos o áreas de
-      mejoramiento "
+    li_4: Haga pruebas de su producto para identificar puntos ciegos o áreas de mejoramiento
     li_5: Cuando las mejores prácticas actuales no son lo suficientemente buenas para
       sus usuarios, pruebe nuevas soluciones y ayude a la adopción
   p_1: |-
@@ -401,16 +382,15 @@ principles_page:
     login.gov está trabajando para implementar todas estas características que mejoran la transparencia. Además, para ayudar a las personas a entender todo lo que está sucediendo, estamos creando una política de privacidad que explica cómo se comparten los datos y lo que significa no participar.
   heading_4: Construya un producto flexible
   ul_3:
-    li_1: |2-
-
-      Desarrolle el producto en etapas y evalúe la efectividad después de cada etapa
+    li_1: Desarrolle el producto en etapas y evalúe la efectividad después de cada
+      etapa
     li_2: Hable continuamente con las partes interesadas y expertos para evaluar las
       necesidades y los indicadores de éxito
     li_3: Haga pruebas de su producto continuamente con los usuarios a medida que
       agrega nuevas herramientas y refina las viejas
     li_4: Defina qué es un producto mínimo viable para sus necesidades de manejo de
       identidades
-    li_5: 'Planifique evolucionar en función de la tecnología y los estándares cambiantes '
+    li_5: Planifique evolucionar en función de la tecnología y los estándares cambiantes
   p_3: |-
     La tecnología y los estándares para la verificación y autenticación de identidad pueden cambiar rápidamente. Los sistemas de manejo de identidad de los consumidores deben adaptarse fácilmente a las normas cambiantes y reaccionar ante las nuevas amenazas de seguridad. Para hacer posible la adaptación a nuevas políticas y capacidades, la creación de productos usando métodos ágiles es una buena práctica, considerando versiones cambiantes en el proceso. En otras palabras, planificar las modificaciones para ayudar a que su servicio de identidad esté tan actualizado como sea posible y sea compatible con las normas y políticas actuales.
 
@@ -455,11 +435,9 @@ principles_page:
   ul_5:
     li_1: Identifique las mejores prácticas de la industria y adhiérase a ellas
     li_2: Cumpla con las regulaciones federales como FISMA y FedRamp
-    li_3: |2-
-
-      Establezca sistemas para monitorear y detectar fraudes
+    li_3: Establezca sistemas para monitorear y detectar fraudes
     li_4: Utilice técnicas modernas de encripción en todo el montón de tecnología
-    li_5: 'Guarde solamente el mínimo absoluto de datos necesarios '
+    li_5: Guarde solamente el mínimo absoluto de datos necesarios
     li_6: Ayude a los usuarios a comprender las medidas de seguridad que deben cumplir
   p_5: "Para la gestión de la identidad del consumidor es clave determinar quién está
     tratando de acceder a la información personal y asegurarse de que sólo los usuarios
@@ -475,12 +453,13 @@ principles_page:
     Todas estas decisiones requieren una deliberación cuidadosa para determinar cuál
     es la mejor opción tanto para los usuarios como para las agencias y para asegurar
     máxima funcionalidad. \n\nEn la construcción de login.gov, estamos cumpliendo
-    con las normas presentadas por el [Instituto Nacional de Estándares y Tecnología (en inglés)](https://pages.nist.gov/800-63-3/){:target=\"_blank\"}
-    (NIST 800-63-2) y adaptaremos sus planes preliminares de estándares nuevos (NIST
-    800-63-3) a medida que sean terminados. Los planes preliminares para los estándares
-    adoptan un enfoque muy diferente para la autenticación y la prueba de identidad
-    (cómo una persona inicia sesión y cómo verifica su identidad) de la versión actual.
-    Además, seguimos las [mejores practicas de seguridad del Gobierno (en inglés)](https://playbook.cio.gov/#play11){:target=\"_blank\"}
+    con las normas presentadas por el [Instituto Nacional de Estándares y Tecnología
+    (en inglés)](https://pages.nist.gov/800-63-3/){:target=\"_blank\"} (NIST 800-63-2)
+    y adaptaremos sus planes preliminares de estándares nuevos (NIST 800-63-3) a medida
+    que sean terminados. Los planes preliminares para los estándares adoptan un enfoque
+    muy diferente para la autenticación y la prueba de identidad (cómo una persona
+    inicia sesión y cómo verifica su identidad) de la versión actual. Además, seguimos
+    las [mejores practicas de seguridad del Gobierno (en inglés)](https://playbook.cio.gov/#play11){:target=\"_blank\"}
     incluyendo FedRAMP, operando en código abierto, realizando rigurosas evaluaciones
     rutinarias de seguridad, además del cumplimiento de la Ley Federal de Gestión
     de la Seguridad de la Información (FISMA, sigla en inglés)."
@@ -494,127 +473,119 @@ help:
     do-i-need-a-mobile-phone-to-use-logingov: "¿Necesito un teléfono móvil para usar
       login.gov?"
     how-do-i-create-an-account-with-logingov: "¿Cómo puedo crear una cuenta con login.gov?"
-    i-didnt-receive-a-confirmation-email-from-logingov: |2-
-
-      No recibí un email de confirmación de login.gov.
+    i-didnt-receive-a-confirmation-email-from-logingov: No recibí un email de confirmación
+      de login.gov.
     what-do-i-do-if-an-account-already-exists-under-my-email-address: "¿Qué debo hacer
       si una cuenta con mi email ya existe?"
     what-is-two-factor-authentication: "¿Qué es la autenticación de dos factores?"
-    why-didnt-i-receive-a-security-code-to-confirm-my-phone: |2-
-
-      ¿Por qué no recibí un código de seguridad para confirmar mi teléfono?
-    why-do-i-need-to-confirm-my-email-address-and-my-phone-number: |2-
-
-      ¿Por qué tengo que confirmar mi email y mi número de teléfono?
+    why-didnt-i-receive-a-security-code-to-confirm-my-phone: "¿Por qué no recibí un
+      código de seguridad para confirmar mi teléfono?"
+    why-do-i-need-to-confirm-my-email-address-and-my-phone-number: "¿Por qué tengo
+      que confirmar mi email y mi número de teléfono?"
     why-do-i-need-to-use-logingov-to-access-government-services-online: "¿Por qué
       tengo que usar login.gov para acceder a los servicios del Gobierno en línea?"
   privacy-and-security:
     can-i-remove-a-saved-password-or-login-information-from-my-browser: "¿Puedo borrar
       de mi navegador una contraseña o información guardarda para iniciar sesión?"
-    how-do-i-make-my-password-strong: |2-
-
-      ¿Cómo puedo hacer que mi contraseña sea segura?
-    how-does-logingov-protect-my-data: |2-
-
-      ¿Cómo protege login.gov mis datos?
+    how-do-i-make-my-password-strong: "¿Cómo puedo hacer que mi contraseña sea segura?"
+    how-does-logingov-protect-my-data: "¿Cómo protege login.gov mis datos?"
     will-logingov-share-my-information: "¿Compartirá login.gov mi información?"
   signing-in:
     i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me: No
       puedo recordar dónde está mi clave personal y no tengo mi teléfono conmigo.
     i-forgot-which-email-address-i-used-to-create-an-account: Olvidé el email que
       utilicé para crear una cuenta.
-    if-i-dont-have-my-phone-with-me-can-i-still-sign-in: |2-
-
-      Si no tengo mi teléfono conmigo, ¿puedo iniciar sesión?
+    if-i-dont-have-my-phone-with-me-can-i-still-sign-in: Si no tengo mi teléfono conmigo,
+      ¿puedo iniciar sesión?
     what-do-i-do-if-my-password-doesnt-work-or-i-forget-it: "¿Qué hago si mi contraseña
       no funciona o la olvido?"
     what-do-i-need-to-have-in-order-to-sign-in: "¿Qué debo tener para iniciar sesión?"
-    what-happens-if-i-miss-the-phone-call-or-the-text-message-with-my-one-time-security-code: |2-
-
-      ¿Qué sucede si pierdo la llamada telefónica o el mensaje de texto con mi código de seguridad de un sólo uso?
+    what-happens-if-i-miss-the-phone-call-or-the-text-message-with-my-one-time-security-code: "¿Qué
+      sucede si pierdo la llamada telefónica o el mensaje de texto con mi código de
+      seguridad de un sólo uso?"
     what-is-an-authenticator-app: "¿Qué es una app de autenticación?"
     why-does-the-system-log-me-out: "¿Por qué el sistema me desconecta?"
 policies:
-  - section: "Nuestras prácticas de privacidad"
-    anchor: "nuestras-prácticas-de-privacidad"
-    content: |
-      Este aviso de privacidad describe cómo pedimos, utilizamos, retenemos
-      y protegemos su información personal, así como su obligación de divulgarla.
+- section: Nuestras prácticas de privacidad
+  anchor: nuestras-prácticas-de-privacidad
+  content: |-
+    Este aviso de privacidad describe cómo pedimos, utilizamos, retenemos
+    y protegemos su información personal, así como su obligación de divulgarla.
 
-      Nuestro objetivo es proteger su información personal, y no la compartiremos
-      sin su permiso. Por ejemplo, encriptaremos su información personal en tránsito
-      y en reposo y pediremos su permiso antes de compartir sus datos con una agencia
-      asociada. Sin embargo, pueden haber circunstancias en las que somos requeridos
-      a compartir ciertos datos. Por ejemplo: si la información es relevante y necesaria
-      para un propósito autorizado en la aplicación de la ley, a fin de responder
-      a una violación, o para ayudar a otra agencia que responde a un incumplimiento.
-      Para obtener información adicional, consulte el [sistema de número de notificación
-      de registro GSA / TTS-1](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"} que el Servicio de Transformación
-      de Tecnología de GSA (TTS, sigla en inglés) publicó el 10 de agosto de 2017.
+    Nuestro objetivo es proteger su información personal, y no la compartiremos
+    sin su permiso. Por ejemplo, encriptaremos su información personal en tránsito
+    y en reposo y pediremos su permiso antes de compartir sus datos con una agencia
+    asociada. Sin embargo, pueden haber circunstancias en las que somos requeridos
+    a compartir ciertos datos. Por ejemplo: si la información es relevante y necesaria
+    para un propósito autorizado en la aplicación de la ley, a fin de responder
+    a una violación, o para ayudar a otra agencia que responde a un incumplimiento.
+    Para obtener información adicional, consulte el [sistema de número de notificación
+    de registro GSA / TTS-1](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"} que el Servicio de Transformación
+    de Tecnología de GSA (TTS, sigla en inglés) publicó el 10 de agosto de 2017.
 
-      ### Declaración de la Ley de Privacidad
+    ### Declaración de la Ley de Privacidad
 
-      #### Autoridades
-      La información que usted proporciona para acceder a su cuenta de login.gov es recogida
-      en conformidad con 6 USC § 1523 (b) (1) (A) - (E), la [Ley de Gobierno Electrónico de 2002
-      (44 USC § 3501)](https://www.gpo.gov/fdsys/pkg/PLAW-107publ347/html/PLAW-107publ347.htm){:target="_blank"},
-      Y 40 USC § 501.
+    #### Autoridades
+    La información que usted proporciona para acceder a su cuenta de login.gov es recogida
+    en conformidad con 6 USC § 1523 (b) (1) (A) - (E), la [Ley de Gobierno Electrónico de 2002
+    (44 USC § 3501)](https://www.gpo.gov/fdsys/pkg/PLAW-107publ347/html/PLAW-107publ347.htm){:target="_blank"},
+    Y 40 USC § 501.
 
-      #### Propósito
-      La información que usted envía se utiliza para crear o actualizar su cuenta de login.gov.
-      Una vez que creada su cuenta, con su consentimiento, login.gov compartirá su email con la
-      agencia asociada para proveer acceso en línea a información y servicios gubernamentales.
+    #### Propósito
+    La información que usted envía se utiliza para crear o actualizar su cuenta de login.gov.
+    Una vez que creada su cuenta, con su consentimiento, login.gov compartirá su email con la
+    agencia asociada para proveer acceso en línea a información y servicios gubernamentales.
 
-      #### Divulgación
-      Usted decide qué información nos da. Sin embargo, la falta de información
-      completa y precisa puede retrasar el acceso a la agencia asociada. La información
-      que usted entrega a login.gov será compartida con la agencia federal correspondiente
-      para proveer acceso a su información bajo el mantenimiento de la agencia, tal
-      como se describe en los correspondientes [sistemas de registros de avisos](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"}. Tenga en cuenta que el sistema login.gov
-      grabará cierta información a nivel de sesión en relación a su uso del servicio,
-      incluyendo pero no limitado a, tipo y versión del navegador web, y la duración
-      de su sesión. Esta información permite que login.gov comprenda mejor cómo el
-      sitio está siendo utilizando y cómo puede hacerse más útil.
+    #### Divulgación
+    Usted decide qué información nos da. Sin embargo, la falta de información
+    completa y precisa puede retrasar el acceso a la agencia asociada. La información
+    que usted entrega a login.gov será compartida con la agencia federal correspondiente
+    para proveer acceso a su información bajo el mantenimiento de la agencia, tal
+    como se describe en los correspondientes [sistemas de registros de avisos](https://www.federalregister.gov/documents/2017/08/10/2017-16852/privacy-act-of-1974-system-of-records){:target="_blank"}. Tenga en cuenta que el sistema login.gov
+    grabará cierta información a nivel de sesión en relación a su uso del servicio,
+    incluyendo pero no limitado a, tipo y versión del navegador web, y la duración
+    de su sesión. Esta información permite que login.gov comprenda mejor cómo el
+    sitio está siendo utilizando y cómo puede hacerse más útil.
 
-      #### Almacenamiento
-      Todos los registros se almacenan electrónicamente en una base de datos
-      en GSA [Amazon Web Services (AWS)](https://aws.amazon.com/){:target="_blank"}.
-      Usted puede modificar o corregir su email o número de teléfono, accediendo a
-      su cuenta. Debe elegir un email a través del cual desea recibir correspondencia
-      de cualquier agencia asociada cuyos servicios o información usted puede acceder.
-      El cambio de su email redireccionará toda la correspondencia por email con cualquier
-      agencia asociada.
+    #### Almacenamiento
+    Todos los registros se almacenan electrónicamente en una base de datos
+    en GSA [Amazon Web Services (AWS)](https://aws.amazon.com/){:target="_blank"}.
+    Usted puede modificar o corregir su email o número de teléfono, accediendo a
+    su cuenta. Debe elegir un email a través del cual desea recibir correspondencia
+    de cualquier agencia asociada cuyos servicios o información usted puede acceder.
+    El cambio de su email redireccionará toda la correspondencia por email con cualquier
+    agencia asociada.
 
-      Del mismo modo, usted debe elegir el número de un teléfono
-      al que tiene acceso para recibir y responder con la(s) contraseña(s) de sólo
-      un uso que se envían a ese número.
+    Del mismo modo, usted debe elegir el número de un teléfono
+    al que tiene acceso para recibir y responder con la(s) contraseña(s) de sólo
+    un uso que se envían a ese número.
 
-      Su email y número de teléfono se mantendrán
-      por al menos seis\naños de acuerdo con la Administración Nacional de Archivos
-      y Registros (NARA, sigla en inglés). Sin embargo, GSA está autorizado a mantener
-      la información por más tiempo si es necesario para el uso comercial. Login.gov
-      debe ser capaz de proporcionar a sus usuarios acceso a información y servicios
-      en agencias asociadas, y por lo tanto, puede tener una necesidad comercial para
-      retener la información por más tiempo que el período de retención de seis años.
+    Su email y número de teléfono se mantendrán
+    por al menos seis\naños de acuerdo con la Administración Nacional de Archivos
+    y Registros (NARA, sigla en inglés). Sin embargo, GSA está autorizado a mantener
+    la información por más tiempo si es necesario para el uso comercial. Login.gov
+    debe ser capaz de proporcionar a sus usuarios acceso a información y servicios
+    en agencias asociadas, y por lo tanto, puede tener una necesidad comercial para
+    retener la información por más tiempo que el período de retención de seis años.
 
-      ### Evaluación de Impacto de la Privacidad
-      Vea nuestra [Evaluación del impacto
-      sobre la privacidad](site.baseurl/docs/privacy-impact-assessment.pdf).
-  - section: "Nuestras prácticas de seguridad"
-    anchor: "nuestras-prácticas-de-seguridad"
-    content: |
-      login.gov utiliza una variedad de métodos de seguridad para proteger este
-      servicio del Gobierno y sus datos, y para asegurar que el servicio permanezca disponible para todos los usuarios. Estos métodos incluyen el monitoreo y registro
-      de tráfico de red (cualquier dato que entra y sale de login.gov) para identificar intentos no autorizados de cambiar la información o de otra manera causar daño.
+    ### Evaluación de Impacto de la Privacidad
+    Vea nuestra [Evaluación del impacto
+    sobre la privacidad](site.baseurl/docs/privacy-impact-assessment.pdf).
+- section: Nuestras prácticas de seguridad
+  anchor: nuestras-prácticas-de-seguridad
+  content: |-
+    login.gov utiliza una variedad de métodos de seguridad para proteger este
+    servicio del Gobierno y sus datos, y para asegurar que el servicio permanezca disponible para todos los usuarios. Estos métodos incluyen el monitoreo y registro
+    de tráfico de red (cualquier dato que entra y sale de login.gov) para identificar intentos no autorizados de cambiar la información o de otra manera causar daño.
 
-      El acceso no autorizado o el uso de login.gov (por ejemplo, uso con fines criminales, o para causar daño, etc.) está en contra de la ley, y puede someterle a procesamiento penal y sanciones.
+    El acceso no autorizado o el uso de login.gov (por ejemplo, uso con fines criminales, o para causar daño, etc.) está en contra de la ley, y puede someterle a procesamiento penal y sanciones.
 
-      ### Política de divulgación de vulnerabilidades
+    ### Política de divulgación de vulnerabilidades
 
-      login.gov autoriza a la comunidad de seguridad externa a realizar investigación en seguridad con la intención de reportar vulnerabilidades de seguridad descubiertas en la plataforma login.gov.
+    login.gov autoriza a la comunidad de seguridad externa a realizar investigación en seguridad con la intención de reportar vulnerabilidades de seguridad descubiertas en la plataforma login.gov.
 
-      Vea nuestra [Política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/){:target="_blank"}
-      Para obtener detalles sobre esta política y sobre cómo informar de las vulnerabilidades detectadas.
+    Vea nuestra [Política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/){:target="_blank"}
+    Para obtener detalles sobre esta política y sobre cómo informar de las vulnerabilidades detectadas.
 help_pages:
   changing-settings:
     how-do-i-change-my-email-address: Ingrese a login.gov y vaya a su página de perfil.

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1,0 +1,667 @@
+---
+global:
+  language: Langue
+  locales:
+    en: English
+    es: Español
+    fr: Français
+meta:
+  contact:
+    title: Contact
+  contact_us:
+    title: Nous joindre
+  developers:
+    title: Développeurs
+  help:
+    title: Aide
+  home:
+    title: Accueil
+  implementation:
+    title: Mise en œuvre
+  not_found:
+    title: '404'
+  principles:
+    title: Principes
+  privacy_and_security:
+    title: Confidentialité et sécurité
+  privacy_policy:
+    title: Politique de confidentialité
+  playbook:
+    title: Guide de mise en œuvre relatif à l'identité
+  security:
+    title: Sécurité
+banner:
+  text: Un site web officiel du gouvernement des États-Unis
+help_subpages:
+  changing-settings: Changement des paramètres
+  creating-an-account: Création d'un compte
+  privacy-and-security: Confidentialité et sécurité
+  signing-in: Connexion
+nav:
+  overview: Aperçu
+  menu: Menu
+  home: Accueil
+  playbook: Guide de mise en œuvre
+  principles: Principes
+  implementation: Mise en œuvre
+  security: Sécurité
+  developers: Développeurs
+  help: Aide
+  manage: Gestion du compte
+  skip_nav: Passer au contenu principal
+footer:
+  gsa: Administration des services généraux des États-Unis
+index:
+  intro:
+    heading: Accès simple et sécurisé aux services en ligne du gouvernement
+    content: login.gov offre l'accès public et sécurisé en ligne aux programmes gouvernementaux
+      participants. Avec un compte de connexion à login.gov, les utilisateurs peuvent
+      se connecter à de multiples agences gouvernementales. Notre objectif est de
+      faciliter la gestion des avantages sociaux, applications et services fédéraux
+      et de la rendre plus sécurisée.
+  column_1:
+    heading: Simple *et* sécurisée pour le public
+    p_1: les utilisateurs ont besoin de moins de mots de passe et doivent apprendre
+      à naviguer dans moins d'interfaces. Les experts en sécurité protègent un service
+      au lieu de plusieurs. Des équipes dédiées d'experts en conception et sécurité
+      améliorent le site de façon continue.
+  column_2:
+    heading: Économiser temps et <br class="sm-show" />argent
+    p_1: |-
+      login.gov gère le développement de logiciels, les opérations de sécurité et l'assistance à la clientèle. Ceci libère les départements gouvernementaux et leur permet de se concentrer sur leurs missions tout en réduisant les coûts et en améliorant la sécurité.
+
+      Une plate-forme d'authentification partagée libère les ressources des agences gouvernementales afin d'offrir d'excellents services tout en réduisant les coûts et en améliorant la sécurité.
+  column_3:
+    heading: Bâti <br class="sm-show"/>de façon coopérative
+    p_1: |-
+      login.gov travaille en collaboration avec le secteur privé, les organismes à but non lucratif afin d'identifier et mettre en œuvre les meilleures pratiques et les nouvelles normes en matière d'authentification sécurisée qui protège la confidentialité.
+
+        Dirigé par le [U.S. Digital Service](https://www.usds.gov){:target="_blank"} et [18F](https://18f.gsa.gov){:target="_blank"}, login.gov est bâti sur les bases établies par le [National Institute for Standards in Technology](https://www.nist.gov/){:target="_blank"}, le [Cybersecurity National Action Plan](https://www.whitehouse.gov/the-press-office/2016/02/09/fact-sheet-cybersecurity-national-action-plan){:target="_blank"} et le [Federal Acquisition Service](href="https://www.gsa.gov/portal/content/105080){:target="_blank"}.
+  footer:
+    heading: Nous joindre
+    p_1: 'Vous avez une question ou un problème? Appelez au [844-875-6446](tél. :
+      1-844-875-6446) entre 8 h et 20 h HE, du lundi au vendredi, sauf les jours fériés
+      fédéraux.'
+policy_page:
+  content:
+    p_1: |-
+      Votre confidentialité est très importante pour nous. Nous vous fournissons notre politique de confidentialité afin que vous soyez informé(e)s de l'information que nous recueillons, des raisons pour lesquelles nous la recueillons et de ce que nous en faisons. login.gov ne recueille pas votre adresse courriel ou votre numéro de téléphone sauf si vous choisissez de fournir ces informations.
+      Nous recueillons d'autres informations limitées automatiquement auprès des visiteurs qui lisent ou parcourent l'information contenue sur notre site. Nous faisons ceci pour mieux comprendre la manière dont le site est utilisé et comment nous pouvons le rendre plus utile.
+    p_2: Si vous créez un compte, login.gov recueille de vous des renseignements permettant
+      d'identifier une personne comme l'adresse courriel et le numéro de téléphone.
+      Nous recueillons votre adresse courriel et avec votre consentement nous la partageons
+      avec chaque agence fédérale (« agence partenaire ») auprès de laquelle vous
+      cherchez à obtenir de l'information et des services. Nous recueillons votre
+      numéro de téléphone afin de permettre une authentification à deux facteurs comme
+      mesure de sécurité pour votre compte login.gov. Votre numéro de téléphone est
+      envoyé uniquement à un fournisseur de mot de passe à utilisation unique, mais
+      à aucune des agences partenaires.
+404_page:
+  heading: La page que vous recherchez n'existe pas.
+  content:
+    p_1: Nous vous recommandons de revérifier votre lien et d'essayer de nouveau.
+      (404)
+security_page:
+  heading: Comment login.gov garde confidentielle l'information privée
+  content:
+    p_1: |-
+      login.gov chiffre séparément l'information personnelle de chaque utilisateur en utilisant une valeur unique générée à partir du mot de passe de chaque utilisateur. Notre méthode de chiffrement fonctionne comme un coffre bancaire dans la chambre forte d'une banque.
+      Seul l'utilisateur possède la clé. Seul l'utilisateur peut ouvrir le coffre pour révéler le contenu. Seul l'utilisateur connaît le mot de passe et seul l'utilisateur peut déchiffrer l'information.
+  column_1:
+    heading: La chambre forte
+    p_1: Il est difficile de s'introduire par effraction dans la « chambre forte »
+      ou dans la base de données. login.gov met en œuvre les normes les plus récentes
+      du [National Institute of Standards and Technology (NIST)](https://www.nist.gov/){:target="_blank"}
+      relatives aux authentifications et vérifications sécurisées. Notre plan d'action
+      pour assurer une sécurité continue inclut des tests réguliers sur la pénétration
+      et des examens réguliers de la sécurité externe.
+  column_2:
+    heading: Le coffre bancaire
+    p_1: Les comptes individuels obtiennent une double couche de sécurité. Nous exigeons
+      une authentification à deux facteurs de même que des mots de passe forts qui
+      répondent aux exigences du NIST. L'authentification à deux facteurs requiert
+      que vous vous connectiez avec votre mot de passe et un code que nous envoyons
+      à votre téléphone.
+    p_2: Nous évaluerons et mettrons en œuvre de nouvelles méthodes d'authentification
+      au fur et à mesure qu'elles deviendront disponibles à grande échelle afin d'assurer
+      que login.gov demeure accessible et sécurisé.
+  column_3:
+    heading: Votre clé personnelle
+    p_1: Le chiffrement des données personnelles signifie que login.gov ne peut partager
+      aucune information avec d'autres entités gouvernementales sans l'autorisation
+      de l'utilisateur. Même les administrateurs de bases de données ne peuvent déchiffrer
+      l'information personnelle d'un utilisateur sans le mot de passe de l'utilisateur.
+  footer:
+    p_1: |-
+      Nous accueillons favorablement tout examen externe de nos mesures de protection de la confidentialité.
+      La totalité de notre code est disponible pour inspection publique dans un référentiel à source ouverte. Notre objectif : s'assurer qu'à chaque étape, les utilisateurs sachent que leur confidentialité est protégée au niveau même de la conception.
+    p_2: Pour obtenir plus d'information, veuillez visiter [Help](site.baseurl/help)
+      ou [contact us](site.baseurl/contact). Vous pouvez aussi visiter notre [référentiel
+      à code source ouvert](https://github.com/18F/identity-idp){:target="_blank"}.
+contact_page:
+  content: Consultez d'abord les réponses aux [questions fréquentes](site.baseurl/help/).
+    Si par la suite vous avez toujours une question ou un problème? Appelez au 844-875-6446
+    sans frais pour obtenir plus de réponses et pour parler avec un spécialiste de
+    l'information. Les spécialistes de l'information sont disponibles entre 8 h et
+    20 h HE, du lundi au vendredi, sauf les jours fériés fédéraux.
+developers_page:
+  intro:
+    heading: Intégration facile et flexibilité
+    p_1: Les protocoles standards, les bibliothèques réutilisables et les examens
+      ouverts accélèrent le développement et vous aident à demeurer conforme.
+    a_1: Voir la documentation
+  column_1:
+    heading: Se conformer à un auditoire changeant
+    content:
+      p_1: Choisissez entre [LOA1 and LOA3](https://developers.login.gov/attributes/){:target="_blank"}
+        pour [NIST 800-63-2](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf){:target="_blank"}.
+        Lorsque [policies](https://pages.nist.gov/800-63-3/){:target="_blank"} change,
+        nous effectuons le travail pour assurer la conformité.
+  column_2:
+    heading: Réduire les délais de lancement
+    content:
+      p_1: Tirez profit des bibliothèques de codes réutilisables. Nous prenons en
+        charge [OpenID Connect](https://developers.login.gov/openid-connect/){:target="_blank"}
+        et [SAML](https://developers.login.gov/saml/){:target="_blank"}. Démarrez
+        rapidement avec un code d'intégration exemple dans [Java](https://github.com/18F/identity-sp-java){:target="_blank"},
+        [Ruby](https://github.com/18F/identity-sp-sinatra){:target="_blank"}, [Python](https://github.com/18F/identity-sp-python){:target="_blank"}
+        et [iOS](https://github.com/18F/identity-openidconnect-ios-client){:target="_blank"}.
+  column_3:
+    heading: Consultez le <br class="sm-show">code
+    content:
+      p_1: Suivez le développement continu des fonctionnalités, les améliorations
+        apportées à l'expérience de l'utilisateur et les examens de la sécurité dans
+        notre [référentiel à code source ouvert](https://github.com/18F/identity-idp){:target="_blank"}.
+  footer:
+    heading: Nous joindre
+    p_1: Si vous souhaitez en savoir plus sur la plate-forme, veuillez envoyer un
+      courriel à [partners@login.gov](mailto:partners@login.gov).
+help_page:
+  p_1: Parcourir les sujets communs
+implementation_page:
+  heading: Mise en œuvre d'un système de gestion d'identité
+  section_1:
+    ul:
+      li_1:
+        a_1: Que protégez-vous?
+      li_2:
+        a_1: Qu'est-ce qu'un système de gestion d'identité du consommateur?
+      li_3:
+        a_1: Mise en œuvre
+      li_4:
+        a_1: Ressources
+  section_2:
+    heading_1: Que protégez-vous?
+    p_1: Il vaut la peine d'évaluer ce dont vous avez réellement besoin avant de commencer
+      la mise en œuvre. Toute l'information ne requiert pas un système d'identité
+      pour gérer l'accès. Vous pouvez protéger la confidentialité des utilisateurs
+      et réduire les risques liés à la sécurité pour vos systèmes en évitant la cueillette
+      non nécessaire de renseignements permettant d'identifier une personne; ceci
+      inclut même les coordonnées.
+    heading_2: 'Vous pourriez ne pas avoir à mettre en œuvre un système d''identité
+      si :'
+    ul_1:
+      li_1: Vous n'avez pas à avoir une relation continue avec les utilisateurs.
+      li_2: Les transactions ne dépendent pas de l'exactitude de l'information personnelle.
+      li_3: Vous pouvez vous fier à d'autres formes de sécurité.
+    heading_3: Pour répondre à ceci, demandez
+    ul_2:
+      li_1:
+        content: De quelles transactions auront besoin les utilisateurs?
+        p_1: Est-ce que les transactions seront continues, comme dans les cas où les
+          utilisateurs prennent en note les avantages sociaux ou des demandes de subvention
+          pour les remplir plus tard, puis reviennent de façon répétée pour vérifier
+          le statut de leur demande? Ou seront-elles uniques ou non fréquentes, comme
+          dans les cas où les utilisateurs téléchargent des dossiers médicaux ou financiers?
+      li_2:
+        content: De quel type d'information avez-vous besoin pour protéger vos clients?
+        p_1: Avez-vous besoin d'un nom complet et autre information personnelle afin
+          que les utilisateurs puissent accéder à de l'information privée? Ou avez-vous
+          seulement besoin de vérifier si l'utilisateur correspond à certaines catégories,
+          comme la catégorie des vétérans ou celle des personnes âgées?
+      li_3:
+        content: Quel type de crime l'accès à cette information peut-il rendre possible?
+        p_1: L'information qui semble innocente en soi peut quand-même avoir une valeur
+          pour les fraudeurs et autres criminels lorsqu'elle est combinée avec d'autres
+          renseignements facilement accessibles.
+      li_4:
+        content: Quels autres moyens de sécurité sont disponibles?
+        p_1: Les numéros de suivi postaux, par exemple, ne sont pas secrets parce
+          que le colis sera livré seulement à une adresse spécifique. La sécurité
+          de la livraison repose sur la sécurité de l'édifice et sur la conduite de
+          l'employé(e) de livraison et non sur l'aspect secret du numéro lui-même.
+    heading_4: Quels types de ressources avez-vous déjà pour identifier les clients?
+    p_2: Votre agence peut déjà posséder de l'information et des ressources spécifiques
+      à la mission et qui peuvent être utilisées pour identifier les clients. En intégrant
+      les ressources que vous connaissez et en lesquelles vous avez confiance, vous
+      pouvez augmenter la fiabilité de l'identification.
+    heading_5: Pour répondre à ceci, demandez
+    ul_3:
+      li_1:
+        content: Quelles ressources sont uniques à votre agence?
+        p_1: Les interactions confidentielles des individus avec les agences gouvernementales
+          peuvent générer des pistes de métadonnées. Utilisées soigneusement, ces
+          métadonnées peuvent faciliter la vérification d'identité basée sur les connaissances
+          de ces activités. D'autres organisations gouvernementales servent de référentiels
+          de données biométriques qui font autorité et qui sont disponibles pour usage
+          interne. Certaines agences peuvent avoir des lieux physiques que les clients
+          peuvent visiter.
+    heading_6: Qu'est-ce qu'un système de gestion de l'identité des consommateurs?
+    p_3: Lorsque vous êtes à la maison et que quelqu'un frappe à la porte, c'est assez
+      facile de décider si vous répondez ou non. Selon votre connaissance de qui se
+      trouve à l'extérieur, vous pouvez décider si vous ouvrez la porte ou non. Est-ce
+      que la personne qui se trouve à l'extérieur est un(e) ami(e)? Un facteur ou
+      autre fournisseur de service attendu? Un complet étranger? En ligne, il est
+      beaucoup plus difficile de répondre à la question « Qui frappe à la porte. Les
+      systèmes de gestion d'identité des consommateurs facilitent la tâche aux administrateurs
+      système et les aident à décider s'ils ouvrent la porte ou non et à déterminer
+      la mesure de l'ouverture de cette porte, le cas échéant.
+    heading_7: Qu'est-ce qu'une identité?
+    p_4: 'dans le monde de la sécurité, « identité » a une signification technique
+      très spécifique qui diffère de la signification française pure. Une « identité »
+      en terme technique est un type de dossier : c''est un regroupement de différents
+      types de données qui décrivent un seul utilisateur du système [NIST 800-63-3].
+      Ces données peuvent inclure des références à des dossiers gouvernementaux officiels
+      comme les numéros de permis de conduire et les dates de naissance enregistrées
+      de même que des données mutables comme des adresses courriel et des noms d''utilisateurs.
+      Des attributs physiques comme les empreintes digitales et l''ADN peuvent aussi
+      faire partie d''un dossier d''identité.'
+    heading_8: Comment fonctionnent l'identité et la gestion de l'accès?
+    p_5: Les administrateurs système attribuent des privilèges d'accès à chaque dossier
+      d'identité. Ces privilèges autorisent certaines activités et en interdisent
+      d'autres. Pour « ouvrir la porte » de façon sécuritaire, toutefois, les administrateurs
+      doivent avoir la certitude que les utilisateurs qui frappent à la porte sont
+      bien qui ils affirment être.
+    p_6: Pour donner au système et à ses administrateurs confiance en leurs identités,
+      les utilisateurs doivent prouver leurs identités par le biais d'une activité
+      appelée authentification. Les utilisateurs s'authentifient en présentant une
+      preuve qui les lie aux dossiers. Pour ce faire, les utilisateurs aident d'abord
+      le système à valider leur dossier; par exemple, en saisissant un nom d'utilisateur.
+      Puis, les utilisateurs fournissent la preuve, souvent des mots de passe ou autre
+      information que seule la vraie personne peut connaître.
+    heading_9: Qu'est-ce que le fait d'avoir un dossier d'identité active-t-il??
+    p_7: 'Les systèmes d''identité ne sont pas qu''à l''avantage des administrateurs
+      système. Les utilisateurs peuvent effectuer des actions très pratiques avec
+      une identité numérique authentifiée. En voici une petite liste :'
+    ul_4:
+      li_1:
+        span_1: Remplir au préalable des formulaires en ligne avec de l'information
+          vérifiée accélère le traitement de la demande.
+        span_2: Il y a moins d'efforts redondants et les utilisateurs n'ont pas à
+          se soucier des erreurs de base.
+      li_2:
+        span_1: Les utilisateurs authentifiés peuvent accéder à des données que le
+          système détient sur eux et les télécharger, comme l'activité du compte.
+        span_2: Avec une identité juridique vérifiée, l'utilisateur peut accéder à
+          des dossiers médicaux ou financiers très sensibles et même les télécharger.
+      li_3:
+        span_1: Les systèmes d'identité peuvent protéger votre confidentialité.
+        span_2: Si vous devez avoir 21 ans ou plus pour accéder au service, vous pouvez
+          autoriser un système d'identité à confirmer votre âge sans partager votre
+          date de naissance exacte.
+    heading_10: Mise en œuvre
+    ul_5:
+      li_1:
+        a_1: veuillez lire la documentation du développeur.
+    heading_11: Ressources
+    ul_6:
+      li_1:
+        a_1: National Institute of Standards in Technology
+        content: "(NIST 800-63-3)"
+      li_2:
+        a_1: Guide de mise en œuvre des services numériques
+      li_3:
+        a_1: Référentiel de GitHub pour login.gov
+      li_4:
+        a_1: Sur Internet, personne ne sait que vous êtes un chien
+playbook_page:
+  section_1:
+    p_1: La gestion d'identité, ou s'assurer que seules les bonnes personnes obtiennent
+      accès au système, est cruciale dans l'offre de services en ligne au public.
+      Nous partageons ces principes pour aider les développeurs et les technologues
+      des agences gouvernementales à bâtir des systèmes de gestion d'identité utilisables,
+      sécurisés et qui protègent la confidentialité des consommateurs.
+  section_2:
+    heading_1: Les principes
+    p_1: Bâtir ce système comprend de recevoir des recommandations et des conseils
+      sur les meilleures pratiques de la part des experts en politiques, des architectes
+      système et des gens qui se consacrent à créer une excellente expérience utilisateur.
+      Notre recherche et notre progrès jusqu'ici nous a menés à identifier cinq principes
+      majeurs qui, nous croyons, nous aideront à rendre le système le meilleur possible.
+    p_2:
+      a_1: Voir les principes
+    heading_2: Mise en œuvre
+    p_3: Avant la mise en œuvre de login.gov ou de tout autre système de gestion d'identité,
+      vous devez déterminer si votre agence ou organisation a besoin d'un tel système.
+      Ci-dessous se trouve une liste de questions à demander et des éléments à considérer
+      pour vous aider à déterminer cela.
+    p_4:
+      a_1: En savoir plus sur la mise en œuvre
+principles_page:
+  heading_1: Les principes du guide de mise en œuvre de l'identité
+  heading_2: Axé sur les besoins des utilisateurs
+  ul_1:
+    li_1: Identifier vos auditoires potentiels
+    li_2: Comprendre les expériences de connexion et identifier les besoins de vos
+      auditoires
+    li_3: Mener des recherches avant de bâtir ou de mettre en œuvre un système
+    li_4: Tester votre produit pour identifier les points morts ou les domaines qui
+      nécessitent une amélioration
+    li_5: Lorsque les meilleures pratiques actuelles ne sont pas assez bonnes pour
+      vos utilisateurs, testez de nouvelles solutions et aidez à guider l'adoption.
+  p_1: |-
+    Résoudre des problèmes réels pour les utilisateurs potentiels doit être l'objectif principal de tout système et est doublement important dans la construction d'un système de gestion d'identité. Tout au long de ce guide, vous constaterez à quel point les besoins des utilisateurs constituent un principe directeur pour chaque prise de décision.
+
+    Une des premières étapes que vous devez effectuer est d'identifier vos utilisateurs principaux. Pour login.gov, nous avons identifié deux groupes comme étant nos utilisateurs principaux: le public et les experts en technologie faisant partie des agences gouvernementales. L'objectif pour le système en soi est de fournir de l'assistance et de répondre aux besoins du public. En bref, nous souhaitons nous assurer que notre système rend les gens à l'aise avec la connexion aux services gouvernementaux. Le public doit avoir confiance que login.gov se comporte comme prévu et qu'il ne les décevra pas. Le système doit aussi aborder l'expérience entière des utilisateurs alors qu'ils tentent d'accomplir leurs objectifs. Parce que la vérification de l'identité et l'authentification sont technologiquement complexes, il est probable que même les personnes les plus aguérries en ce qui a trait aux technologies peuvent rester piégées si leur téléphone est perdu ou si un système comporte des erreurs. Alors, en soutien à la mission de chaque agence, les architectes et les concepteurs des systèmes de gestion de l'identité doivent anticiper les points probables de friction afin que les utilisateurs ne perdent pas leur accès aux services et aux avantages.
+
+    Les agences doivent identifier la portion du public qu'elles desservent et comment les services peuvent être bâtis pour répondre spécifiquement à leurs besoins. Ceci aidera les équipes d'intégration des agences à comprendre ce dont ils ont besoin si elles décident de mettre en œuvre la plate-forme login.gov ou tout autre système de gestion d'identité du consommateur.
+
+    Enfin, vous devez constamment tester les designs et outils au moment où ils sont prêts à être partagés et ensuite ajuster votre projet en fonction de ce que vous avez appris. Dans certains cas, nous apprenons que les meilleures pratiques actuelles ne sont pas adéquates. Et dans ces cas, nous sommes poussés à essayer de nouvelles façons de donner aux utilisateurs la meilleure expérience possible. Ce processus implique plus de tests, l'éducation des utilisateurs et une volonté à itérer.
+
+    Il existe un nombre de méthodes de conception spécifiques que nous mettons en pratique pour demeurer axés sur l'utilisateur et vous pouvez lire au sujet de tous ces processus et les utiliser en passant en revue le [18F Design Methods](https://methods.18f.gov/){:target="_blank"}.
+  heading_3: Être transparent sur le fonctionnement
+  ul_2:
+    li_1: Impliquez des experts, des intervenants et le public tôt et souvent
+    li_2: Expliquez comment et pourquoi vous recueillez, partagez et stockez des données
+    li_3: Créez une politique de confidentialité à laquelle tous peuvent accéder et
+      que tous peuvent comprendre
+    li_4: Créez une politique de confidentialité inclusive et informative
+  p_2: |-
+    [Travailler de façon transparente](https://playbook.cio.gov/#play13){:target="_blank"} et créer un système transparent devrait être la façon dont toute agence travaille pour bâtir ou mettre en œuvre un système de gestion d'identité. Pour exécuter ce principe avec login.gov, nous bâtissons la plate-forme de manière à ce que les parties intéressées puisse nous conseiller sur les meilleures pratiques afin que nous demeurions responsables envers le public et envers nos partenaires de toutes les agences gouvernementales. De plus, cela signifie qu'un système qui indique aux utilisateurs ce qu'il fait de leur information dans le but de créer une responsabilisation et établir une confiance. Nous impliquons les utilisateurs et autres parties intéressées par le biais de notre [référentiel GitHub](https://github.com/18F/identity-idp){:target="_blank"} et travaillons à la création de forums publics où les utilisateurs peuvent discuter de notre travail.
+
+    Afin de rendre un système de gestion d'identité transparent pour les utilisateurs finaux, le système doit inclure des fonctionnalités qui éduquent les gens sur la façon dont le système fonctionne, pourquoi il fonctionne de cette façon et de quelle manière ils peuvent contrôler ce qui advient de leurs données. Vous devriez aussi informer les utilisateurs de l'information qui est requise par une agence pour la connexion à un service. Il est aussi important d'informer les utilisateurs de quelle information vos systèmes stockeront et si toute donnée est partagée avec les autres agences. Si les gens qui utilisent le système ne sont pas à l'aise avec le partage d'information, ils ne doivent pas être obligés de participer.
+
+    login.gov travaille pour mettre en œuvre toutes ces fonctionnalités ayant pour but d'améliorer la transparence. De plus, pour aider les gens à comprendre tout le processus, nous créons une politique de confidentialité qui explique comment les données sont partagées et ce que signifie de choisir l'option de retrait.
+  heading_4: Bâtir un produit flexible
+  ul_3:
+    li_1: Développer le produit en sprints et évaluer son efficacité après chaque
+      sprint
+    li_2: Communiquer continuellement avec les parties prenantes et les experts afin
+      d'évaluer les besoins et les mesures de succès
+    li_3: Tester votre produit auprès des utilisateurs de façon continuelle au fur
+      et à mesure que vous ajoutez de nouvelles fonctionnalités et raffinez les fonctionnalités
+      existantes
+    li_4: Définir ce qu'un produit minimal viable est pour vos besoins de gestion
+      d'identité
+    li_5: Planifier une évolution basée sur une technologie et des normes changeantes
+  p_3: |-
+    La technologie et les normes pour de la vérification d'identité peuvent changer rapidement. La gestion de l'identité du consommateur doit s'adapter rapidement aux normes changeantes et réagir aux nouvelles menaces à la sécurité. Afin de rendre l'adaptation aux nouvelles politiques et aux capacités possible, il s'agit d'une bonne pratique de bâtir des produits en utilisant des méthodes agiles qui tiennent compte des versions changeantes. En d'autres termes, planifier les modifications pour aider votre service d'identité à être aussi à jour et conforme que possible aux normes et politiques actuelles.
+
+    Nous adhérons à ce principe pour chaque aspect des projets qui construisent login.gov.
+
+    [Lisez ce guide](https://pages.18f.gov/agile/index.html){:target="_blank"} des principes et pratiques agiles élaborés par l'équipe 18F pour en savoir plus sur ce que signifie de travailler de façon agile.
+  heading_5: Utiliser des pratiques de confidentialité modernes
+  ul_4:
+    li_1: Stockez aussi peu de renseignements permettant d'identifier une personne
+      que possible
+    li_2: Donnez au utilisateurs les moyens d'atteindre leurs objectifs
+    li_3: Donnez aux utilisateurs le contrôle de leurs données
+  p_4: |-
+    Les systèmes de gestion d'identité stockent l'information personnelle sur les utilisateurs afin que les gens n'aient pas à répéter sans cesse les processus de vérification et d'authentification. Toutefois, recueillir et stocker de l'information personnelle sou;ève des questions éthiques et légales que les concepteurs de systèmes et les développeurs doivent considérer. Souvent, ce qui vient d'abord à l'esprit sont les questions techniques sur la sécurité : la protection de l'information contre les usages non autorisés et illégaux. Toutefois, nous devons aussi nous préoccuper des usages autorisés et légaux de l'information personnelle qui violent les attentes des utilisateurs en matière de confidentialité. Les utilisateurs de login.gov doivent être assurés que nous gérons leur information personnelle de façon respectueuse et appropriée.
+
+    La première étape est de recueillir seulement l'information dont vous avez absolument besoin. Et c'est ce que fait login.gov. La vérification d'identité à assurance élevée pour les tâches sensibles requiert une collecte d'information exhaustive. Cependant, de nombreuses activités ne requièrent pas des niveaux élevés d'assurance (NEA) et login.gov prend en charge différents LOA afin que les agences puissent clairement délimiter leurs utilisateurs qui ont besoin d'un niveau de sécurité plus bas de ceux qui ont des besoins plus sensibles tout en assurant l'utilisabilité et la sécurité des données. Minimiser la quantité d'information recueillie et stockée ne réduit pas seulement les risques liés à la sécurité; cela réduit aussi pour les utilisateurs les craintes liées à la réutilisation et la divulgation.
+
+    La prochaine étape est de donner aux utilisateurs autant de contrôle que possible sur l'information qui est partagée. Nous croyons fermement que les gens possèdent leurs propres données, pas nous, et nous agirons toujours en conséquence. Si les utilisateurs ne sont pas à l'aise avec les demandes de données pour l'utilisation du système, ils doivent savoir qu'ils n'ont pas à s'inscrire et qu'il existe d'autres moyens d'atteindre leurs objectifs.
+
+    Au fur et à mesure que nous faisons la conception de login.gov, nous travaillons également à éduquer les utilisateurs pour les aider à sécuriser leurs propres données. Nous souhaitons que les gens comprennent pourquoi nous devons demander certains types d'information, comme les numéros de sécurité sociale, et comment nous les utilisons.
+  heading_6: Créer des systèmes de sécurité réactifs
+  ul_5:
+    li_1: Identifier les meilleures pratiques de l'industrie et s'y conformer
+    li_2: Se conformer aux règlementations fédérales comme FISMA et FedRamp
+    li_3: Mettre en place des systèmes pour effectuer une surveillance et une détection
+      de la fraude
+    li_4: Utiliser des techniques modernes de chiffrement dans toute la pile technologique
+    li_5: Stocker seulement la quantité minimale nécessaire de données
+    li_6: Aider les utilisateurs à comprendre les mesures de sécurité qu'ils doivent
+      effectuer
+  p_5: |-
+    Comprendre qui essaie d'accéder à l'information personnelle et s'assurer que seuls utilisateurs autorisés obtiennent l'accès à cette information sont les clés de la gestion d'identité du consommateur. Les systèmes comme ceci existent pour sécuriser l'identité de l'utilisateur contre ceux qui cherchent à commettre du vol ou de la fraude.
+
+    Être délibéré à propos de la sécurité signifie de concentrer notre attention sur ce qui doit être protégé. Cela signifie de réfléchir attentivement aux moyens possibles pour équilibrer protection et accessibilité. Y parvenir avec succès comprend d'éduquer les utilisateurs sur les moyens qu'ils peuvent utiliser pour se protéger ou mitiger les effets du crime.
+
+    Dans le cas de login.gov, par exemple, nous devons décider exactement quelles données nous stockons et pour combien de temps. Nous devons aussi décider quelles étapes les utilisateurs doivent suivre pour accéder à leur information. Toutes ces décisions nécessitent une délibération attentive afin de déterminer la meilleure option pour les utilisateurs autant que pour les agences et assurer une fonctionnalité maximale.
+
+    Pour la construction de login.gov, nous adhérons aux normes mises de l'avant par le [National Institute of Standards and Technology](https://pages.nist.gov/800-63-3/){:target="_blank"} (NIST 800-63-2) nous adapterons les nouveaux projets de normes (NIST 800-63-3) au fur et à mesure qu'elles deviennent finales. Les projets de normes adoptent une approche très différente de l'authentification et de la vérification de l'identité (comment une personne se connecte-t-elle et comment vérifie-t-elle son identité) de celle de la version actuelle. De plus, nous adhérons aux [meilleures pratiques du gouvernement](https://playbook.cio.gov/#play11){:target="_blank"} incluant FedRAMP, en bâtissant dans la transparence et en menant des évaluations de sécurité rigoureuses et routinières en plus d'assurer la conformité au Federal Information Security Management Act (FISMA).
+help:
+  changing-settings:
+    how-do-i-change-my-email-address: Comment changer mon adresse courriel?
+    how-do-i-change-my-password: Comment changer mon mot de passe?
+    how-do-i-change-the-phone-number-i-am-using-with-my-account: Comment changer le
+      numéro de téléphone que j'utilise avec mon compte?
+  creating-an-account:
+    do-i-need-a-mobile-phone-to-use-logingov: Dois-je posséder un téléphone cellulaire
+      pour utiliser login.gov?
+    how-do-i-create-an-account-with-logingov: Comment créer un compte sur login.gov?
+    i-didnt-receive-a-confirmation-email-from-logingov: Je n'ai pas reçu de courriel
+      de confirmation de login.gov.
+    what-do-i-do-if-an-account-already-exists-under-my-email-address: Que dois-je
+      faire si un compte existe déjà avec mon adresse courriel?
+    what-is-two-factor-authentication: Qu'est-ce qu'une authentification à deux facteurs?
+    why-didnt-i-receive-a-security-code-to-confirm-my-phone: Pourquoi n'ai-je pas
+      reçu de code de sécurité pour confirmer mon numéro de téléphone?
+    why-do-i-need-to-confirm-my-email-address-and-my-phone-number: Pourquoi dois-je
+      confirmer mon adresse courriel et mon numéro de téléphone?
+    why-do-i-need-to-use-logingov-to-access-government-services-online: Pourquoi dois-je
+      utiliser login.gov pour accéder aux services en ligne du gouvernement?
+  privacy-and-security:
+    can-i-remove-a-saved-password-or-login-information-from-my-browser: Can I remove
+      a saved password or login information from my browser?
+    how-do-i-make-my-password-strong: How do I make my password strong?
+    how-does-logingov-protect-my-data: How does login.gov protect my data?
+    will-logingov-share-my-information: Will login.gov share my information?
+  signing-in:
+    i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me: Je
+      ne me rappelle pas de ma clé personnelle et je n'ai pas mon téléphone avec moi.
+    i-forgot-which-email-address-i-used-to-create-an-account: J'ai oublié quelle adresse
+      courriel j'ai utilisée pour créer un compte.
+    if-i-dont-have-my-phone-with-me-can-i-still-sign-in: Si je n'ai pas mon téléphone
+      avec moi, puis-je quand même me connecter?
+    what-do-i-do-if-my-password-doesnt-work-or-i-forget-it: Que dois-je faire si mon
+      mot de passe ne fonctionne pas ou si je l'ai oublié?
+    what-do-i-need-to-have-in-order-to-sign-in: Que dois-je avoir en main pour me
+      connecter?
+    what-happens-if-i-miss-the-phone-call-or-the-text-message-with-my-one-time-security-code: Que
+      se produit-il si je manque l'appel téléphonique ou le message texte contenant
+      mon code de sécurité à utilisation unique?
+    what-is-an-authenticator-app: Qu'est-ce qu'une application d'authentification?
+    why-does-the-system-log-me-out: Pourquoi le système me déconnecte-t-il?
+policies:
+- section: Nos pratiques relatives à la confidentialité
+  anchor: nos pratiques relatives à la confidentialité
+  content: |-
+    Cet avis lié à la confidentialité décrit comment nous demandons, utilisons, conservons et protégeons votre information personnelle de même que votre obligation à la divulguer.
+
+    Notre objectif est de protéger votre information personnelle et nous ne la partagerons pas sans votre autorisation. Par exemple, nous chiffrerons votre information personnelle en transit et inactive et nous vous demanderons avant de partager vos données avec une agence partenaire. Toutefois, il peut y avoir des circonstances où nous devons partager certaines données. Par exemple : si l'information est pertinente et nécessaire pour un but d'application de la loi autorisée; afin de réagir à une intrusion; ou pour aider une autre agence à intervenir suite à une intrusion. Pour de l'information additionnelle, consultez le [system of record notice number GSA/TTS-1](https://www.federalregister.gov/documents/2017/01/19/2017-01174/privacy-act-of-1974-notice-of-a-new-system-of-records){:target="-blank"}
+    que les Services de transformation technologique de GSA ont publié le 19 janvier 2017.
+
+    ### Loi sur la protection des renseignements personnels
+
+    #### Autorités
+
+    L'information que vous fournissez pour accéder à votre compte login.gov est recueillie conformément à la norme 6 USC § 1523 (b)(1)(A)-(E), au [E-Government Act of 2002 (44 USC § 3501)](https://www.gpo.gov/fdsys/pkg/PLAW-107publ347/html/PLAW-107publ347.htm){:target="_blank"},
+    et à la norme 40 USC § 501.
+
+    #### Objectif
+
+    L'information que vous soumettez est utilisée pour créer ou mettre à jour votre compte login.gov. Une fois que vous avez créé votre compte, avec votre consentement, login.gov partagera votre adresse courriel avec l'agence partenaire pour fournir un accès en ligne à l'information et aux services du gouvernement.
+
+    #### Divulgation
+
+    Vous décidez quelle information vous nous donnez. Toutefois, le défaut de fournir de l'information complète et exacte peut retarder l'accès à l'agence partenaire.
+    L'information que vous donnez à login.gov sera partagée avec l'agence fédérale applicable pour fournir un accès à l'information sur vous détenue par cette agence tel que décrit dans les [systèmes d'avis sur les comptes](https://www.federalregister.gov/documents/2017/01/19/2017-01174/privacy-act-of-1974-notice-of-a-new-system-of-records){:target="_blank"} associés.
+    Veuillez noter que le système login.gov enregistrera certinaes informations du niveau session sur votre utilisation du service, incluant, mais sans s'y limiter, type et version de navigateur et la durée de votre session. Cette information permet à
+    login.gov de mieux comprendre comment le site est utilisé et comment il peut être rendu plus utile.
+
+    #### Stockage
+
+    Tous les dossiers sont stockés électroniquement dans une base de données dans l'[environnement Amazon Web Services (AWS)](https://aws.amazon.com/){:target="_blank"} de GSA.
+    Vous pouvez changer ou modifier votre adresse courriel ou numéro de téléphone en y accédant dans votre compte. Vous devez choisir une adresse courriel à laquelle vous souhaitez recevoir des correspondances de n'importe quelle agence partenaire dont vous pourriez accéder aux services ou à l'information. Changer cette adresse redirigera toutes les correspondances par courriel de toute agence partenaire.
+
+    De manière similaire, vous devez choisir le numéro d'un téléphone auquel vous avez accès afin de recevoir et répondre avec le(s) mot(s) de passe à utilisation unique qui est/sont envoyé(s) à ce numéro.
+
+    Votre adresse courriel et votre numéro de téléphone seront conservés pendant un minimum de six ans conformément aux directives de la National Archives and Records Administration
+    (NARA) guidance. Cependant, GSA est autorisée à conserver l'information
+    plus longtemps si cela est requis pour des usages commerciaux. login.gov doit pouvoir fournir un accès aux utilisateurs à l'information et aux services des agences partenaires et donc peut avoir un besoin commercial de conserver l'information plus longtemps que la période de rétention de six ans.
+
+    ### Évaluation d'impact sur la confidentialité
+
+    Consultez notre [Évaluation d'impact sur la confidentialité](site.baseurl/assets/docs/privacy-impact-assessment.pdf).
+- section: Nos pratiques relatives à la sécurité
+  anchor: nos pratiques relatives à la sécurité
+  content: |-
+    login.gov utilise diverses méthodes de sécurité pour protéger ce service du gouvernement des États-Unis et vos données et pour assurer que le service demeure disponible pour tous les utilisateurs. Ces méthodes comprennent la surveillance et l'enregistrement du trafic sur le réseau (toute donnée arrivant à, ou sortant de, login.gov) destinés à identifier les tentatives non autorisées de changement d'information ou à causer préjudice de toute autre manière.
+
+    L'accès ou l'utilisation non autorisés de login.gov (par ex., l'usage à des fins criminelles ou pour causer préjudice, etc.) est contraire à la loi et peut vous assujettir à des poursuites criminelles et des pénalités.
+
+    ### Politique de divulgation de vulnérabilité
+
+    login.gov autorise la communauté externe de sécurité à effectuer des recherches de sécurité destinées à produire des rapports des vulnérabilités de sécurité découvertes sur la plate-forme login.gov.
+
+    Consultez notre [Politique de divulgation de vulnérabilité](https://18f.gsa.gov/vulnerability-disclosure-policy/){:target="_blank"}
+    pour obtenir plus de détails sur cette politique et comment soumettre des rapports des vulnérabilités découvertes.
+
+    ### Pour plus d'information
+
+    Nous sommes heureux de répondre à vos questions concernant notre sécurité et nos pratiques relatives à la confidentialité.
+    Pour plus d'information, veuillez visiter [Help](site.baseurl/help)
+    ou [contactez-nous](site.baseurl/contact).
+help_pages:
+  changing-settings:
+    how-do-i-change-my-email-address: Pour changer votre adresse courriel, sélectionnez
+      « Modifier » à côté de celle-ci. Entrez la nouvelle adresse courriel et soumettez-la.
+      Retrouvez ensuite le courriel de login.gov dans votre boîte. Ouvrez le courriel
+      et cliquez sur le lien fourni, ce qui vous ramènera à login.gov. Votre nouvelle
+      adresse courriel est fonctionnelle une fois de retour sur login.gov.
+    how-do-i-change-my-password: |-
+      Pour changer votre mot de passe, connectez-vous à login.gov et allez à votre page de profil. Si vous souhaitez changer votre mot de passe, sélectionnez « Modifier » à côté de celui-ci, entrez le nouveau mot de passe et soumettez votre changement. Les mots de passe doivent contenir au moins 8 caractères, mais il n'y a aucune autre restriction. Vous pouvez même utiliser plus d'un mot avec des espaces pour obtenir 8 caractères.
+
+      Essayez de créer un mot de passe long et complexe en utilisant une phrase ou une série de mots que vous seul(e) pouvez reconnaître. Assurez-vous également qu'il soit différent de tout autre mot de passe que vous utilisez pour vous connecter à d'autres comptes, par exemple votre compte bancaire ou votre compte courriel. Utiliser le même mot de passe pour les courriels, les comptes bancaires et les médias sociaux facilite le vol d'identité.
+    how-do-i-change-the-phone-number-i-am-using-with-my-account: Pour changer le numéro
+      de téléphone où est envoyé votre code de sécurité, sélectionnez « Modifier »
+      à côté de celui-ci. Le site login.gov vous enverra immédiatement votre code
+      de sécurité pour confirmer le nouveau numéro de téléphone.
+  creating-an-account:
+    do-i-need-a-mobile-phone-to-use-logingov: Vous n'avez pas besoin de téléphone
+      cellulaire pour utiliser login.gov. Vous devez fournir un numéro de téléphone,
+      soit une ligne fixe ou mobile où vous pouvez recevoir les codes de sécurité.
+      Ceux-ci vous seront envoyés chaque fois que vous vous connectez, par message
+      texte ou par un appel téléphonique.
+    how-do-i-create-an-account-with-logingov: |-
+      Pour créer un compte login.gov, vous devrez fournir : une adresse courriel valide et un numéro de téléphone actif. Nous vous demanderons aussi de créer un mot de passe.
+      #### Entrez votre adresse courriel et confirmez-la
+
+      Sélectionnez « Créer un compte » et entrez votre adresse courriel là où c'est indiqué. Consultez ensuite le message que nous vous avons envoyé dans votre boîte de courriels. Celui-ci contient un lien sur lequel vous devez cliquer. Vous serez alors redirigé vers login.gov.
+      #### Entrez votre mot de passe
+
+      Vous devez ensuite créer un mot de passe fort. Servez-vous de l'indicateur de force à l'écran comme guide. Les mots de passe doivent contenir au moins 8 caractères, mais il n'y a aucune autre restriction. Vous pouvez même entrer des espaces entre les mots pour obtenir 8 caractères.
+      #### Entrez votre numéro de téléphone et confirmez-le
+
+      Vous devez également inscrire un numéro de téléphone où vous pouvez recevoir des appels ou des messages texte. Si vous avez une ligne fixe, vous devez demander de recevoir un code de sécurité par appel téléphonique. Nous enverrons un code de sécurité unique à ce numéro de téléphone chaque fois que vous vous connecterez à votre compte. Il s'agit d'une authentification à deux facteurs. La deuxième étape maintient votre compte plus sécurisé que si vous utilisiez seulement un mot de passe.
+
+      Chaque code de sécurité expire après 5 minutes et peut être utilisé une fois seulement. Si vous n'entrez pas le code dans un délai de 5 minutes, vous n'avez qu'à demander un nouveau code. Chaque code est valide pour une seule fois. Ainsi, personne ne peut voler un code que vous avez déjà utilisé.
+
+      Entrez le code de sécurité dans le champ. C'est tout! Vous venez de franchir une étape importante pour vous maintenir, ainsi que le gouvernement, en sécurité. Chaque fois que vous vous connecterez à votre compte login.gov, vous recevrez un nouveau code de sécurité à inscrire. Chaque fois, vous aurez également l'option d'obtenir un code de sécurité par téléphone ou par message texte.
+
+      #### Sauvegardez votre clé personnelle
+
+      Après avoir créé votre compte, vous obtiendrez une clé personnelle qui est une suite de 16 caractères aléatoires. Notez-la et conservez-la séparément de votre téléphone. Si vous oubliez votre mot de passe ou si vous n'avez pas votre téléphone, vous pouvez entrer la clé personnelle pour accéder à vos services ou applications.
+    i-didnt-receive-a-confirmation-email-from-logingov: |-
+      Si vous n'avez pas reçu de courriel de confirmation, regardez dans votre courrier indésirable. Autrement, vous pourriez avoir noté l'adresse courriel de façon erronée. Si c'est le cas, vous pouvez toujours créer un autre compte avec la bonne adresse courriel.
+
+      - Si vous avez mal écrit votre adresse, vous pouvez créer un nouveau compte.
+      - Si vous êtes certain(e) d'avoir entré la bonne adresse, choisissez « Envoyer de nouveau » pour recevoir un nouveau courriel de confirmation.
+    what-do-i-do-if-an-account-already-exists-under-my-email-address: |-
+      La confirmation de l'accès à une adresse courriel est la première étape de création d'un compte login.gov. Si vous avez reçu un avis indiquant qu'un compte login.gov associé à votre adresse courriel a été créé, mais que vous ne vous souvenez pas l'avoir créé, utilisez votre adresse courriel pour vous connecter et effectuer le processus de réinitialisation du mot de passe.
+
+      Veuillez informer login.gov si vous êtes certain(e) de ne pas avoir créé de compte et si vous croyez que quelqu'un utilise votre adresse courriel.
+    what-is-two-factor-authentication: login.gov utilise une authentification à deux
+      facteurs pour maintenir les comptes sécurisés. Comme son nom l'indique, l'authentification
+      à deux facteurs (parfois appelée 2FA) requiert deux méthodes de connexion différentes
+      pour se connecter à un compte. Habituellement, cela signifie d'entrer un mot
+      de passe mémorisé et un code unique envoyé à un de vos appareils (comme un téléphone).
+      Percer la sécurité de votre compte est beaucoup plus difficile grâce à la combinaison
+      de ces deux méthodes.
+    why-didnt-i-receive-a-security-code-to-confirm-my-phone: |-
+      Si vous n'avez pas reçu de code de sécurité, assurez-vous d'avoir inscrit votre numéro de téléphone correctement.
+
+      - Avez-vous entré un numéro de téléphone incorrect? Recherchez l'option qui vous permet de l'inscrire de nouveau.
+      - S'il s'agit du bon numéro, demandez le code de nouveau. Vous le recevrez par message texte ou par appel téléphonique sur une ligne fixe ou un téléphone cellulaire.
+    why-do-i-need-to-confirm-my-email-address-and-my-phone-number: Le site login.gov
+      utilise votre adresse courriel et votre numéro de téléphone pour vous envoyer
+      d'importants messages de sécurité sur l'activité de votre compte. Nous ne les
+      utiliserons à aucune autre fin et nous ne les partagerons avec personne sans
+      votre consentement.
+    why-do-i-need-to-use-logingov-to-access-government-services-online: |-
+      Les agences gouvernementales décident de façon indépendante comment interagir avec le public. Vous avez été redirigé(e) vers login.gov parce que le service ou le programme que vous souhaitez utiliser a choisi la plateforme partagée login.gov pour son efficacité et sa sécurité. Lorsque vous aurez terminé d'utiliser login.gov, vous serez redirigé(e) vers l'agence de départ.
+
+      Nous espérons que login.gov est une option pratique et sécuritaire pour vous. Cependant, si vous préférez ne pas utiliser login.gov, il demeure possible d'accéder aux services gouvernementaux. Vous trouverez plus d'information à ce sujet auprès de votre agence.
+  privacy-and-security:
+    can-i-remove-a-saved-password-or-login-information-from-my-browser: |-
+      "Si vous avez accidentellement sauvegardé votre mot de passe ou toute autre information de connexion liée à login.gov dans votre navigateur, il est préférable de les supprimer. Ainsi, vous conserverez un compte plus sécurisé. Dans la liste suivante, sélectionnez le navigateur (le programme informatique que vous utilisez pour accéder au web) que vous utilisez pour apprendre comment supprimer toute information sauvegardée :"
+
+      - [Chrome](https://support.google.com/chrome/answer/95606){:target="_blank"}
+      - [Firefox](https://support.mozilla.org/kb/password-manager-remember-delete-change-passwords#w_viewing-and-deleting-passwords){:target="_blank"}
+      - [Internet Explorer](https://support.microsoft.com/en-us/help/17499/windows-internet-explorer-11-remember-passwords-fill-out-web-forms#ie=ie-11){:target="_blank"}
+      - [Safari](https://help.apple.com/safari/mac/8.0/#/ibrw1103){:target="_blank"}
+
+      Aussi, lorsque vous êtes en ligne, vérifiez la barre d'adresse de toute page que vous visitez et assurez-vous qu'il s'agit de sites de confiance, particulièrement les pages qui vous demandent d'inscrire un nom d'utilisateur et un mot de passe. Soyez prudent(e) quand vous partagez de l'information personnelle par courriel, notamment vos authentifiants de connexion, votre information bancaire ou votre numéro de sécurité sociale.
+    how-do-i-make-my-password-strong: |-
+      Votre mot de passe doit compter un minimum de 8 caractères. Essayez avec plusieurs mots et espaces pour créer une phrase facile à mémoriser. Les mots de passe plus longs et contenant plusieurs mots sont plus forts que les mots de passe courts comportant des caractères spéciaux.
+
+      Au moment de créer un mot de passe, évitez également d'utiliser des termes du langage de la rue, les fautes d'orthographe communes et les mots épelés à l'envers. Évitez aussi d'utiliser le nom de votre entreprise, de votre conjoint(e) ou les noms de vos enfants ou de vos animaux de compagnie ainsi que de l'information personnelle comme votre âge ou votre date de naissance.
+
+      Si vous êtes déjà connecté(e) et que vous essayez de changer votre mot de passe, votre courriel ou votre numéro de téléphone, on vous demandera d'entrer votre mot de passe actuel avant de pouvoir effectuer les changements.
+
+      Cependant, si vous entrez un mot de passe erroné à répétition, il est probable qu'une personne mal intentionnée essaie de prendre le contrôle de votre machine que vous avez laissée sans surveillance. Dans une telle situation, vous serez déconnecté après trois échecs de connexion, et ce, pour assurer votre sécurité.
+    how-does-logingov-protect-my-data: |-
+      Le site login.gov respecte la confidentialité. Nous recueillons des données personnelles en ligne seulement pour répondre aux demandes que vous transmettez aux agences fédérales partenaires du site. Le site login.gov gère des parties spécifiques du site web de ces agences, ce qui nous permet de recueillir des données personnelles dans un environnement sécurisé et confidentiel lorsque vous accédez à certains services gouvernementaux. Nous sommes tenus de respecter notre politique de confidentialité. Le site login.gov ne loue, ne vend pas et ne publie aucune information personnelle à des fins marketing à des entreprises privées, des entrepreneurs ou des distributeurs.
+
+      Les hyperliens présents sur login.gov qui mènent vers des sites externes du gouvernement fédéral concernent des services fournis par ces agences. Ces sites sont tenus par leur propre politique de confidentialité qui se trouve normalement sur leur site avec les mentions légales.
+
+      Les comptes individuels font face à une sécurité à deux étapes. Nous exigeons une authentification à deux facteurs de même que des mots de passe forts qui répondent aux normes du [National Institute of Standards of Technology](https://www.nist.gov/){:target="_blank"} relatives à la validation et à la vérification. Celles-ci incluent l'authentification à deux facteurs qui requiert que vous vous connectiez avec votre mot de passe et un code de sécurité reçu sur votre téléphone. L'authentification à deux facteurs peut aider à protéger votre compte et à empêcher que la sécurité de votre mot de passe soit compromise.
+
+      Votre information demeurera sécurisée. Pour plus d'information, consultez notre [politique de sécurité et de confidentialité](site.baseurl/policy).
+    will-logingov-share-my-information: Le site login.gov ne peut partager de l'information
+      avec d'autres agences gouvernementales sans l'autorisation de l'utilisateur.
+      Même les administrateurs de login.gov ne peuvent déchiffrer ou accéder à l'information
+      personnelle sans le mot de passe de l'utilisateur.
+  signing-in:
+    i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me: |-
+      Si n'avez pas votre téléphone ou votre clé personnelle, vous pourriez devoir créer un nouveau compte et vérifier votre information personnelle de nouveau. Pour créer un nouveau compte, vous devrez utiliser une adresse courriel différente de celle que vous avez utilisée lorsque vous avez créé votre premier compte. Pour les questions urgentes, par exemple pour vérifier le statut d'une application en cours, il est recommandé de communiquer directement avec l'agence gouvernementale.
+
+      Vous pouvez également vous connecter plus tard lorsque vous aurez votre téléphone avec vous.
+    i-forgot-which-email-address-i-used-to-create-an-account: |-
+      Si vous ne vous souvenez pas quelle adresse courriel vous avez utilisée pour créer votre compte, vous pouvez utiliser la fonction de réinitialisation de mot de passe pour vérifier si votre adresse courriel est inscrite au dossier.
+
+      Essayez de vous connecter comme d'habitude et demandez une réinitialisation de mot de passe. Ensuite, entrez l'adresse courriel que vous croyez avoir utilisée pour créer votre compte. Si votre adresse courriel est inscrite dans nos dossiers, nous vous enverrons des instructions pour réinitialiser votre mot de passe. Vérifiez vos courriels dans quelques minutes pour y trouver ces instructions.
+    if-i-dont-have-my-phone-with-me-can-i-still-sign-in: |-
+      Vous devez avoir votre téléphone afin d'obtenir la clé de sécurité pour vous connecter. Si vous n'avez pas votre téléphone avec vous, vous devrez utiliser la clé personnelle que vous avez reçue lorsque vous avez créé votre compte. Après avoir inscrit votre clé personnelle, cliquez sur « soumettre ». Une fois connecté(e), vous obtiendrez immédiatement une nouvelle clé personnelle. Veuillez conserver votre clé personnelle en lieu sûr, séparément de votre téléphone, car elle vous permet de vous connecter à votre compte quand vous n'avez pas votre téléphone avec vous.
+
+      Nous vous encourageons à conserver votre clé personnelle ailleurs que dans votre ordinateur ou appareil mobile. Ainsi, vous serez en mesure d'accéder à votre clé personnelle même si votre appareil est volé ou que votre compte en ligne est piraté.
+    what-do-i-do-if-my-password-doesnt-work-or-i-forget-it: |-
+      Si vous ne connaissez pas votre mot de passe, le lien pour le réinitialiser se trouve sur la page de connexion. Entrez votre adresse courriel pour recevoir un lien de réinitialisation de mot de passe. Après avoir cliqué sur le lien, on vous demandera d'entrer un nouveau mot de passe. Confirmez de nouveau que vous avez votre téléphone (celui que vous utiliserez pour recevoir des codes d'accès à utilisation unique).
+
+
+      Lorsque vous serez connectés à login.gov après la réinitialisation de votre mot de passe, login.gov vous fournira une clé personnelle. La clé personnelle vous sera utile si vous oubliez votre mot de passe ou si vous n'avez pas votre téléphone avec vous. Assurez-vous de la prendre en note et de la conserver séparément de votre téléphone.
+    what-do-i-need-to-have-in-order-to-sign-in: Chaque fois que vous vous connectez
+      à votre compte, vous devez avoir votre adresse courriel, votre mot de passe,
+      ainsi que votre téléphone à portée de main. Après avoir inscrit votre adresse
+      courriel, login.gov enverra un code de sécurité à votre téléphone. Vous devrez
+      l'inscrire dans le champ du code de sécurité pour vous connecter de façon sécurisée.
+    what-happens-if-i-miss-the-phone-call-or-the-text-message-with-my-one-time-security-code: Chaque
+      fois que vous vous connectez, vous devez entrer un code de sécurité qui est
+      envoyé à votre téléphone par message texte ou par appel téléphonique. Le code
+      de sécurité que vous recevez expire après 5 minutes et peut être utilisé une
+      fois seulement. Si vous n'entrez pas le code dans un délai de 5 minutes ou que
+      vous avez simplement manqué l'appel, vous n'avez qu'à demander un nouveau code
+      de sécurité. Chaque code de sécurité est valide une fois seulement, donc personne
+      ne peut voler un code que vous avez déjà utilisé. Nous limitons les demandes
+      à trois par 15 minutes, mais autrement, vous pouvez demander autant de code
+      que vous le souhaitez.
+    what-is-an-authenticator-app: Il s'agit d'une application de sécurité mobile qui
+      génère des codes de sécurité pour la connexion. Vous pouvez utiliser l'application
+      pour obtenir des codes même si vous n'avez pas de connexion internet.
+    why-does-the-system-log-me-out: |-
+      Lorsqu'un utilisateur est déjà connecté et qu'il souhaite changer son adresse courriel, son mot de passe ou son numéro de téléphone, il doit d'abord entrer son mot de passe courant. Après trois essais ratés, l'utilisateur est déconnecté.
+
+      Le système vous déconnecte également si vous avez entré 3 fois de façon erronée le code de sécurité qui a été envoyé à votre téléphone. Les tentatives échouées sont limitées à 3 par session, suivies d'un verrouillage de l'accès de 5 minutes.


### PR DESCRIPTION
This is the XML translations provided from translator, converted into yaml, and compiled into a single file with all of the help documentation to match the other existing locales.

Page meta descriptions were added after these translations, so there are a handful of `NOT YET TRANSLATED` values for those, but in large part this is mostly complete.