### PR TITLE
Update proofer script for external URLs

### DIFF
--- a/scripts/htmlproofer-external
+++ b/scripts/htmlproofer-external
@@ -10,17 +10,7 @@ if directory.nil?
   STR
 end
 
-# ignore new files from the PR
-directories = %w(content)
-merge_base = `git merge-base origin/production HEAD`.chomp
-diffable_files = `git diff -z --name-only --diff-filter=AC #{merge_base}`.split("\0")
-diffable_files = diffable_files.select do |filename|
-  next true if directories.include?(File.dirname(filename))
-  filename.end_with?('.md')
-end.map { |f| Regexp.new(File.basename(f, File.extname(f))) }
-
 HTMLProofer.check_directory(directory, {
-  url_ignore: diffable_files,
   external_only: true,
   typhoeus: {
     ssl_verifypeer: false,

--- a/scripts/htmlproofer-external
+++ b/scripts/htmlproofer-external
@@ -16,4 +16,7 @@ HTMLProofer.check_directory(directory, {
     ssl_verifypeer: false,
     ssl_verifyhost: 0,
   },
+  # treat absolute URLs to our domain as if they were local
+  # helps for rel="canonical" tags that exist locally but are not deployed yet
+  url_swap: { %r|https://www.login.gov/| => '/' },
 }).run


### PR DESCRIPTION
Treats login.gov URLs with a domain as local URLs for testing

This is a PR to patch #438 to simplify the checks and get the build passing