### PR TITLE
Fix fancy punctuation on static site headers

### DIFF
--- a/_includes/help/nav_page_bottom.html
+++ b/_includes/help/nav_page_bottom.html
@@ -22,7 +22,8 @@
                 <li class="py1 px2 nav-sidenav-item{% if question.url == page.url %} active{% endif %}">
                   {% assign url_size = question.url | size | minus: 1 %}
                   {% assign page_title = question.url | replace: "/", "." | slice: 1, url_size %}
-                  {% t page_title %}
+                  {% capture page_title %}{% t page_title %}{% endcapture %}
+                  {{ page_title | markdownify }}
                 </li>
               </a>
             {% endfor %}

--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -11,7 +11,8 @@
         <li class="p2 {% unless forloop.last %}border-bottom{% endunless %}">
           {% assign url_size = question.url | size | minus: 1 %}
           {% assign page_title = question.url | replace: "/", "." | slice: 1, url_size %}
-          {% t page_title %}
+          {% capture page_title %}{% t page_title %}{% endcapture %}
+          {{ page_title | markdownify }}
         </li>
       </a>
     {% endfor %}

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -17,7 +17,8 @@ layout: main
         <h2 id="{{ page.slug }}" class="mt0 mb1 pt2">
           {% assign url_size = page.url | size | minus: 1 %}
           {% assign page_title = page.url | replace: "/", "." | slice: 1, url_size %}
-          {% t page_title %}
+          {% capture page_title %}{% t page_title %}{% endcapture %}
+          {{ page_title | markdownify }}
         </h2>
         <img alt="" src="{{ site.baseurl }}/assets/img/hr-red-{{ _index }}.svg" height="6" class="mb2">
         <div class="mb0">


### PR DESCRIPTION
**Why**: Body content uses fancy punctuation but headers do not

**How**: Added the markdownify filter to the header content
