### PR TITLE
Add FAQ on recommended MFA methods

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,7 @@ plugins:
 
 help_pages:
 - creating-an-account
+- authentication-methods
 - verifying-your-identity
 - signing-in
 - changing-settings

--- a/_help/authentication-methods/which-authentication-method-should-i-use.md
+++ b/_help/authentication-methods/which-authentication-method-should-i-use.md
@@ -1,0 +1,7 @@
+---
+order: 1
+redirect_from:
+- /help/authentication-methods/
+---
+
+{% include help/translate_page.html url=page.url %}

--- a/_help/index.md
+++ b/_help/index.md
@@ -9,13 +9,12 @@ links:
   - name: Creating an account
     url: /help/creating-an-account/do-i-need-a-mobile-phone-to-use-logingov/
     img_url: /assets/img/create-account-light.svg
-## LG-1378 - the following section has been commented out until Proofing release 
-#  - name: Identity verification
-#    url: /help/identity-verification/do-i-need-a-mobile-phone-to-use-logingov/
-#    img_url: /assets/img/lg-1425-identity-verfication.svg
+  - name: Authentication methods
+    url: /help/authentication-methods/which-authentication-method-should-i-use/
+    img_url: /assets/img/create-account-light.svg
   - name: Verifying your identity
     url: /help/verifying-your-identity/why-do-i-need-to-verify-my-identity/
-    img_url: /assets/img/create-account-light.svg
+    img_url: /assets/img/lg-1425-identity-verfication.svg
   - name: Signing in
     url: /help/signing-in/i-cant-remember-where-my-personal-key-is-and-i-dont-have-my-phone-with-me/
     img_url: /assets/img/sign-in-light.svg

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -168,6 +168,8 @@ help:
     no-phone-or-other-authentication-method: No phone or other authentication method
     personal-key: Personal key
     what-are-backup-codes: What are backup codes?
+  authentication-methods:
+    which-authentication-method-should-i-use: Which authentication method should I use?
   verifying-your-identity:
     why-do-i-need-to-verify-my-identity: Why do I need to verify my identity?
     how-to-verify-my-identity: How to verify my identity
@@ -332,10 +334,39 @@ help_pages:
 
       ### Configure a second layer of security
       Next, you will configure a secondary authentication method. The second step keeps your account more secure than using only a password. You can choose between text messages, phone calls, an authentication application, a security key, or backup codes. Government employees can also use their PIV or CAC cards.
+
+      Login.gov uses two-factor authentication (TFA), or multi-factor authentication (MFA), as an added layer of protection to secure your most sensitive information.
+
+      Two-factor authentication can be done in multiple ways and each has a different level of security. You can choose between text messages, phone calls, an authentication application, a security key, or backup codes. Government employees can also use their PIV or CAC cards.
+
+      We encourage you to review the available options and select the most secure option for you.
+
+      [Learn more about each authentication method.](site.baseurl/help/authentication-methods/which-authentication-method-should-i-use/)
+
       <img src="site.baseurl/assets/img/help/2nd_factor_options.png" class="mt3 mb3 block" alt="2nd factor options help image" />
 
+      #### Authentication application
+      Authentication apps are downloaded to your device and generate secure, 6-digit codes you can use to log in to your accounts. Unlike phone calls or text messaging/SMS, a hacker would need physical access to your cell phone in order to use the code.
+
+      While authentication apps are not protected if your device is lost or stolen, these apps offer more security than phone calls or text messaging/SMS against phishing, hacking or interception.
+
+      If you choose to use this secure option, you can download and install one of the supported applications and configure it to work with login.gov. Learn how to set up an authentication app.
+      [Read more on how to set up an authentication app.](site.baseurl/help/creating-an-account/authentication-application/)
+
+      <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
+
+      #### Security key
+      A security key is typically a physical device, like a USB, that you plug into your computer. The key is linked to your accounts and will only grant access to those accounts once the key is plugged in and activated. Since a security key does not rely on your cell phone, it has the highest level of protection against phishing and built in protections against hacking if it is lost or stolen.
+
+      Login.gov requires security keys that meet the FIDO standards. You can also add as many security keys as you want to secure your account.
+
+      To use this secure option for authentication, plug the key into a USB port and assign the key a name to identify it within your login.gov account. The next step will ask you to activate your key. This is generally done by pressing a button on the key itself.
+      <img src="site.baseurl/assets/img/help/security_key.png" class="mt3 mb3 block" alt="Security key help image" />
+
       #### Text message/SMS or Phone call
