### PR TITLE
Remove 'Create an account' secondary link

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1157,7 +1157,6 @@ meta:
     description: U.S. government agencies can take advantage of login.gov’s authentication and identity proofing platform. Find out more about login.gov’s offerings and opportunities.
     title: Why login.gov
 nav:
-  create_account: Create an account
   help: Help
   home: Home
   implementation: Implementation

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1141,7 +1141,6 @@ meta:
       personal.
     title: Seguridad
 nav:
-  create_account: Crea una cuenta
   developers: Desarrolladores
   help: Ayuda
   home: Inicio

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1187,7 +1187,6 @@ meta:
       personnels.
     title: Sécurité
 nav:
-  create_account: Créer un compte
   developers: Développeurs
   help: Aide
   home: Accueil

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -94,10 +94,7 @@
     <div class="usa-nav__secondary">
       <div class="usa-nav__secondary-container">
         <ul class="usa-nav__secondary-links">
-          <li class="usa-nav__secondary-item">
-            <a href="{% if site.lang != 'en' %}https://secure.login.gov/{{site.lang}}/sign_up/enter_email{% else %}https://secure.login.gov/sign_up/enter_email{% endif %}">{% t nav.create_account %}</a>
-          </li>
-          <li class="usa-nav__secondary-item">
+          <li class="usa-nav__secondary-item b">
             <a href="{% if site.lang != 'en' %}https://secure.login.gov/{{site.lang}}/{% else %}https://secure.login.gov/{% endif %}">{% t nav.sign_in %}</a>
           </li>
         </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -94,7 +94,7 @@
     <div class="usa-nav__secondary">
       <div class="usa-nav__secondary-container">
         <ul class="usa-nav__secondary-links">
-          <li class="usa-nav__secondary-item b">
+          <li class="usa-nav__secondary-item bold">
             <a href="{% if site.lang != 'en' %}https://secure.login.gov/{{site.lang}}/{% else %}https://secure.login.gov/{% endif %}">{% t nav.sign_in %}</a>
           </li>
         </ul>


### PR DESCRIPTION
**Why:** In the near future, we want only one Call-to-Action (CTA) link in the header instead of two (Create an account | Sign in) — Per conversations w/ @amoose, @karlaturcios and design huddle

**Note:** This is a temporary fix until we develop a more through design for 'Sign in' CTA

[Preview via Federalist](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-remove-create-an-account-link/)

**How:**

- Remove 'Create an account' code snippet
- Bold 'Sign in' so it doesn't get lost in the header/nav