### PR TITLE
LG-2607 - Add new styles to FAQ

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -512,37 +512,42 @@ help_pages:
       Two-factor authentication can be done in multiple ways and each has a different level of security. You can choose between text messages, phone calls, an authentication application, a security key, or backup codes. Government employees can also use their PIV or CAC cards.
 
       We encourage you to review the available options and select the most secure option for you.
+      
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">More Secure</div>
+        <h3>Security Key</h3>
+        <p class="bold mt1">More secure against phishing and hacks with built in protections against theft.</p>
+        <p>A security key is typically a physical device, like a USB, that you plug into your computer. The key is linked to your accounts and will only grant access to those accounts once the key is plugged in and activated. Since a security key does not rely on your cell phone, it has the highest level of protection against phishing and built in protections against hacking if it is lost or stolen.</p>
+      </div>
 
-      <div class="usa-tag float-right bg-info-dark">MORE SECURE</div>
-      ### Security Key
-      More secure against phishing and hacks with built in protections against theft.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">More Secure</div>
+        <h3>PIV/CAC for military and federal employees</h3>
+        <p class="bold mt1">More secure against phishing and hacks with built in protections against theft.</p>
+        <p>Physical PIV and CAC smart cards are secure options for military personnel and federal employees. These cards, with encrypted chip technology, are resistant to phishing and difficult to hack if stolen.</p>
+      </div>
 
-      A security key is typically a physical device, like a USB, that you plug into your computer. The key is linked to your accounts and will only grant access to those accounts once the key is plugged in and activated. Since a security key does not rely on your cell phone, it has the highest level of protection against phishing and built in protections against hacking if it is lost or stolen.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">More Secure</div>
+        <h3>Authentication App</h3>
+        <p class="bold mt1">More secure against phishing and hacks but with less protection against theft.</p>
+        <p>Authentication apps are downloaded to your device and generate secure, 6-digit codes you can use to log in to your accounts. Unlike phone calls or text messaging/SMS, a hacker would need physical access to your cell phone in order to use the code.</p>
+        <p>While authentication apps are not protected if your device is lost or stolen, these apps offer more security than phone calls or text messaging/SMS against phishing, hacking or interception.</p>
+      </div>
 
-      <div class="usa-tag float-right bg-info-dark">MORE SECURE</div>
-      ### PIV/CAC for military and federal employees
-      More secure against phishing and hacks with built in protections against theft.
+      <div class="mt3">
+        <h3>Text message/SMS or Phone call</h3>
+        <p class="bold mt1">Less secure against phishing, hacks and theft.</p>
+        <p>Text message/SMS or phone calls are convenient but are extremely vulnerable to theft, hackers and other attacks.</p>
+      </div>
 
-      Physical PIV and CAC smart cards are secure options for military personnel and federal employees. These cards, with encrypted chip technology, are resistant to phishing and difficult to hack if stolen.
+      <div class="my3">
+        <div class="usa-tag caps float-right bg-info-dark">Less Secure</div>
+        <h3>Backup codes</h3>
+        <p class="bold mt1">Less secure against phishing, hacks and more subjective to theft.</p>
+        <p>While backup codes are an accessible option for users who do not have phone access, these codes are the least secure option for two-factor authentication. Backup codes must be printed or written down which makes them more vulnerable to theft and phishing.</p>
+      </div>
 
-      <div class="usa-tag float-right bg-info-dark">MORE SECURE</div>
-      ### Authentication App
-      More secure against phishing and hacks but with less protection against theft.
-
-      Authentication apps are downloaded to your device and generate secure, 6-digit codes you can use to log in to your accounts. Unlike phone calls or text messaging/SMS, a hacker would need physical access to your cell phone in order to use the code.
-
-      While authentication apps are not protected if your device is lost or stolen, these apps offer more security than phone calls or text messaging/SMS against phishing, hacking or interception.
-
-      ### Text message/SMS or Phone call
-      Less secure against phishing, hacks and theft.
-
-      Text message/SMS or phone calls are convenient but are extremely vulnerable to theft, hackers and other attacks.
-
-      <div class="usa-tag float-right bg-info-dark">LESS SECURE</div>
-      ### Backup codes
-      Less secure against phishing, hacks and more subjective to theft.
-
-      While backup codes are an accessible option for users who do not have phone access, these codes are the least secure option for two-factor authentication. Backup codes must be printed or written down which makes them more vulnerable to theft and phishing.
   verifying-your-identity:
     why-do-i-need-to-verify-my-identity: |-
       Some government applications that use login.gov require users to verify their identities. This means that you must prove that you are who you say you are. By doing this, we make sure that only the right people get access to sensitive information.

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -471,36 +471,41 @@ help_pages:
 
       Le recomendamos que revise las opciones disponibles y seleccione la opción más segura para usted.
 
