### PR TITLE
Remove extra word from help page

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -456,7 +456,7 @@ help:
     schedule-an-appointment: Can you help with scheduling an appointment?
     application-status: What is the status of my application?
     known-traveler-number: Will my KTN (Known Traveler Number) change? 
-    whats-going-on: I’m seeing seeing a lot of changes on the Trusted Travelers Programs site. What’s going on?
+    whats-going-on: I’m seeing a lot of changes on the Trusted Travelers Programs site. What’s going on?
   signing-in:
     i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me: I can't
       remember where my personal key is and I don't have my phone with me.


### PR DESCRIPTION
Fix typo / remove extra word in header: https://login.gov/help/trusted-traveler-programs/whats-going-on/