### PR TITLE
Restore border on nav link of active policy page

### DIFF
--- a/_includes/policy_nav.html
+++ b/_includes/policy_nav.html
@@ -2,7 +2,11 @@
   <ul id="pb-nav--side" class="list-reset nav">
     {% assign section_index = 0 %}
     {% for section in site.translations[site.lang]["policies"]["sections"] %}
-      <li class="border-bottom nav-sidenav-item">
+      {% assign active_class = '' %}
+      {% if section_index == page.index %}
+        {% assign active_class = 'active' %}
+      {% endif %}
+      <li class="border-bottom nav-sidenav-item {{ active_class }}">
         <a href="{{ section.link.url | prepend: site.baseurl }}" class="p2 block h6">
           {{ section.link.text }}
         </a>

--- a/_sass/pages/_policy.scss
+++ b/_sass/pages/_policy.scss
@@ -2,10 +2,9 @@ nav.policy {
   li {
     border-left: 0;
 
-    a {
-      &:hover {
-        box-shadow: inset 4px 0 0 $red;
-      }
+    &.active a,
+    a:hover {
+      box-shadow: inset 4px 0 0 $red;
     }
 
     ul {


### PR DESCRIPTION
Before, the active page's nav link had no border:
<img width="961" alt="Screen Shot 2020-09-08 at 9 19 03 AM" src="https://user-images.githubusercontent.com/1053255/92481756-cd5c3180-f1b4-11ea-96a1-0fa9ded9a781.png">


Now:
<img width="978" alt="Screen Shot 2020-09-08 at 9 19 20 AM" src="https://user-images.githubusercontent.com/1053255/92481775-d2b97c00-f1b4-11ea-9c7b-0a46eff66871.png">
