### PR TITLE
Fix broken link in FAQ to authenticator (LG-2521)

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -347,7 +347,7 @@ help_pages:
       <img src="site.baseurl/assets/img/help/6-enter-one-time-security-code.png" class="mt3 mb3 block" alt="Enter security code help image" />
 
       #### Authentication application
-      To use an authentication app, you must first install one of the supported applications and configure it to work with login.gov.  [Read more on how to set up an authentication app.](site.baseurl/help/changing-settings/authentication-application/)
+      To use an authentication app, you must first install one of the supported applications and configure it to work with login.gov.  [Read more on how to set up an authentication app.](site.baseurl/help/creating-an-account/authentication-application/)
       <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
 
       #### Security key

--- a/spec/_pages/help.md_spec.rb
+++ b/spec/_pages/help.md_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe 'help.md' do
   it 'has valid links' do
     expect(doc).to link_to_valid_urls
   end
+
+  describe '/help/creating-an-account/how-to-create-an-account' do
+    let(:doc) { Nokogiri::HTML(file_at('/help/creating-an-account/how-to-create-an-account')) }
+
+    it 'links to valid internal pages' do
+      expect(doc).to link_to_valid_internal_pages
+    end
+  end
 end


### PR DESCRIPTION
Spanish and French translations had the correct link already