### PR TITLE
Remove GPO banner and i18n content

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -103,10 +103,8 @@ contact_page:
       unwanted_otp: I am receiving security codes from login.gov that I didn't request
       verify_identity_error: I got a failure trying to verify my identity
       wrong_account_update: Wrong account update
-    alert_banner: We are unable to send Government Printing Office verification 
-      letters to those Railroad Retirement Board (RRB) users who are attempting to 
-      verify their identities online. Please contact
-    alert_banner_link: RRB for assistance
+    alert_banner: 
+    alert_banner_link:
     title: Contact the login.gov team
     topics:
       account_linking: Linking your login.gov account to your profile

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -90,10 +90,8 @@ contact_page:
       site_navigation: Navegación en la página web
       unwanted_otp: Múltiples pedidos de pago
       wrong_account_update: Actualización de la cuenta errónea
-    alert_banner: No podemos enviar cartas de verificación de la Imprenta del Gobierno a 
-      los usuarios de la Junta de Railroad Retirement Board (RRB) que intentan verificar sus 
-      identidades en línea. Póngase en contacto con
-    alert_banner_link: RRB para obtener ayuda
+    alert_banner: 
+    alert_banner_link:
     title: Póngase en contacto con el equipo de login.gov
     topics:
       account_linking: Vinculación de cuenta

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -91,10 +91,8 @@ contact_page:
       site_navigation: Navigation du site
       unwanted_otp: Multiples OTP
       wrong_account_update: Mise à jour de compte erronée
-    alert_banner: Nous ne pouvons pas envoyer de lettres de vérification de l’imprimerie 
-      du gouvernement aux utilisateurs de la Railroad Retirement Board (RRB) qui tentent 
-      de vérifier leur identité en ligne. Veuillez contacter
-    alert_banner_link: RRB pour obtenir de l'aide
+    alert_banner:
+    alert_banner_link:
     title: Contactez l'équipe login.gov
     topics:
       account_linking: Lien vers le compte

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -168,16 +168,6 @@
     document.addEventListener('DOMContentLoaded', doNotAnswer);
 </script>
 
-<!-- Alert for RRB - Removed when ready -->
-<div class="usa-alert usa-alert--info margin-bottom-4">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      {% t contact_page.support_request_form.alert_banner %}
-        <a href="https://rrb.gov/Benefits/myRRB/AccountSupport" target="_blank">
-          {% t contact_page.support_request_form.alert_banner_link %}</a>.</p>
-  </div>
-</div>
-
 <h2>{% t contact_page.support_request_form.title %}</h2>
 <p>{% t contact_page.support_request_form.instructions %}</p>
 


### PR DESCRIPTION
**Why:** Login.gov is able to send out the letters now and per RRB request, we're taking the banner down (Related note: banner addition was prompted by #363).

[Preview via Federalist re: contact page](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-remove-gpo-banner/contact/)

**How:**

- Remove banner code snippet
- Remove i18n content related to RRB