-      If you select Text message/SMS or Phone call as a second authentication method, enter a phone number at which you can get phone calls or text messages. If you have a landline, you must receive your security code by phone call. login.gov cannot send security codes to extensions or voicemails.
+      Text message/SMS or phone calls are convenient but are extremely vulnerable to theft, hackers and other attacks.
+
+      If you choose to use this less secure option, enter a phone number at which you can get phone calls or text messages. If you have a landline, you must receive your security code by phone call. login.gov cannot send security codes to extensions or voicemails.
 
       We will send a unique security code to that phone number each time you sign into your account.
       <img src="site.baseurl/assets/img/help/5-phonenumber.png" class="mt3 mb3 block" alt="Add a phone number help image" />
@@ -346,18 +377,10 @@ help_pages:
       Type the security code into the field. That’s it! Every time you sign back into your login.gov account, you will receive a new security code that you need to enter. You’ll get the option each time you sign in to get a security code by a phone call or by SMS.
       <img src="site.baseurl/assets/img/help/6-enter-one-time-security-code.png" class="mt3 mb3 block" alt="Enter security code help image" />
 
-      #### Authentication application
-      To use an authentication app, you must first install one of the supported applications and configure it to work with login.gov.  [Read more on how to set up an authentication app.](site.baseurl/help/creating-an-account/authentication-application/)
-      <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
-
-      #### Security key
-      Your security key must support the FIDO standard. You can add as many security keys as you want. Once you connect your key to your computer, usually by plugging it into a USB port, assign the key a name to identify it within your login.gov account. The next step will ask you to activate your key. This is generally done by pressing a button on the key itself.
-
-      <img src="site.baseurl/assets/img/help/security_key.png" class="mt3 mb3 block" alt="Security key help image" />
-
       #### Backup codes
-      Backup codes are another method of authentication. When you elect to use the backup codes as your 2nd factor, login.gov will generate a set of 10 codes. After you sign in with your username and password, you will be prompted for a code. Each code may only be used once, once the 10th code has been used you will be prompted to download a new list. Treat your recovery codes with the same level of attention as you would your password.
+      While backup codes are an accessible option for users who do not have phone access, these codes are the least secure option for two-factor authentication. Backup codes must be printed or written down which makes them more vulnerable to theft and phishing.
 
+      If you choose to select this less secure option, login.gov will generate a set of 10 codes. After you sign in with your username and password, you will be prompted for a code. Each code may only be used once, once the 10th code has been used you will be prompted to download a new list. Treat your recovery codes with the same level of attention as you would your password.
       <img src="site.baseurl/assets/img/help/backup_codes.png" class="mt3 mb3 block" alt="Backup codes generated help image" />
     no-phone-or-other-authentication-method: |-
       login.gov requires users to set up two forms of two-factor authentication methods when creating an account. However, if you do not have access to a phone, authentication application, security key, or government employee ID (PIV/CAC card), you can set up your account with only backup codes.
