### PR TITLE
Fix language dropdown

### DIFF
--- a/_includes/i18n_dropdown_desktop.html
+++ b/_includes/i18n_dropdown_desktop.html
@@ -12,9 +12,9 @@
             {% if locale == 'en' %}
               <a href="{{ page.url | prepend: site.baseurl_root }}" class="block pl-24p py2 text-decoration-none white">{% t name %}</a>
             {% elsif site.lang != 'en' and locale == site.lang %}
-              <a href="{{ page.url | relative_url  }}" class="block pl-24p py2 text-decoration-none white">{% t name %}</a>
+              <a href="{{ page.url | prepend: site.baseurl  }}" class="block pl-24p py2 text-decoration-none white">{% t name %}</a>
             {% else %}
-              <a href="{{ page.url | prepend: locale | relative_url }}" class="block pl-24p py2 text-decoration-none white">{% t name %}</a>
+              <a href="{{ page.url | prepend: locale | prepend: '/' | prepend: site.baseurl_root }}" class="block pl-24p py2 text-decoration-none white">{% t name %}</a>
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
Using `relative_path` was causing multiple locales to appear within the url when toggling languages.