### PR TITLE
remove covid banner from remaining  pages

### DIFF
--- a/_pages/partners/index.md
+++ b/_pages/partners/index.md
@@ -22,7 +22,6 @@ description: meta.partners.description
 
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt4 pb2">
-    {% include covid_banner.html %}
     <div class="clearfix mxn3">
       <div class="sm-col sm-col-4 px3">
         <h2 class="mt0 mb2 pb2 gray border-bottom border-light-blue" markdown="1">

--- a/_pages/partners/our-agency-partners.md
+++ b/_pages/partners/our-agency-partners.md
@@ -14,7 +14,6 @@ class: relative
 </div>
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt4 pb5">
-    {% include covid_banner.html %}
     <div class="clearfix">
       <nav id="pb-nav--side-cntnr" class="sm-col-right sm-col-4 sm-show">
         <ul id="pb-nav--side" class="list-reset nav">

--- a/_pages/partners/why-login-gov.md
+++ b/_pages/partners/why-login-gov.md
@@ -14,7 +14,6 @@ class: relative
 </div>
 <div class="bg-white">
   <div class="container cntnr-wide px2 pt4 pb5">
-    {% include covid_banner.html %}
     <div class="clearfix">
           <nav id="pb-nav--side-cntnr" class="sm-col-right sm-col-4 sm-show">
         <ul id="pb-nav--side" class="list-reset nav">


### PR DESCRIPTION
WHY
removing banner from other covid pages