@@ -474,6 +497,46 @@ help_pages:
       If the confirmation link still does not work and you have done the steps outlined above, it is possible your email provider has scrambled the link. One way to determine if this has happened is by copying and pasting the confirmation link into your browser. If there are any unusual symbols or words in the link, remove them and hit enter.
 
       For additional help, [please submit a support ticket] (https://login.gov/contact).
+  authentication-methods:
+    which-authentication-method-should-i-use: |-
+      Unfortunately, passwords aren’t enough to protect your account anymore.
+
+      Login.gov uses two-factor authentication (TFA), or multi-factor authentication (MFA), as an added layer of protection to secure your most sensitive information.
+
+      Two-factor authentication can be done in multiple ways and each has a different level of security. You can choose between text messages, phone calls, an authentication application, a security key, or backup codes. Government employees can also use their PIV or CAC cards.
+
+      We encourage you to review the available options and select the most secure option for you.
+
+      <div class="usa-tag float-right bg-info-dark">MORE SECURE</div>
+      ### Security Key
+      More secure against phishing and hacks with built in protections against theft.
+
+      A security key is typically a physical device, like a USB, that you plug into your computer. The key is linked to your accounts and will only grant access to those accounts once the key is plugged in and activated. Since a security key does not rely on your cell phone, it has the highest level of protection against phishing and built in protections against hacking if it is lost or stolen.
+
+      <div class="usa-tag float-right bg-info-dark">MORE SECURE</div>
+      ### PIV/CAC for military and federal employees
+      More secure against phishing and hacks with built in protections against theft.
+
+      Physical PIV and CAC smart cards are secure options for military personnel and federal employees. These cards, with encrypted chip technology, are resistant to phishing and difficult to hack if stolen.
+
+      <div class="usa-tag float-right bg-info-dark">MORE SECURE</div>
+      ### Authentication App
+      More secure against phishing and hacks but with less protection against theft.
+
+      Authentication apps are downloaded to your device and generate secure, 6-digit codes you can use to log in to your accounts. Unlike phone calls or text messaging/SMS, a hacker would need physical access to your cell phone in order to use the code.
+
+      While authentication apps are not protected if your device is lost or stolen, these apps offer more security than phone calls or text messaging/SMS against phishing, hacking or interception.
+
+      ### Text message/SMS or Phone call
+      Less secure against phishing, hacks and theft.
+
+      Text message/SMS or phone calls are convenient but are extremely vulnerable to theft, hackers and other attacks.
+
+      <div class="usa-tag float-right bg-info-dark">LESS SECURE</div>
+      ### Backup codes
+      Less secure against phishing, hacks and more subjective to theft.
+
+      While backup codes are an accessible option for users who do not have phone access, these codes are the least secure option for two-factor authentication. Backup codes must be printed or written down which makes them more vulnerable to theft and phishing.
   verifying-your-identity:
     why-do-i-need-to-verify-my-identity: |-
       Some government applications that use login.gov require users to verify their identities. This means that you must prove that you are who you say you are. By doing this, we make sure that only the right people get access to sensitive information.
@@ -876,6 +939,7 @@ help_pages:
 help_subpages:
   changing-settings: Changing settings
   creating-an-account: Creating an account
+  authentication-methods: Authentication methods
   verifying-your-identity: Verifying your identity
   privacy-and-security: Privacy & security
   sam: SAM

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -129,6 +129,8 @@ help:
     multiple-accounts-to-verifying-my-identity-for: "¿Por qué
       tengo que usar login.gov para acceder a los servicios del Gobierno en línea?"
     email-address-confirmation-link-is-invalid: "El enlace para confirmar mi correo electrónico no es válido"
+  authentication-methods:
+    which-authentication-method-should-i-use: "¿Qué método de autenticación debo usar?"
   verifying-your-identity:
     phone-plan-is-not-in-my-name-or-address: "Mi plan telefónico no está a mi nombre o dirección"
     why-do-i-need-to-verify-my-identity: ¿Por qué necesito verificar mi identidad?
@@ -335,26 +337,49 @@ help_pages:
 
       ### Configure una segunda barrera de seguridad
       Después, configurará un factor de autenticación secundario. El segundo paso mantiene su cuenta más segura que con solo usar una contraseña. Puede elegir entre mensajes de texto, llamadas telefónicas, una aplicación de autenticación, una clave de seguridad o códigos de respaldo. Los empleados del gobierno también pueden usar sus tarjetas PIV (verificación de identidad personal) o CAC (tarjeta de acceso común).
+
+      Login.gov utiliza la autenticación de dos factores (TFA) o la autenticación de múltiples factores (MFA), como una capa adicional de protección para proteger su información más confidencial.
+
+      La autenticación de dos factores se puede realizar de varias maneras y cada una tiene un nivel de seguridad diferente. Puede elegir entre mensajes de texto, llamadas telefónicas, una aplicación de autenticación, una clave de seguridad o códigos de respaldo. Los empleados del gobierno también pueden usar sus tarjetas PIV o CAC.
+
+      Le recomendamos que revise las opciones disponibles y seleccione la opción más segura para usted.
+
+      [Obtenga más información sobre cada método de autenticación.](site.baseurl/help/authentication-methods/which-authentication-method-should-i-use/)
+
       <img src="site.baseurl/assets/img/help/2nd_factor_options.png" class="mt3 mb3 block" alt="2nd factor options help image" />
 
+      #### Aplicación de autenticación
+      Las aplicaciones de autenticación se descargan en su dispositivo y generan códigos seguros de 6 dígitos que puede usar para iniciar sesión en sus cuentas. A diferencia de las llamadas telefónicas o los mensajes de texto / SMS, un hacker necesitaría acceso físico a su teléfono celular para usar el código.
+
+      Si bien las aplicaciones de autenticación no están protegidas si su dispositivo se pierde o es robado, estas aplicaciones ofrecen más seguridad que las llamadas telefónicas o los mensajes de texto / SMS contra el phishing, la piratería o la intercepción.
+
+      Si elige usar esta opción segura, puede descargar e instalar una de las aplicaciones compatibles y configurarla para que funcione con login.gov. Aprenda a configurar una aplicación de autenticación.
+      [Lea más sobre cómo configurar una aplicación de autenticación.](site.baseurl/help/creating-an-account/authentication-application/)
+
+      <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
+
+      #### Llave de seguridad
+      Una clave de seguridad suele ser un dispositivo físico, como un USB, que se conecta a la computadora. La clave está vinculada a sus cuentas y solo otorgará acceso a esas cuentas una vez que la clave esté enchufada y activada. Dado que una clave de seguridad no depende de su teléfono celular, tiene el más alto nivel de protección contra phishing y protecciones integradas contra piratería si se pierde o es robada.
+
+      Login.gov requiere claves de seguridad que cumplan con los estándares de FIDO. También puede agregar tantas claves de seguridad como desee para asegurar su cuenta.
+
+      Para utilizar esta opción segura para la autenticación, conecte la clave a un puerto USB y asigne un nombre a la clave para identificarla dentro de su cuenta login.gov. El siguiente paso le pedirá que active su clave. Esto generalmente se hace presionando un botón en la tecla.
+      <img src="site.baseurl/assets/img/help/security_key.png" class="mt3 mb3 block" alt="Security key help image" />
+
       #### Mensaje de texto/SMS o llamada telefónica
+      Los mensajes de texto / SMS o las llamadas telefónicas son convenientes, pero son extremadamente vulnerables a robos, piratas informáticos y otros ataques.
 
       Si usted selecciona el mensaje de texto/SMS o llamada telefónica como segundo factor de autenticación, ingrese un número telefónico en el cual pueda recibir llamadas telefónicas o mensajes de texto. Si tiene un teléfono fijo, debe recibir su código de seguridad por llamada telefónica. login.gov no puede enviar códigos de seguridad a las extensiones.
       Enviaremos un código de seguridad único a ese número telefónico cada vez que inicie sesión en su cuenta.
       <img src="site.baseurl/assets/img/help/5-phonenumber.png" class="mt3 mb3 block" alt="Add a phone number help image" />
+
       Cada código de seguridad caduca a los 10 minutos y solo se puede utilizar una vez. Si no ingresa el código de seguridad en 10 minutos, solo solicite un código nuevo. Cada código solo es válido una vez, por lo que nadie puede robar uno que ya haya usado.
       <img src="site.baseurl/assets/img/help/text-confirmation-code.png" class="mt3 mb3 block" alt="Phone text confirmation code help image" />
 
-      #### Aplicación de autenticación
-      Para usar una aplicación de autenticación, primero debe instalar una de las aplicaciones compatibles y configurarla para que trabaje con login.gov [Lea más sobre cómo configurar una aplicación de autenticación.](site.baseurl/help/creating-an-account/authentication-application/)
-      <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
-
-      #### Llave de seguridad
-      Su clave de seguridad debe ser compatible con el estándar FIDO. Puede agregar tantas claves de seguridad como desee. Una vez que conecte su clave a su computadora, usualmente conectándola a un puerto USB, asigne un nombre a la clave para así identificarla dentro de su cuenta en login.gov. El siguiente paso le pedirá que active su cuenta. Por lo general, esto se hace presionando un botón en la misma clave.
-      <img src="site.baseurl/assets/img/help/security_key.png" class="mt3 mb3 block" alt="Security key help image" />
-
       #### Códigos de respaldo
-      Los códigos de respaldo son otro método de autenticación. Cuando elija usar los códigos de respaldo como su segundo factor, login.gov le generará una serie de 10 códigos. Después de que inicie sesión con su nombre de usuario y contraseña, se le pedirá un código. Cada código puede usarse una vez, y cuando se haya usado el décimo, se le pedirá que descargue una lista nueva. Trate sus códigos de recuperación con el mismo nivel de atención que le daría a su contraseña.
+      Si bien los códigos de respaldo son una opción accesible para los usuarios que no tienen acceso telefónico, estos códigos son la opción menos segura para la autenticación de dos factores. Los códigos de respaldo deben imprimirse o escribirse, lo que los hace más vulnerables al robo y al phishing.
+
+      Si elige seleccionar esta opción menos segura, login.gov generará un conjunto de 10 códigos. Después de iniciar sesión con su nombre de usuario y contraseña, se le solicitará un código. Cada código solo se puede usar una vez, una vez que se haya usado el décimo código, se le pedirá que descargue una nueva lista. Trate sus códigos de recuperación con el mismo nivel de atención que lo haría con su contraseña.
       <img src="site.baseurl/assets/img/help/backup_codes.png" class="mt3 mb3 block" alt="Backup codes generated help image" />
     no-phone-or-other-authentication-method: |-
       login.gov requiere que los usuarios configuren dos formas de métodos de autenticación de dos factores al crear una cuenta. Sin embargo, si no tiene acceso a un teléfono, una aplicación de autenticación, una clave de seguridad o una identificación de empleado del gobierno (tarjeta PIV / CAC), puede configurar su cuenta solo con códigos de respaldo.
@@ -436,6 +461,46 @@ help_pages:
       Si el enlace de confirmación sigue sin ser válido y ha seguido los pasos descritos anteriormente, es posible que su proveedor de correo electrónico haya codificado el enlace. Una forma de determinar si ha sucedido esto es copiando y pegando el enlace de confirmación en su navegador. Si hay símbolos o palabras inusuales en el enlace, quítelos y pulse "Intro".
 
       Para obtener ayuda adicional, envíe un correo electrónico a [hello@login.gov](mailto:hello@login.gov).
+  authentication-methods:
+    which-authentication-method-should-i-use: |-
+      Lamentablemente, las contraseñas ya no son suficientes para proteger su cuenta.
+
+      Login.gov utiliza la autenticación de dos factores (TFA) o la autenticación de múltiples factores (MFA), como una capa adicional de protección para proteger su información más confidencial.
+
+      La autenticación de dos factores se puede realizar de varias maneras y cada una tiene un nivel de seguridad diferente. Puede elegir entre mensajes de texto, llamadas telefónicas, una aplicación de autenticación, una clave de seguridad o códigos de respaldo. Los empleados del gobierno también pueden usar sus tarjetas PIV o CAC.
+
+      Le recomendamos que revise las opciones disponibles y seleccione la opción más segura para usted.
+
+      <span class="usa-tag float-right bg-info-dark">MÁS SEGURIDAD</span>
+      ### Clave de seguridad
+      Más seguro contra phishing y piratas informáticos con protecciones integradas contra robo.
+
+      Una clave de seguridad suele ser un dispositivo físico, como un USB, que se conecta a la computadora. La clave está vinculada a sus cuentas y solo otorgará acceso a esas cuentas una vez que la clave esté enchufada y activada. Dado que una clave de seguridad no depende de su teléfono celular, tiene el más alto nivel de protección contra phishing y protecciones integradas contra piratería si se pierde o es robada.
+
+      <span class="usa-tag float-right bg-info-dark">MÁS SEGURIDAD</span>
+      ### PIV/CAC para empleados militares y federales
+      Más seguro contra phishing y piratas informáticos con protecciones integradas contra robo.
+
+      Las tarjetas inteligentes físicas PIV y CAC son opciones seguras para el personal militar y los empleados federales. Estas tarjetas, con tecnología de chip encriptado, son resistentes al phishing y difíciles de hackear si son robadas.
+
+      <span class="usa-tag float-right bg-info-dark">MÁS SEGURIDAD</span>
+      ### Aplicación de autenticación
+      Más seguro contra phishing y piratas informáticos, pero con menos protección contra el robo.
+
+      Las aplicaciones de autenticación se descargan en su dispositivo y generan códigos seguros de 6 dígitos que puede usar para iniciar sesión en sus cuentas. A diferencia de las llamadas telefónicas o los mensajes de texto / SMS, un hacker necesitaría acceso físico a su teléfono celular para usar el código.
+
+      Si bien las aplicaciones de autenticación no están protegidas si su dispositivo se pierde o es robado, estas aplicaciones ofrecen más seguridad que las llamadas telefónicas o los mensajes de texto / SMS contra el phishing, la piratería o la intercepción.
+
+      ### Mensaje de texto / SMS o llamada telefónica
+      Menos seguro contra phishing, hacks y robos.
+
+      Los mensajes de texto / SMS o las llamadas telefónicas son convenientes, pero son extremadamente vulnerables a robos, piratas informáticos y otros ataques.
+
+      <span class="usa-tag float-right bg-info-dark">MENOS SEGURIDAD</span>
+      ### Códigos de respaldo
+      Menos seguro contra phishing, piratas informáticos y más subjetivo al robo.
+
+      Si bien los códigos de respaldo son una opción accesible para los usuarios que no tienen acceso telefónico, estos códigos son la opción menos segura para la autenticación de dos factores. Los códigos de respaldo deben imprimirse o escribirse, lo que los hace más vulnerables al robo y al phishing.
   verifying-your-identity:
     phone-plan-is-not-in-my-name-or-address: |-
       Si no podemos verificar automáticamente su dirección, debe verificarla por correo. Esto significa que le enviaremos una carta con un código de confirmación que debe usar para terminar de configurar su cuenta.

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -160,6 +160,8 @@ help:
     multiple-accounts-to-verifying-my-identity-for: Pourquoi dois-je
       utiliser login.gov pour accéder aux services en ligne du gouvernement?
     email-address-confirmation-link-is-invalid: Le lien de confirmation de l'adresse e-mail est invalide
+  authentication-methods:
+    which-authentication-method-should-i-use: Quelle méthode d'authentification dois-je utiliser?
   verifying-your-identity:
     phone-plan-is-not-in-my-name-or-address: Le forfait de téléphone n'est pas à mon nom ou adresse
     why-do-i-need-to-verify-my-identity: Pourquoi est-il nécessaire de vérifier mon identité?
@@ -366,25 +368,46 @@ help_pages:
       ### Configuration d’une deuxième étape de sécurité
       Ensuite, vous configurerez un deuxième méthode d’authentification. La deuxième étape maintient une meilleure sécurité pour votre compte que la simple utilisation d’un mot de passe. Vous pouvez choisir entre des messages texte, des appels téléphoniques, une application d’authentification, une clé de sécurité ou des codes de sauvegarde. Les employés du gouvernement peuvent aussi utiliser leurs cartes PIV ou CAC.
 
+      Login.gov utilise l'authentification à deux facteurs (TFA) ou l'authentification à plusieurs facteurs (MFA), comme couche de protection supplémentaire pour sécuriser vos informations les plus sensibles.
+
+      L'authentification à deux facteurs peut être effectuée de plusieurs manières et chacune a un niveau de sécurité différent. Vous pouvez choisir entre des SMS, des appels téléphoniques, une application d'authentification, une clé de sécurité ou des codes de sauvegarde. Les employés du gouvernement peuvent également utiliser leurs cartes PIV ou CAC.
+
+      Nous vous encourageons à examiner les options disponibles et à sélectionner l'option la plus sécurisée pour vous.
+
+      [En savoir plus sur chaque méthode d'authentification.](site.baseurl/help/authentication-methods/which-authentication-method-should-i-use/)
+
       <img src="site.baseurl/assets/img/help/2nd_factor_options.png" class="mt3 mb3 block" alt="2nd factor options help image" />
 
+      #### Application d’authentification
+      Les applications d'authentification sont téléchargées sur votre appareil et génèrent des codes sécurisés à 6 chiffres que vous pouvez utiliser pour vous connecter à vos comptes. Contrairement aux appels téléphoniques ou à la messagerie texte / SMS, un pirate aurait besoin d'un accès physique à votre téléphone portable pour utiliser le code.
+
+      Bien que les applications d'authentification ne soient pas protégées en cas de perte ou de vol de votre appareil, ces applications offrent plus de sécurité que les appels téléphoniques ou la messagerie texte / SMS contre le phishing, le piratage ou l'interception.
+
+      Si vous choisissez d'utiliser cette option sécurisée, vous pouvez télécharger et installer l'une des applications prises en charge et la configurer pour qu'elle fonctionne avec login.gov. Découvrez comment configurer une application d'authentification.
+      [En savoir plus sur la configuration d’une application d’authentification.](site.baseurl/help/creating-an-account/authentication-application/)
+
+      <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
+
+      #### Clé de sécurité
+      Une clé de sécurité est généralement un périphérique physique, comme une clé USB, que vous branchez à votre ordinateur. La clé est liée à vos comptes et n'accordera l'accès à ces comptes qu'une fois la clé connectée et activée. Puisqu'une clé de sécurité ne dépend pas de votre téléphone portable, elle possède le plus haut niveau de protection contre le phishing et des protections intégrées contre le piratage en cas de perte ou de vol.
+
+      Login.gov nécessite des clés de sécurité conformes aux normes FIDO. Vous pouvez également ajouter autant de clés de sécurité que vous souhaitez pour sécuriser votre compte.
+
+      Pour utiliser cette option sécurisée pour l'authentification, branchez la clé dans un port USB et attribuez un nom à la clé pour l'identifier dans votre compte login.gov. L'étape suivante vous demandera d'activer votre clé. Cela se fait généralement en appuyant sur un bouton de la clé elle-même.
+      <img src="site.baseurl/assets/img/help/security_key.png" class="mt3 mb3 block" alt="Security key help image" />
+
       #### Messages texte/SMS ou appels téléphoniques
+      Les SMS / SMS ou les appels téléphoniques sont pratiques mais sont extrêmement vulnérables au vol, aux pirates et autres attaques.
+
       Si vous choisissez messages texte/SMS ou appels téléphoniques comme deuxième méthode d’authentification, entrez un numéro de téléphone auquel vous pouvez recevoir votre code de sécurité par appel téléphonique. Si vous avez une ligne fixe, vous devez recevoir le code de sécurité par appel téléphonique. login.gov ne peut envoyer de codes de sécurité à des numéros de poste.
 
       Nous enverrons un code de sécurité unique à ce numéro de téléphone chaque fois où vous vous connectez à votre compte.
       <img src="site.baseurl/assets/img/help/5-phonenumber.png" class="mt3 mb3 block" alt="Add a phone number help image" />
 
-      #### Application d’authentification
-      Pour utiliser une application d’authentification, vous devez d’abord installer une des applications prises en charge et la configurer pour qu’elle fonctionne avec login.gov. [En savoir plus sur la configuration d’une application d’authentification.](site.baseurl/help/creating-an-account/authentication-application/)
-      <img src="site.baseurl/assets/img/help/auth_app.png" class="mt3 mb3 block" alt="Enter security code help image" />
-
-      #### Clé de sécurité
-      Votre clé de sécurité doit prendre en charge la norme FIDO. Vous pouvez ajouter autant de clés de sécurité que vous le souhaitez. Une fois que vous avez connecté votre clé à votre ordinateur, de manière générale en la connectant à un port USB, assignez un nom à la clé pour l’identifier dans votre compte login.gov. À l’étape suivante, on vous demandera d’activer votre clé. Cela peut être fait généralement en appuyant sur un bouton situé sur la clé.
-
-      <img src="site.baseurl/assets/img/help/security_key.png" class="mt3 mb3 block" alt="Security key help image" />
-
       #### Codes de sauvegarde
-      Les codes de sauvegarde sont une autre méthode d’authentification. Lorsque vous choisissez d’utiliser les codes de sauvegarde comme deuxième facteur, login.gov génère un ensemble de 10 codes. Une fois connecté(e) avec votre nom d’utilisateur et votre mot de passe, on vous demandera un code. Chaque code peut être utilisé une fois, une fois le 10e code utilisé, on vous demandera de télécharger une nouvelle liste. Traitez vos codes de récupération avec le même niveau d’attention que vous auriez pour votre mot de passe.
+      Bien que les codes de sauvegarde soient une option accessible pour les utilisateurs qui n'ont pas accès au téléphone, ces codes sont l'option la moins sécurisée pour l'authentification à deux facteurs. Les codes de sauvegarde doivent être imprimés ou écrits, ce qui les rend plus vulnérables au vol et au phishing.
+
+      Si vous choisissez de sélectionner cette option moins sécurisée, login.gov générera un ensemble de 10 codes. Après vous être connecté avec votre nom d'utilisateur et votre mot de passe, un code vous sera demandé. Chaque code ne peut être utilisé qu'une seule fois, une fois le 10e code utilisé, vous serez invité à télécharger une nouvelle liste. Traitez vos codes de récupération avec le même niveau d'attention que votre mot de passe.
       <img src="site.baseurl/assets/img/help/backup_codes.png" class="mt3 mb3 block" alt="Backup codes generated help image" />
     no-phone-or-other-authentication-method: |-
       login.gov exige que les utilisateurs configurent deux méthodes de méthodes d'authentification à deux facteurs lors de la création d'un compte. Toutefois, si vous n'avez pas accès à un téléphone, à une application d'authentification, à une clé de sécurité ou à un ID d'employé gouvernemental (carte PIV / CAC), vous pouvez configurer votre compte avec uniquement des codes de sauvegarde.
@@ -465,6 +488,46 @@ help_pages:
       Si le lien de confirmation ne fonctionne pas et que vous avez suivi les étapes indiquées ci-dessus, il est possible que votre fournisseur de messagerie ait brouillé le lien. Une façon de déterminer si cela s'est produit est de copier et de coller le lien de confirmation dans votre navigateur. S'il y a des symboles ou des mots inhabituels dans le lien, éliminez-les et appuyez sur la touche entrer.
 
       Pour obtenir de l'assistance additionnelle, veuillez envoyer un e-mail à [hello@login.gov](mailto:hello@login.gov).
+  authentication-methods:
+    which-authentication-method-should-i-use: |-
+      Malheureusement, les mots de passe ne suffisent plus à protéger votre compte.
+
+      Login.gov utilise l'authentification à deux facteurs (TFA) ou l'authentification à plusieurs facteurs (MFA), comme couche de protection supplémentaire pour sécuriser vos informations les plus sensibles.
+
+      L'authentification à deux facteurs peut être effectuée de plusieurs manières et chacune a un niveau de sécurité différent. Vous pouvez choisir entre des SMS, des appels téléphoniques, une application d'authentification, une clé de sécurité ou des codes de sauvegarde. Les employés du gouvernement peuvent également utiliser leurs cartes PIV ou CAC.
+
+      Nous vous encourageons à examiner les options disponibles et à sélectionner l'option la plus sécurisée pour vous.
+
+      <span class="usa-tag float-right bg-info-dark">PLUS SÉCURISÉ</span>
+      ### Clef de sécurité
+      Plus sûr contre le phishing et les hacks avec des protections intégrées contre le vol.
+
+      Une clé de sécurité est généralement un périphérique physique, comme une clé USB, que vous branchez à votre ordinateur. La clé est liée à vos comptes et n'accordera l'accès à ces comptes qu'une fois la clé connectée et activée. Puisqu'une clé de sécurité ne dépend pas de votre téléphone portable, elle possède le plus haut niveau de protection contre le phishing et des protections intégrées contre le piratage en cas de perte ou de vol.
+
+      <span class="usa-tag float-right bg-info-dark">PLUS SÉCURISÉ</span>
+      ### PIV/CAC pour les employés militaires et fédéraux
+      Plus sûr contre le phishing et les hacks avec des protections intégrées contre le vol.
+
+      Les cartes à puce physiques PIV et CAC sont des options sécurisées pour le personnel militaire et les employés fédéraux. Ces cartes, dotées d'une technologie de puce cryptée, résistent au phishing et sont difficiles à pirater en cas de vol.
+
+      <span class="usa-tag float-right bg-info-dark">PLUS SÉCURISÉ</span>
+      ### Application d'authentification
+      Plus sûr contre le phishing et les hacks mais avec moins de protection contre le vol.
+
+      Les applications d'authentification sont téléchargées sur votre appareil et génèrent des codes sécurisés à 6 chiffres que vous pouvez utiliser pour vous connecter à vos comptes. Contrairement aux appels téléphoniques ou à la messagerie texte / SMS, un pirate aurait besoin d'un accès physique à votre téléphone portable pour utiliser le code.
+
+      Bien que les applications d'authentification ne soient pas protégées en cas de perte ou de vol de votre appareil, ces applications offrent plus de sécurité que les appels téléphoniques ou la messagerie texte / SMS contre le phishing, le piratage ou l'interception.
+
+      ### Message texte/SMS ou appel téléphonique
+      Moins sécurisé contre le phishing, les hacks et le vol.
+
+      Les SMS / SMS ou les appels téléphoniques sont pratiques mais sont extrêmement vulnérables au vol, aux pirates et autres attaques.
+
+      <span class="usa-tag float-right bg-info-dark">MOINS SÉCURISÉ</span>
+      ### Codes de sauvegarde
+      Moins sécurisé contre le phishing, les hacks et plus subjectif au vol.
+
+      Bien que les codes de sauvegarde soient une option accessible pour les utilisateurs qui n'ont pas accès au téléphone, ces codes sont l'option la moins sécurisée pour l'authentification à deux facteurs. Les codes de sauvegarde doivent être imprimés ou écrits, ce qui les rend plus vulnérables au vol et au phishing.
   verifying-your-identity:
     phone-plan-is-not-in-my-name-or-address: |-
       Si nous ne pouvons pas vérifier automatiquement votre adresse, vous devez la vérifier par courrier. Cela signifie que nous vous enverrons une lettre avec un code de confirmation que vous devez utiliser pour terminer la configuration de votre compte.

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -30,3 +30,9 @@ html {
   height: 0;
   visibility: hidden;
 }
+
+footer {
+  .flex-auto {
+    flex: 1 1 auto;
+  }
+}

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -1,3 +1,9 @@
+header {
+  .flex-auto {
+    flex: 1 1 auto;
+  }
+}
+
 @media #{$breakpoint-sm} {
   #developer-header {
     background-image: url('../../img/dev-landing@2x.png');

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -6,6 +6,7 @@
 @import 'vendor';
 
 @import 'mixins/all';
+@import 'identity-style-guide/dist/assets/scss/styles';
 @import 'components/all';
 
 @import 'pages/playbook';

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "basscss-sass": "^3.0.0",
     "bootstrap": "^3.4.0",
     "hint.css": "^2.5.0",
+    "identity-style-guide": "^2.1.5",
     "jquery": "^3.4.1",
     "node-sass": "^4.9.3",
     "normalize.css": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,6 +1899,13 @@ iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+identity-style-guide@^2.1.5:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-2.2.0.tgz#ec6cf44a3a623063a7a04335e179e2a50442b476"
+  integrity sha512-AKK+03R2lB0MXe0aBlyFWaiIyW6ORNBtOsRnve54VNW9SPauytX2bLBnb3qCg2/T6BZKr3Cj0v4dwZpo/J8R0A==
+  dependencies:
+    zxcvbn "^4.4.2"
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"


### PR DESCRIPTION
WHY:
As a user who is signing up, I want to understand why certain MFA methods are recommended, so that I can make an informed decision about which one to choose

https://cm-jira.usa.gov/browse/LG-2499

AC: There is an FAQ answer on why WebAuthn is recommended
AC: There is an FAQ answer on why TOTP is recommended
AC: There is an FAQ answer on why backup codes are not recommended

Preview available here:
https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/identity-site/LG-2499_Add_FAQ_on_recommended_MFA_methods/

![image](https://user-images.githubusercontent.com/18326436/74245603-4348fa80-4cb1-11ea-8e7d-1616bf3c8016.png)
