### PR TITLE
Add a security.txt file.

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: mailto:security@login.gov
+Contact: https://login.gov/contact/
+Contact: https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform
+Preferred-Languages: en
+Canonical: https://login.gov/.well-known/security.txt
+Policy: https://18f.gsa.gov/vulnerability-disclosure-policy/
+Hiring: https://join.tts.gsa.gov/join/security-ops-engineer/

--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,10 @@ defaults:
   values:
     layout: main
 
+include:
+  # dotfiles are excluded by default
+  - .well-known
+
 exclude:
   - /assets/stylesheets/main.scss
   - Gemfile*


### PR DESCRIPTION
Security.txt is a proposed standard for publishing methods of reporting
and points of contact for receiving notice of security issues.

https://securitytxt.org/

It will be visible at https://login.gov/.well-known/security.txt