### PR TITLE
Build CSS and JS as prerequisite for Jekyll

### DIFF
--- a/Makefile.server
+++ b/Makefile.server
@@ -1,6 +1,12 @@
 run: jekyll npm-watch-js npm-watch-css
 
-jekyll:
+assets/stylesheets/main.css: assets/stylesheets/*.scss
+	yarn run build-css
+
+assets/js/build/bundle.js: assets/js/main.js
+	yarn run build-js
+
+jekyll: assets/stylesheets/main.css assets/js/build/bundle.js
 	bundle exec jekyll serve --watch
 
 npm-watch-js:


### PR DESCRIPTION
**Why**: Without defining prerequisite build targets, it's possible for a race condition to occur where Jekyll build creates the `_site` directory before CSS and JavaScript files are built, resulting in an outcome where there is no stylesheet or script files present for the site to load.

**Story**: As a developer, I can run the setup instructions, so that I can navigate to http://localhost:4000/ and see a running copy of the identity site.

It was my experience in running the setup instructions that the site appeared without any styles. It's likely not quite so obvious after the first run, since the built file will already exist. Technically the problem can still manifest after the first run, if the developer modifies files while the watch process is not running in the background, since the problem of outdated source files is the same.