-      <span class="usa-tag float-right bg-info-dark">MÁS SEGURIDAD</span>
-      ### Clave de seguridad
-      Más seguro contra phishing y piratas informáticos con protecciones integradas contra robo.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">MÁS SEGURIDAD</div>
+        <h3>Clave de seguridad</h3>
+        <p class="bold mt1">Más seguro contra phishing y piratas informáticos con protecciones integradas contra robo.</p>
+        <p>Una clave de seguridad suele ser un dispositivo físico, como un USB, que se conecta a la computadora. La clave está vinculada a sus cuentas y solo otorgará acceso a esas cuentas una vez que la clave esté enchufada y activada. Dado que una clave de seguridad no depende de su teléfono celular, tiene el más alto nivel de protección contra phishing y protecciones integradas contra piratería si se pierde o es robada.</p>
+      </div>
 
-      Una clave de seguridad suele ser un dispositivo físico, como un USB, que se conecta a la computadora. La clave está vinculada a sus cuentas y solo otorgará acceso a esas cuentas una vez que la clave esté enchufada y activada. Dado que una clave de seguridad no depende de su teléfono celular, tiene el más alto nivel de protección contra phishing y protecciones integradas contra piratería si se pierde o es robada.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">MÁS SEGURIDAD</div>
+        <h3>PIV/CAC para empleados militares y federales</h3>
+        <p class="bold mt1">Más seguro contra phishing y piratas informáticos con protecciones integradas contra robo.</p>
+        <p>Las tarjetas inteligentes físicas PIV y CAC son opciones seguras para el personal militar y los empleados federales. Estas tarjetas, con tecnología de chip encriptado, son resistentes al phishing y difíciles de hackear si son robadas.</p>
+      </div>
 
-      <span class="usa-tag float-right bg-info-dark">MÁS SEGURIDAD</span>
-      ### PIV/CAC para empleados militares y federales
-      Más seguro contra phishing y piratas informáticos con protecciones integradas contra robo.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">MÁS SEGURIDAD</div>
+        <h3>Aplicación de autenticación</h3>
+        <p class="bold mt1">Más seguro contra phishing y piratas informáticos, pero con menos protección contra el robo.</p>
+        <p>Las aplicaciones de autenticación se descargan en su dispositivo y generan códigos seguros de 6 dígitos que puede usar para iniciar sesión en sus cuentas. A diferencia de las llamadas telefónicas o los mensajes de texto / SMS, un hacker necesitaría acceso físico a su teléfono celular para usar el código.</p>
+        <p>Si bien las aplicaciones de autenticación no están protegidas si su dispositivo se pierde o es robado, estas aplicaciones ofrecen más seguridad que las llamadas telefónicas o los mensajes de texto / SMS contra el phishing, la piratería o la intercepción.</p>
+      </div>
 
-      Las tarjetas inteligentes físicas PIV y CAC son opciones seguras para el personal militar y los empleados federales. Estas tarjetas, con tecnología de chip encriptado, son resistentes al phishing y difíciles de hackear si son robadas.
+      <div class="mt3">
+        <h3>Mensaje de texto / SMS o llamada telefónica</h3>
+        <p class="bold mt1">Menos seguro contra phishing, hacks y robos.</p>
+        <p>Los mensajes de texto / SMS o las llamadas telefónicas son convenientes, pero son extremadamente vulnerables a robos, piratas informáticos y otros ataques.</p>
+      </div>
 
-      <span class="usa-tag float-right bg-info-dark">MÁS SEGURIDAD</span>
-      ### Aplicación de autenticación
-      Más seguro contra phishing y piratas informáticos, pero con menos protección contra el robo.
+      <div class="my3">
+        <div class="usa-tag caps float-right bg-info-dark">MENOS SEGURIDAD</div>
+        <h3>Códigos de respaldo</h3>
+        <p class="bold mt1">Menos seguro contra phishing, piratas informáticos y más subjetivo al robo.</p>
+        <p>Si bien los códigos de respaldo son una opción accesible para los usuarios que no tienen acceso telefónico, estos códigos son la opción menos segura para la autenticación de dos factores. Los códigos de respaldo deben imprimirse o escribirse, lo que los hace más vulnerables al robo y al phishing.</p>
+      </div>
 
