### PR TITLE
Add the Jekyll cache to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 *.swp
 .idea/
 .DS_Store
+.jekyll-cache


### PR DESCRIPTION
**Why**: We upgraded jekyll via snyk. As part of that upgrade we were supposed to start ignoring this file.