### PR TITLE
Remove the temporary alert banner re: TTP on contact form

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -94,8 +94,8 @@ contact_page:
       unwanted_otp: I am receiving security codes from login.gov that I didn't request
       verify_identity_error: I got a failure trying to verify my identity
       wrong_account_update: Wrong account update
-    alert_banner: New York Residents are no longer eligible to apply for or renew membership in U.S. Customs and Border Protection (CBP) Trusted Traveler Programs. Your refund will be processed automatically. For additional information, please visit
-    alert_banner_link: the CBP media release
+    alert_banner: 
+    alert_banner_link:
     title: Contact the login.gov team
     topics:
       account_linking: Linking your login.gov account to your profile

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -81,8 +81,8 @@ contact_page:
       site_navigation: Navegación en la página web
       unwanted_otp: Múltiples pedidos de pago
       wrong_account_update: Actualización de la cuenta errónea
-    alert_banner: Los residentes de Nueva York ya no son elegibles para solicitar o renovar la membresía en los Programas de Viajero Confiable de Aduanas y Protección Fronteriza (CBP) de EE. UU. Su reembolso será procesado automáticamente. Para obtener información adicional, visite
-    alert_banner_link: el comunicado de prensa de CBP
+    alert_banner:
+    alert_banner_link:
     title: Póngase en contacto con el equipo de login.gov
     topics:
       account_linking: Vinculación de cuenta

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -82,8 +82,8 @@ contact_page:
       site_navigation: Navigation du site
       unwanted_otp: Multiples OTP
       wrong_account_update: Mise à jour de compte erronée
-    alert_banner: Les résidents de New York ne sont plus éligibles pour demander ou renouveler leur adhésion aux programmes de voyageurs de confiance des États-Unis pour les douanes et la protection des frontières (CBP). Votre remboursement sera traité automatiquement. Pour plus d'informations, veuillez visiter 
-    alert_banner_link: consulter le communiqué de presse du CBP
+    alert_banner:
+    alert_banner_link:
     title: Contactez l'équipe login.gov
     topics:
       account_linking: Lien vers le compte

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -168,17 +168,6 @@
     document.addEventListener('DOMContentLoaded', doNotAnswer);
 </script>
 
-<!--Alert Banner - Remove comment out to add or add comment out to remove
-<div class="usa-alert usa-alert--info margin-bottom-4">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      {% t contact_page.support_request_form.alert_banner %}
-        <a href="#" target="_blank">
-          {% t contact_page.support_request_form.alert_banner_link %}</a>.</p>
-  </div>
-</div>
--->
-
 <h2>{% t contact_page.support_request_form.title %}</h2>
 <p>{% t contact_page.support_request_form.instructions %}</p>
 

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -168,15 +168,16 @@
     document.addEventListener('DOMContentLoaded', doNotAnswer);
 </script>
 
-<!--Banner for TTP - Remove when ready-->
+<!--Alert Banner - Remove comment out to add or add comment out to remove
 <div class="usa-alert usa-alert--info margin-bottom-4">
   <div class="usa-alert__body">
     <p class="usa-alert__text">
       {% t contact_page.support_request_form.alert_banner %}
-        <a href="https://www.cbp.gov/newsroom/national-media-release/new-york-residents-no-longer-eligible-apply-or-renew-trusted" target="_blank">
+        <a href="#" target="_blank">
           {% t contact_page.support_request_form.alert_banner_link %}</a>.</p>
   </div>
 </div>
+-->
 
 <h2>{% t contact_page.support_request_form.title %}</h2>
 <p>{% t contact_page.support_request_form.instructions %}</p>


### PR DESCRIPTION
**Why:** The impact of TTP on Contact Center has decreased, so we are good to remove the temporary alert banner via #357 

View [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/Remove-alert-banner-for-TTP/contact/)

**How:**

1. Comment out alert banner component via `<!-- -->`, keeping this component intact when we need it again in the future while removing its visibility
2. Remove reference to TTP in `en.yml`, `es.yml` and `fr.yml`