### PR TITLE
Removed fixed wdith from login.gov launch widget

### DIFF
--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -11,7 +11,6 @@
 
 .sign-in-logo {
   background-color: transparent;
-  width: 103px;
   height: 27px;
   padding: 7px 6px 6px;
   margin-left: 0.2rem;


### PR DESCRIPTION
**Why**: To base the width off the link's text instead
**How**: CSS

This is related to https://cm-jira.usa.gov/browse/LG-2963