### PR TITLE
add nowrap to navigation dropdown

### DIFF
--- a/_sass/components/_dropdown.scss
+++ b/_sass/components/_dropdown.scss
@@ -29,6 +29,7 @@ $dropdown-min-width: 125px;
       padding: 0;
       position: absolute;
       transition: all .1s;
+      white-space: nowrap;
       visibility: hidden;
 
       a {


### PR DESCRIPTION
Adding `white-space: nowrap` to the navigation dropdown UL prevents the text from breaking to a new line on each word and creating difficult to read dropdown menus.