### PR TITLE
Remove sentence about sharing phone numbers

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1065,8 +1065,7 @@ policy_page:
       with each federal agency (“partner agency”) at which you are seeking
       to access information and services. We collect your phone number in
       order to enable two-factor authentication as a security measure for
-      your login.gov account. Your phone number is only sent to a one-time
-      password service provider, not any of the partner agencies.
+      your login.gov account.
 principles_page:
   heading_1: The principles of the identity playbook
   heading_2: Focus on user needs

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1066,6 +1066,7 @@ policy_page:
       Recopilamos otra información limitada automáticamente de los visitantes que leen o navegan la información de nuestro sitio. Hacemos esto para entender mejor cómo se utiliza el sitio y cómo podemos hacerlo más servicial.
     p_2: |-
       Si crea una cuenta, login.gov recopila su información personal identificable (PII, sigla en inglés), incluyendo su email y número de teléfono. Recopilamos su email y con su consentimiento lo compartimos con cada agencia federal ("agencia asociada") en la que usted está buscando acceso a información y servicios. Recopilamos su número de teléfono para poder permitir la autenticación de dos factores como medida de seguridad para su cuenta de login.gov.
+principles_page:
   heading_1: Los principios del manual de identidad
   heading_2: Concéntrese en las necesidades de los usuarios
   heading_3: Sea transparente sobre cómo funciona

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1065,9 +1065,7 @@ policy_page:
       Su privacidad es muy importante para nosotros. Le proveemos nuestra política de privacidad para que usted tenga conocimiento de la información que recopilamos, por qué la recopilamos y qué hacemos con ella. Login.gov no recopila su email o número de teléfono, a menos que usted elija proporcionarlo.
       Recopilamos otra información limitada automáticamente de los visitantes que leen o navegan la información de nuestro sitio. Hacemos esto para entender mejor cómo se utiliza el sitio y cómo podemos hacerlo más servicial.
     p_2: |-
-      Si crea una cuenta, login.gov recopila su información personal identificable (PII, sigla en inglés), incluyendo su email y número de teléfono. Recopilamos su email y con su consentimiento lo compartimos con cada agencia federal ("agencia asociada") en la que usted está buscando acceso a información y servicios. Recopilamos su número de teléfono para poder permitir la autenticación de dos factores como medida de seguridad para su cuenta de login.gov. Su número de teléfono es compartido sólo una vez con un
-      proveedor de servicios de contraseñas, no con cualquiera de las agencias asociadas.
-principles_page:
+      Si crea una cuenta, login.gov recopila su información personal identificable (PII, sigla en inglés), incluyendo su email y número de teléfono. Recopilamos su email y con su consentimiento lo compartimos con cada agencia federal ("agencia asociada") en la que usted está buscando acceso a información y servicios. Recopilamos su número de teléfono para poder permitir la autenticación de dos factores como medida de seguridad para su cuenta de login.gov.
   heading_1: Los principios del manual de identidad
   heading_2: Concéntrese en las necesidades de los usuarios
   heading_3: Sea transparente sobre cómo funciona

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1062,9 +1062,7 @@ policy_page:
       avec chaque agence fédérale (« agence partenaire ») auprès de laquelle vous
       cherchez à obtenir de l'information et des services. Nous recueillons votre
       numéro de téléphone afin de permettre une authentification à deux facteurs comme
-      mesure de sécurité pour votre compte login.gov. Votre numéro de téléphone est
-      envoyé uniquement à un fournisseur de mot de passe à utilisation unique, mais
-      à aucune des agences partenaires.
+      mesure de sécurité pour votre compte login.gov.
 principles_page:
   heading_1: Les principes du guide de mise en œuvre de l'identité
   heading_2: Axé sur les besoins des utilisateurs


### PR DESCRIPTION
**Why**: Per @rspeidel, the statement is overly broad given that if a
phone number is used for identity verification we may share it with a
service provider if the service provider requests it.