### PR TITLE
Remove jQuery from the contact center form

### DIFF
--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -144,10 +144,6 @@
     window.onload = populatetopics;
 </script>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-
-
 <h2>{% t contact_page.support_request_form.title %}</h2>
 <p>{% t contact_page.support_request_form.instructions %}</p>
 


### PR DESCRIPTION
**Why**: So @amirbey does not have to send us angry emails about jQuery being out of date

It looks like the issue is that the form the contact center sent us included a link to the jQuery. We changed their code to not use it, but retained the jQuery import and that is what is getting picked up in GSAIT's scans. This commit removes it entirely.