### PR TITLE
Update stylesheet path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run make-dirs && npm run copy && npm run build-css && npm run build-js",
     "build-federalist": "npm run make-dirs && npm run copy && npm run build-css && npm run build-js",
-    "build-css": "node-sass --output-style compressed assets/stylesheets/main.scss assets/stylesheets/build/main.css",
+    "build-css": "node-sass --output-style compressed assets/stylesheets/static.scss assets/stylesheets/build/main.css",
     "build-js": "webpack --config --progress --colors",
     "clean": "rm -rf ./assets && rm -rf _sass && rm -f ./*.ico && rm -f ./*.png && rm -f ./*.svg && rm -f ./browserconfig.xml && rm -f ./manifest.json",
     "copy": "npm run copy-img && npm run copy-font && npm run copy-js && npm run copy-css && npm run copy-favicons",
@@ -48,7 +48,7 @@
   "main": "webpack.config.js",
   "keywords": [],
   "dependencies": {
-    "identity-style-guide": "^0.2.4",
+    "identity-style-guide": "0.2.6",
     "node-sass": "^3.7.0",
     "webpack": "^1.13.2"
   }


### PR DESCRIPTION
In order to keep the stylesheets organized I split them into an `app` and `static` entry point file - updating to reflect the proper stylesheet to import into the static site.

I'm using the [github branch](https://github.com/18F/identity-style-guide/pull/15) for the `identity-style-guide` npm package for testing, but once it all looks good I can bump the version of the package and update this PR to reflect.