### PR TITLE
Add messaging terms and conditions

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1370,14 +1370,14 @@ policies:
   content: |-
     Login.gov uses SMS text messaging to help verify your identity when you create
     a new account.  SMS text messages, or automated voice calls, may also be used if
-    you choose your telephone number as on of your authentication methods.
+    you choose your telephone number as one of your authentication methods.
 
     ### SMS Terms and Conditions
     - Login.gov provides an authentication service and will not use text or
       voice messaging for any other purpose.
-    - Messaging and data rates may apply. 
+    - Your carriers messaging and data rates may apply.
     - Messages will only be sent as part of setting up and signing into your
-      Login.gov account.
+      login.gov account.
     -	You may contact customer care by email at <hello@login.gov> on the web at <https://login.gov/contact>
     -	To opt out of receiving text messages from login.gov reply with the message _STOP_
       to the unwanted text message.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1378,7 +1378,7 @@ policies:
     - Your carriers messaging and data rates may apply.
     - Messages will only be sent as part of setting up and signing into your
       login.gov account.
-    -	You may contact customer care by email at <hello@login.gov> on the web at <https://login.gov/contact>
+    -	You may [contact customer care here](site.baseurl/contact) or by email at <hello@login.gov>.
     -	To opt out of receiving text messages from login.gov reply with the message _STOP_
       to the unwanted text message.
     -	See [Our Privacy Practices](#our-privacy-practices) for privacy policy information.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1368,16 +1368,16 @@ policies:
 - section: Messaging terms and conditions
   anchor: our-messaging-practices
   content: |-
-    login.gov uses SMS text messaging to help verify your identity when you create
-    a new account.  SMS text messages or automated voice calls may also used if you
-    choose your phone as one of your authentication methods.
+    Login.gov uses SMS text messaging to help verify your identity when you create
+    a new account.  SMS text messages, or automated voice calls, may also be used if
+    you choose your telephone number as on of your authentication methods.
 
     ### SMS Terms and Conditions
-    - login.gov provides an authentication service and will not use text or
+    - Login.gov provides an authentication service and will not use text or
       voice messaging for any other purpose.
     - Messaging and data rates may apply. 
     - Messages will only be sent as part of setting up and signing into your
-      login.gov account.
+      Login.gov account.
     -	You may contact customer care by email at <hello@login.gov> on the web at <https://login.gov/contact>
     -	To opt out of receiving text messages from login.gov reply with the message _STOP_
       to the unwanted text message.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1378,8 +1378,7 @@ policies:
     - Messaging and data rates may apply. 
     - Messages will only be sent as part of setting up and signing into your
       login.gov account.
-    -	You may contact customer care by email at <hello@login.gov> or by voice
-      at +1 (844) 875-6446.
+    -	You may contact customer care by email at <hello@login.gov> on the web at <https://login.gov/contact>
     -	To opt out of receiving text messages from login.gov reply with the message _STOP_
       to the unwanted text message.
     -	See [Our Privacy Practices](#our-privacy-practices) for privacy policy information.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1365,6 +1365,25 @@ policies:
     We are happy to answer questions about our security and privacy practices.
     For more information, please visit [Help](site.baseurl/help)
     or [contact us](site.baseurl/contact).
+- section: Messaging terms and conditions
+  anchor: our-messaging-practices
+  content: |-
+    login.gov uses SMS text messaging to help verify your identity when you create
+    a new account.  SMS text messages or automated voice calls may also used if you
+    choose your phone as one of your authentication methods.
+
+    ### SMS Terms and Conditions
+    - login.gov provides an authentication service and will not use text or
+      voice messaging for any other purpose.
+    - Messaging and data rates may apply. 
+    - Messages will only be sent as part of setting up and signing into your
+      login.gov account.
+    -	You may contact customer care by email at <hello@login.gov> or by voice
+      at +1 (844) 875-6446.
+    -	To opt out of receiving text messages from login.gov reply with the message _STOP_
+      to the unwanted text message.
+    -	See [Our Privacy Practices](#our-privacy-practices) for privacy policy information.
+    -	Carriers are not liable for delayed or undelivered messages.
 policy_page:
   content:
     p_1: |-


### PR DESCRIPTION
I added a section to the existing policies page, but this can be moved and changed any way you see fit.   The only requirements are that we address the following items:

-	Service name and description
-	“Message and data rates may apply”
-	Message frequency
-	Customer care information
-	Opt-out instructions
-	Link to Privacy Policy
-	“Carriers are not liable for delayed or undelivered messages”
