### PR TITLE
Set the baseurl to empty string by default

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 # Site settings
 title: login.gov
-baseurl: ''
 image: /assets/img/login-gov-288x288.png
 canonical_domain: www.login.gov
 
@@ -90,3 +89,4 @@ playbook:
    - anchor: security
      img: graphic-hex
      text: Create responsive security systems
+baseurl:

--- a/_plugins/baseurl.rb
+++ b/_plugins/baseurl.rb
@@ -1,0 +1,9 @@
+# The jekyll-multiple-languages-plugin does not allow the baseurl to be nil
+# because it tries to deconstruct it and add the locale to it for each page.
+#
+# Federalist will override the config at build time and set the baseurl to nil
+# if the site is being built for a live url. This counters that by setting it
+# to an empty string if that's been done.
+Jekyll::Hooks.register :site, :after_init do |site|
+  site.config['baseurl'] ||= ''
+end


### PR DESCRIPTION
**Why**: When Federalist is building the site, it sets the baseurl value
to nil if the site is being build with a custom domain, meaning it is
being built to be deployed to either preview.login.gov or login.gov.
This creates a problem with the multiple languages plugin which expects
the baseurl to be present. This commit adds a plugin with a hook to set
the baseurl to an empty string if it is nil, which fixes the bug.