### PR TITLE
Don't specify specific version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '~> 2.5.1'
 
 gem 'jekyll'
 gem 'jekyll-redirect-from'


### PR DESCRIPTION
**Why**: CI will steadily upgrade the ruby version we use. This means we
don't have to upgrade the ruby version every time circle does.