-      Las aplicaciones de autenticación se descargan en su dispositivo y generan códigos seguros de 6 dígitos que puede usar para iniciar sesión en sus cuentas. A diferencia de las llamadas telefónicas o los mensajes de texto / SMS, un hacker necesitaría acceso físico a su teléfono celular para usar el código.
-
-      Si bien las aplicaciones de autenticación no están protegidas si su dispositivo se pierde o es robado, estas aplicaciones ofrecen más seguridad que las llamadas telefónicas o los mensajes de texto / SMS contra el phishing, la piratería o la intercepción.
-
-      ### Mensaje de texto / SMS o llamada telefónica
-      Menos seguro contra phishing, hacks y robos.
-
-      Los mensajes de texto / SMS o las llamadas telefónicas son convenientes, pero son extremadamente vulnerables a robos, piratas informáticos y otros ataques.
-
-      <span class="usa-tag float-right bg-info-dark">MENOS SEGURIDAD</span>
-      ### Códigos de respaldo
-      Menos seguro contra phishing, piratas informáticos y más subjetivo al robo.
-
-      Si bien los códigos de respaldo son una opción accesible para los usuarios que no tienen acceso telefónico, estos códigos son la opción menos segura para la autenticación de dos factores. Los códigos de respaldo deben imprimirse o escribirse, lo que los hace más vulnerables al robo y al phishing.
   verifying-your-identity:
     phone-plan-is-not-in-my-name-or-address: |-
       Si no podemos verificar automáticamente su dirección, debe verificarla por correo. Esto significa que le enviaremos una carta con un código de confirmación que debe usar para terminar de configurar su cuenta.

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -498,36 +498,40 @@ help_pages:
 
       Nous vous encourageons à examiner les options disponibles et à sélectionner l'option la plus sécurisée pour vous.
 
-      <span class="usa-tag float-right bg-info-dark">PLUS SÉCURISÉ</span>
-      ### Clef de sécurité
-      Plus sûr contre le phishing et les hacks avec des protections intégrées contre le vol.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">PLUS SÉCURISÉ</div>
+        <h3>Clef de sécurité</h3>
+        <p class="bold mt1">Plus sûr contre le phishing et les hacks avec des protections intégrées contre le vol.</p>
+        <p>Une clé de sécurité est généralement un périphérique physique, comme une clé USB, que vous branchez à votre ordinateur. La clé est liée à vos comptes et n'accordera l'accès à ces comptes qu'une fois la clé connectée et activée. Puisqu'une clé de sécurité ne dépend pas de votre téléphone portable, elle possède le plus haut niveau de protection contre le phishing et des protections intégrées contre le piratage en cas de perte ou de vol.</p>
+      </div>
 
-      Une clé de sécurité est généralement un périphérique physique, comme une clé USB, que vous branchez à votre ordinateur. La clé est liée à vos comptes et n'accordera l'accès à ces comptes qu'une fois la clé connectée et activée. Puisqu'une clé de sécurité ne dépend pas de votre téléphone portable, elle possède le plus haut niveau de protection contre le phishing et des protections intégrées contre le piratage en cas de perte ou de vol.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">PLUS SÉCURISÉ</div>
+        <h3>PIV/CAC pour les employés militaires et fédéraux</h3>
+        <p class="bold mt1">Plus sûr contre le phishing et les hacks avec des protections intégrées contre le vol.</p>
+        <p>Les cartes à puce physiques PIV et CAC sont des options sécurisées pour le personnel militaire et les employés fédéraux. Ces cartes, dotées d'une technologie de puce cryptée, résistent au phishing et sont difficiles à pirater en cas de vol.</p>
+      </div>
 
-      <span class="usa-tag float-right bg-info-dark">PLUS SÉCURISÉ</span>
-      ### PIV/CAC pour les employés militaires et fédéraux
-      Plus sûr contre le phishing et les hacks avec des protections intégrées contre le vol.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">PLUS SÉCURISÉ</div>
+        <h3>Application d'authentification</h3>
+        <p class="bold mt1">Plus sûr contre le phishing et les hacks mais avec moins de protection contre le vol.</p>
+        <p>Les applications d'authentification sont téléchargées sur votre appareil et génèrent des codes sécurisés à 6 chiffres que vous pouvez utiliser pour vous connecter à vos comptes. Contrairement aux appels téléphoniques ou à la messagerie texte / SMS, un pirate aurait besoin d'un accès physique à votre téléphone portable pour utiliser le code.</p>
+        <p>Bien que les applications d'authentification ne soient pas protégées en cas de perte ou de vol de votre appareil, ces applications offrent plus de sécurité que les appels téléphoniques ou la messagerie texte / SMS contre le phishing, le piratage ou l'interception.</p>
+      </div>
 
