### PR TITLE
Adds covid-19 informational banner

### DIFF
--- a/_includes/covid_banner.html
+++ b/_includes/covid_banner.html
@@ -1,7 +1,7 @@
 <!--- begin covid banner --->
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">
-    <p class="usa-alert__text">Login.gov is dedicated to supporting efforts to provide relief in response to COVID-19. We have updated our <a href="https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e">partner inquiry form</a> with an option to designate inquiries as related to the COVID-19 response. Our team is standing by.</p>
+    <p class="usa-alert__text">Login.gov is dedicated to supporting efforts to provide relief in response to COVID-19. We have updated our <a href="https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e" target="_blank">partner inquiry form</a> with an option to designate inquiries as related to the COVID-19 response. Our team is standing by.</p>
   </div>
 </div>
 <br class="clearfix" />

--- a/_includes/covid_banner.html
+++ b/_includes/covid_banner.html
@@ -1,0 +1,8 @@
+<!--- begin covid banner --->
+<div class="usa-alert usa-alert--info">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Login.gov is dedicated to supporting efforts to provide relief in response to COVID-19. We have updated our <a href="https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e">partner inquiry form</a> with an option to designate inquiries as related to the COVID-19 response. Our team is standing by.</p>
+  </div>
+</div>
+<br class="clearfix" />
+<!--- end covid banner --->

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -16,6 +16,7 @@ image: /assets/img/login-gov-600x314.png
 
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt3 pb2">
+    {% include covid_banner.html %}
     <div class="clearfix mxn2">
       <div class="col sm-col-4 px2 sm-mb3 mb2">
         <img alt="" src="{{ site.baseurl }}/assets/img/users.svg" height="90">

--- a/_pages/partners/index.md
+++ b/_pages/partners/index.md
@@ -22,6 +22,7 @@ description: meta.partners.description
 
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt4 pb2">
+    {% include covid_banner.html %}
     <div class="clearfix mxn3">
       <div class="sm-col sm-col-4 px3">
         <h2 class="mt0 mb2 pb2 gray border-bottom border-light-blue" markdown="1">

--- a/_pages/partners/learn.md
+++ b/_pages/partners/learn.md
@@ -15,6 +15,12 @@ description: Learn about login.gov
 </div>
 
 <div class="bg-white">
+<!--- begin covid banner holder --->
+  <div class="container cntnr-wide px2 pt4 pb2">
+    {% include covid_banner.html %}
+</div>
+<!--- end covid banner holder --->
+
   <div class="container cntnr-wide px2 pt4 pb2" markdown="1">
 
 

--- a/_pages/partners/our-agency-partners.md
+++ b/_pages/partners/our-agency-partners.md
@@ -14,6 +14,7 @@ class: relative
 </div>
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt4 pb5">
+    {% include covid_banner.html %}
     <div class="clearfix">
       <nav id="pb-nav--side-cntnr" class="sm-col-right sm-col-4 sm-show">
         <ul id="pb-nav--side" class="list-reset nav">

--- a/_pages/partners/why-login-gov.md
+++ b/_pages/partners/why-login-gov.md
@@ -14,6 +14,7 @@ class: relative
 </div>
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt4 pb5">
+    {% include covid_banner.html %}
     <div class="clearfix">
           <nav id="pb-nav--side-cntnr" class="sm-col-right sm-col-4 sm-show">
         <ul id="pb-nav--side" class="list-reset nav">


### PR DESCRIPTION
Adds the following banner to the homepage and all /partners pages. 

<img width="1031" alt="Screen Shot 2020-04-01 at 5 50 47 PM" src="https://user-images.githubusercontent.com/1328699/78199833-9b92b200-7441-11ea-8a9d-021ee18c5971.png">
 