### PR TITLE
Update jQuery to latest, v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "basscss-sass": "^3.0.0",
     "bootstrap": "^3.4.0",
     "hint.css": "^2.5.0",
-    "jquery": "^3.4.0",
+    "jquery": "^3.4.1",
     "node-sass": "^4.9.3",
     "normalize.css": "^4.2.0",
     "webpack": "^1.13.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,7 +2250,7 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-jquery@^3.4.0:
+jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==


### PR DESCRIPTION
**Why?**:  to ensure that we have all security fixes in use.