-      Les cartes à puce physiques PIV et CAC sont des options sécurisées pour le personnel militaire et les employés fédéraux. Ces cartes, dotées d'une technologie de puce cryptée, résistent au phishing et sont difficiles à pirater en cas de vol.
+      <div class="mt3">
+        <h3> Message texte/SMS ou appel téléphonique</h3>
+        <p class="bold mt1">Moins sécurisé contre le phishing, les hacks et le vol.</p>
+        <p>Les SMS / SMS ou les appels téléphoniques sont pratiques mais sont extrêmement vulnérables au vol, aux pirates et autres attaques.</p>
+      </div>
 
-      <span class="usa-tag float-right bg-info-dark">PLUS SÉCURISÉ</span>
-      ### Application d'authentification
-      Plus sûr contre le phishing et les hacks mais avec moins de protection contre le vol.
+      <div class="mt3">
+        <div class="usa-tag caps float-right bg-info-dark">MOINS SÉCURISÉ</div>
+        <h3> Codes de sauvegarde</h3>
+        <p class="bold mt1">Moins sécurisé contre le phishing, les hacks et plus subjectif au vol.</p>
+        <p>Bien que les codes de sauvegarde soient une option accessible pour les utilisateurs qui n'ont pas accès au téléphone, ces codes sont l'option la moins sécurisée pour l'authentification à deux facteurs. Les codes de sauvegarde doivent être imprimés ou écrits, ce qui les rend plus vulnérables au vol et au phishing.</p>
 
-      Les applications d'authentification sont téléchargées sur votre appareil et génèrent des codes sécurisés à 6 chiffres que vous pouvez utiliser pour vous connecter à vos comptes. Contrairement aux appels téléphoniques ou à la messagerie texte / SMS, un pirate aurait besoin d'un accès physique à votre téléphone portable pour utiliser le code.
-
-      Bien que les applications d'authentification ne soient pas protégées en cas de perte ou de vol de votre appareil, ces applications offrent plus de sécurité que les appels téléphoniques ou la messagerie texte / SMS contre le phishing, le piratage ou l'interception.
-
-      ### Message texte/SMS ou appel téléphonique
-      Moins sécurisé contre le phishing, les hacks et le vol.
-
-      Les SMS / SMS ou les appels téléphoniques sont pratiques mais sont extrêmement vulnérables au vol, aux pirates et autres attaques.
-
-      <span class="usa-tag float-right bg-info-dark">MOINS SÉCURISÉ</span>
-      ### Codes de sauvegarde
-      Moins sécurisé contre le phishing, les hacks et plus subjectif au vol.
-
-      Bien que les codes de sauvegarde soient une option accessible pour les utilisateurs qui n'ont pas accès au téléphone, ces codes sont l'option la moins sécurisée pour l'authentification à deux facteurs. Les codes de sauvegarde doivent être imprimés ou écrits, ce qui les rend plus vulnérables au vol et au phishing.
   verifying-your-identity:
     phone-plan-is-not-in-my-name-or-address: |-
       Si nous ne pouvons pas vérifier automatiquement votre adresse, vous devez la vérifier par courrier. Cela signifie que nous vous enverrons une lettre avec un code de confirmation que vous devez utiliser pour terminer la configuration de votre compte.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4243,3 +4243,8 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=


### PR DESCRIPTION
**Why:** As a user, I want the authentication methods FAQ on login.gov to be easy to read and accessible, so that I can understand the information given. 

[Preview for this PR](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-2607-add-styles-faq-auth/help/authentication-methods/which-authentication-method-should-i-use/) vs. [the current page being updated](https://www.login.gov/help/authentication-methods/which-authentication-method-should-i-use/)

**AC**

1. A subheading style is created
2. Spacing / margins are added to give sections a breathing room between
3. The page functionally makes sense with keyboard accessibility / screen reader when tabbing through headings / element
4. `en.yml`, `es.yml`, and `fr.yml` have new styles across

**How:**

1. Subheading style is created, using `bold`
2. Spacing between section is created via margin properties
3. The FAQ's Auth Methods content itself is generally accessible, but there are accessibility concerns that is outside the scope of this task. A new story should be consider
   - ID attributes for SVGs on the page are not unique, which could create issues for assistive technologies
   - List items `<li>` for secondary `nav` (blue section, e.g. "Creating an account", "USAJOBs", etc) are not contained within parent elements, i.e. `<ul>` or `<ol>`
4. `en.yml`, `es.yml`, and `fr.yml` are updated