### PR TITLE
Changing any reference to USAJobs to USAJOBS

### DIFF
--- a/_help/index.md
+++ b/_help/index.md
@@ -23,7 +23,7 @@ links:
   - name: Trusted Traveler Programs
     url: /help/trusted-traveler-programs/
     img_url: /assets/img/app.svg
-  - name: USAJobs
+  - name: USAJOBS
     url: /help/usajobs/
     img_url: /assets/img/app.svg
   - name: SAM

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -35,7 +35,7 @@ contact_page:
       railroad_retirement_board: Railroad Retirement Board
       sam: SAM.gov
       trusted_traveler_program: Trusted Traveler Program
-      usajobs: USAJobs
+      usajobs: USAJOBS
       usss_pix: USSS PIX
     instructions: Let us know a bit about the problem you’re experiencing and we’ll
       get back to you soon
@@ -729,7 +729,7 @@ help_subpages:
   security-keys: Security keys
   signing-in: Signing in
   trusted-traveler-programs: Trusted Traveler Programs
-  usajobs: USAJobs
+  usajobs: USAJOBS
 implementation_page:
   heading: Implementing an identity management system
   section_1:

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -30,7 +30,7 @@ contact_page:
       railroad_retirement_board: Railroad Retirement Board
       sam: SAM.gov
       trusted_traveler_program: Trusted Traveler Program
-      usajobs: USAJobs
+      usajobs: USAJOBS
       usss_pix: USSS PIX
     instructions: Cuéntanos un poco sobre el problema que estás experimentando y te
       responderemos pronto
@@ -747,7 +747,7 @@ help_subpages:
   security-keys: Llaves de seguridad
   signing-in: Iniciando sesión
   trusted-traveler-programs: Trusted Traveler Programs
-  usajobs: USAJobs
+  usajobs: USAJOBS
 implementation_page:
   heading: Implementando un sistema de gestión de la identidad
   section_1:

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -31,7 +31,7 @@ contact_page:
       railroad_retirement_board: Railroad Retirement Board
       sam: SAM.gov
       trusted_traveler_program: Trusted Traveler Program
-      usajobs: USAJobs
+      usajobs: USAJOBS
       usss_pix: USSS PIX
     instructions: Décrivez-nous le problème que vous rencontrez et nous vous répondrons
       dans les plus brefs délais.
@@ -751,7 +751,7 @@ help_subpages:
   security-keys: Clés de sécurité
   signing-in: Connexion
   trusted-traveler-programs: Trusted Traveler Programs
-  usajobs: USAJobs
+  usajobs: USAJOBS
 implementation_page:
   heading: Mise en œuvre d'un système de gestion d'identité
   section_1:


### PR DESCRIPTION
Dan from USAJOBS reached out saying we have a few places on the site where we list USAJOBS incorrectly. I went through and update the places where we don't have USAJOBS in all caps. 