### PR TITLE
LG-2609 Add sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '~> 2.5.5'
 gem 'jekyll'
 gem 'jekyll-redirect-from'
 gem 'jekyll-multiple-languages-plugin'
+gem 'jekyll-sitemap'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -87,6 +89,7 @@ DEPENDENCIES
   jekyll
   jekyll-multiple-languages-plugin
   jekyll-redirect-from
+  jekyll-sitemap
   nokogiri (~> 1.10)
   pry
   rb-readline

--- a/_config.yml
+++ b/_config.yml
@@ -69,6 +69,7 @@ keep_files:
 plugins:
   - jekyll-redirect-from
   - jekyll-multiple-languages-plugin
+  - jekyll-sitemap
 
 help_pages:
 - creating-an-account
@@ -100,3 +101,5 @@ playbook:
      img: graphic-hex
      text: Create responsive security systems
 baseurl:
+
+url: www.login.gov

--- a/_config.yml
+++ b/_config.yml
@@ -102,4 +102,4 @@ playbook:
      text: Create responsive security systems
 baseurl:
 
-url: www.login.gov
+url: https://www.login.gov

--- a/spec/sitemap.xml_spec.rb
+++ b/spec/sitemap.xml_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe 'sitemap.xml' do
+  let(:doc) { Nokogiri::XML(file_at('/sitemap.xml')) }
+
+  it 'is valid XML' do
+    expect(doc).to be
+  end
+
+  it 'it points to valid pages' do
+    doc.remove_namespaces!
+
+    expect(doc.xpath('//urlset/url/loc')).to_not be_empty
+
+    doc.xpath('//urlset/url/loc').each do |loc|
+      path = URI("https://#{loc.text}").path
+      expect(file_at(path)).to be
+    end
+  end
+end

--- a/spec/sitemap.xml_spec.rb
+++ b/spec/sitemap.xml_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'sitemap.xml' do
     expect(doc.xpath('//urlset/url/loc')).to_not be_empty
 
     doc.xpath('//urlset/url/loc').each do |loc|
-      path = URI("https://#{loc.text}").path
+      path = URI(loc.text).path
       expect(file_at(path)).to be
     end
   end


### PR DESCRIPTION
**Why:** we need a sitemap for search.gov

The jekyll-sitemap gem should generate a sitemap that will live at login.gov/sitemap.xml and also be indicated at login.gov/robots.txt

