### PR TITLE
Fix navigation for french

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,10 +5,10 @@
 
 <nav class="sm-flex flex-center z2 {{ site.lang }}-nav">
   <ul class="list-reset m0 sm-mt1">
-    <li class="sm-mr3">
+    <li class="sm-mr3 lang-nav-item">
       <a href="{{ '/' | relative_url }}" class="blue caps text-decoration-none {% if page.url == '/' %}active{% endif %}">{% t nav.home %}</a>
     </li>
-    <li class="sm-mr3 dropdown">
+    <li class="sm-mr3 lang-nav-item dropdown">
       <a href="{{ '/playbook/' | relative_url }}" class="blue caps text-decoration-none {% if page.url contains '/playbook/' %}active{% endif %}">{% t nav.playbook %}<span class="dropdown-arrow"> &#9662;</span></a>
         <ul class="sm-show">
           <li><a href="{{ '/playbook/' | relative_url }}">{% t nav.overview %}</a></li>
@@ -17,13 +17,13 @@
         </ul>
       </li>
     </li>
-    <li class="sm-mr3">
+    <li class="sm-mr3 lang-nav-item">
       <a href="{{ '/security/' | relative_url }}" class="blue caps text-decoration-none {% if page.url == '/security/' %}active{% endif %}">{% t nav.security %}</a>
     </li>
-    <li class="sm-mr3">
+    <li class="sm-mr3 lang-nav-item">
       <a href="{{ '/developers/' | relative_url }}" class="blue caps text-decoration-none {% if page.url == '/developers/' %}active{% endif %}">{% t nav.developers %}</a>
     </li>
-    <li class="sm-mr2 md-mr3 dropdown">
+    <li class="sm-mr3 lang-nav-item dropdown">
       <a href="{{ '/help/' | relative_url }}" class="blue caps text-decoration-none {% if page.url contains '/help/' %}active{% endif %}">{% t nav.help %}<span class="dropdown-arrow"> &#9662;</span></a>
       <ul class="sm-show dropdown-min-width">
         <li><a href="{{ '/help/' | relative_url }}">{% t nav.overview %}</a></li>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -5,7 +5,7 @@
     {% include styles.html %}
     {% include google_analytics.html %}
   </head>
-  <body class="{{ layout.class }} {{ page.class }} site" data-spy="scroll" data-target="#pb-nav--side-cntnr" data-offset="48">
+  <body class="{{ layout.class }} {{ page.class }} site lang-{{ site.lang }}" data-spy="scroll" data-target="#pb-nav--side-cntnr" data-offset="48">
     <div class="site-wrap {{ page.bg_color | default: layout.bg_color | default:'' }}">
       {% include skip_nav.html %}
       {% include banner.html %}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -31,9 +31,9 @@ $sm-h1: 2rem !default;
 $sm-h2: 1.5rem !default;
 $sm-h3: 1.125rem !default;
 $sm-h4: 1rem !default;
-$sm-h5: .875rem !default;
-$sm-h6: .8125rem !default;
-$sm-es: .74249rem !default;
+$sm-h5: 0.875rem !default;
+$sm-h6: 0.8125rem !default;
+$sm-lang: 0.72rem !default;
 
 $space-tiny: .25rem !default;
 
@@ -101,7 +101,7 @@ $breakpoint-lg: '(min-width: 64em)' !default;
 $breakpoint-xl: '(min-width: 96em)' !default;
 $breakpoint-sm-md: '(min-width: 40em) and (max-width: 52em)' !default;
 $breakpoint-md-lg: '(min-width: 52em) and (max-width: 64em)' !default;
-$breakpoint-es: '(min-width: 736px) and (max-width: 775px)' !default;
+$breakpoint-lang: '(min-width: 736px) and (max-width: 775px)' !default;
 
 $container-width: 780px !default;
 $container-skinny-width: 620px !default;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -1,7 +1,23 @@
-.logo { 
+.logo {
   line-height: 14px;
 
   img { height: 14px; }
+}
+
+.lang-es {
+  header nav {
+    .lang-nav-item {
+      margin-right: $space-2;
+    }
+  }
+}
+
+.lang-fr {
+  header nav {
+    .lang-nav-item {
+      margin-right: $space-1;
+    }
+  }
 }
 
 header { position: relative; }
@@ -46,9 +62,9 @@ header nav {
 
 
 @media #{$breakpoint-sm} {
-  .logo { 
+  .logo {
     line-height: 17px;
-    
+
     img { height: 17px; }
   }
 
@@ -87,8 +103,43 @@ header nav {
   }
 }
 
-@media #{$breakpoint-es}{
-  header nav.es-nav {
-    font-size: $sm-es; 
+@media #{$breakpoint-md} {
+  .lang-es {
+    header nav {
+      .lang-nav-item {
+        margin-right: $space-3;
+      }
+    }
+  }
+
+  .lang-fr {
+    header nav {
+      .lang-nav-item {
+        margin-right: $space-2;
+      }
+    }
+  }
+}
+
+@media #{$breakpoint-lg}{
+  .lang-fr {
+    header nav {
+      .lang-nav-item {
+        margin-right: $space-3;
+      }
+    }
+  }
+}
+
+
+@media #{$breakpoint-lang}{
+  header nav {
+    &.es-nav {
+      font-size: $sm-lang;
+    }
+
+    &.fr-nav {
+      font-size: $sm-lang;
+    }
   }
 }


### PR DESCRIPTION
For https://github.com/18F/identity-private/issues/2296

This PR makes a few updates that prevents the navigation items from rolling over on to a new line. Accompanying style-guide changes exist [here](https://github.com/18F/identity-style-guide/pull/17). 

- Updates to `identity-style-guide@0.2.8`

<img width="653" alt="screen shot 2017-08-25 at 6 12 46 pm" src="https://user-images.githubusercontent.com/4803473/29735751-04a5b44a-89c1-11e7-92ff-a905e62b700a.png">
