### PR TITLE
LG-3628: Brochure site refinement

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1267,7 +1267,7 @@ nav:
   principles: Principles
   privacy_&_security: Privacy & security
   security: Security
-  sign_in: 'Sign in to:'
+  sign_in: 'Sign in with'
   skip_nav: Skip to main content
   system_status: login.gov system status
   what_is_login_gov: What is login.gov?

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1654,7 +1654,7 @@ what-is-login-page:
     heading: What is login.gov?
     text: Accessing government agencies should be simple — and secure.
   one-account: |-
-    ## One account
+    ## One account, one password
 
     Login.gov is a shared service, used by the public, and trusted by government agencies.  With one login.gov account, you eliminate the need to remember different passwords for each agency and streamline your sign in process.
 

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1150,6 +1150,8 @@ index:
     content: Use one account and password for secure, private access to participating government agencies.
     heading: The public’s one account for government.
   why:
+    heading: |-
+      ## Login.gov is for you
     developers: |-
       <h4 class="hdr developers">Agency developers</h4>
 

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1147,7 +1147,7 @@ index:
       portfolio: TTS Solutions is a portfolio of products and services that help agencies improve
         delivery of information and services to the public.
   intro:
-    content: Use one account for secure, private access to participating government agencies.
+    content: Use one account and password for secure, private access to participating government agencies.
     heading: The public’s one account for government.
   why:
     developers: |-

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1656,7 +1656,7 @@ what-is-login-page:
     heading: What is login.gov?
     text: Accessing government agencies should be simple — and secure.
   one-account: |-
-    ## One account, one password
+    ## One account and password
 
     Login.gov is a shared service, used by the public, and trusted by government agencies.  With one login.gov account, you eliminate the need to remember different passwords for each agency and streamline your sign in process.
 

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1250,7 +1250,7 @@ nav:
   principles: Principios
   privacy_&_security: Privacidad y seguridad
   security: Seguridad
-  sign_in: 'Inicia sesión a:'
+  sign_in: 'Inicie sesión con'
   skip_nav: Salte al contenido principal
   system_status: Estado del sistema login.gov
   what_is_login_gov: ¿Qué es login.gov?

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1610,7 +1610,7 @@ what-is-login-page:
     heading: ¿Qué es login.gov?
     text: Acceder a las agencias gubernamentales debe ser simple y seguro.
   one-account: |-
-    ## Una cuenta
+    ## Una cuenta, una contraseña
 
     Login.gov es un servicio compartido, utilizado por el público y en el que confían las agencias gubernamentales. Con una cuenta de login.gov, elimina la necesidad de recordar diferentes contraseñas para cada agencia y agiliza su proceso de inicio de sesión.
 

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1141,6 +1141,8 @@ index:
       participantes.
     heading: La única cuenta del gobierno para el público.
   why:
+    heading: |-
+      ## Login.gov es para ti
     developers: |-
       #### Desarrolladores de agencias
 

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1612,7 +1612,7 @@ what-is-login-page:
     heading: ¿Qué es login.gov?
     text: Acceder a las agencias gubernamentales debe ser simple y seguro.
   one-account: |-
-    ## Una cuenta, una contraseña
+    ## Una cuenta y contraseña
 
     Login.gov es un servicio compartido, utilizado por el público y en el que confían las agencias gubernamentales. Con una cuenta de login.gov, elimina la necesidad de recordar diferentes contraseñas para cada agencia y agiliza su proceso de inicio de sesión.
 

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1137,7 +1137,7 @@ index:
       portfolio: TTS Solutions es una cartera de productos y servicios que ayudan a las agencias a
         mejorar la entrega de información y servicios al público.
   intro:
-    content: Use una cuenta para tener acceso privado y seguro a las agencias gubernamentales
+    content: Use una cuenta y contraseña para tener acceso privado y seguro a las agencias gubernamentales participantes.
       participantes.
     heading: La única cuenta del gobierno para el público.
   why:

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1627,7 +1627,7 @@ what-is-login-page:
     heading: Qu'est-ce que login.gov?
     text: L'accès aux agences gouvernementales doit être simple - et sécurisé.
   one-account: |-
-    ## Un compte, un mot de passe
+    ## Un compte et un mot de passe
 
     Login.gov est un service partagé, utilisé par le public et approuvé par les agences gouvernementales. Avec un compte login.gov, vous évitez de devoir mémoriser différents mots de passe pour chaque agence et rationalisez votre processus de connexion.
 

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1183,8 +1183,7 @@ index:
       portfolio: TTS Solutions est un portefeuille de produits et de services qui aident les agences
         à améliorer la fourniture d'informations et de services au public.
   intro:
-    content: Utilisez un seul compte pour un accès sécurisé et privé aux agences gouvernementales
-      participantes.
+    content: Utilisez un compte et un mot de passe pour un accès sécurisé et privé aux agences gouvernementales participantes.
     heading: Le seul compte public pour le gouvernement.
   why:
     developers: |-

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1296,7 +1296,7 @@ nav:
   principles: Principes
   privacy_&_security: Confidentialité et sécurité
   security: Sécurité
-  sign_in: 'Connectez-vous à:'
+  sign_in: 'Connectez-vous avec'
   skip_nav: Passer au contenu principal
   system_status: État du système login.gov
   what_is_login_gov: Qu'est-ce que login.gov?

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1186,6 +1186,8 @@ index:
     content: Utilisez un compte et un mot de passe pour un accès sécurisé et privé aux agences gouvernementales participantes.
     heading: Le seul compte public pour le gouvernement.
   why:
+    heading: |-
+      ## Login.gov est fait pour vous
     developers: |-
       #### Développeurs d'agence
 

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1625,7 +1625,7 @@ what-is-login-page:
     heading: Qu'est-ce que login.gov?
     text: L'accès aux agences gouvernementales doit être simple - et sécurisé.
   one-account: |-
-    ## Un compte
+    ## Un compte, un mot de passe
 
     Login.gov est un service partagé, utilisé par le public et approuvé par les agences gouvernementales. Avec un compte login.gov, vous évitez de devoir mémoriser différents mots de passe pour chaque agence et rationalisez votre processus de connexion.
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -17,6 +17,8 @@ image: /assets/img/login-gov-600x314.png
 
 <div class="bg-white">
   <div class="container why-login-gov">
+    <div>{{ site.translations[site.lang]["index"]["why"]["heading"] | replace: 'site.baseurl', site.baseurl | markdownify }}</div>
+    <hr>
     <div class="grid-row">
       <div class="tablet:grid-col">
         {{ site.translations[site.lang]["index"]["why"]["individuals"] | replace: 'site.baseurl', site.baseurl | markdownify }}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -32,3 +32,8 @@ image: /assets/img/login-gov-600x314.png
     </div>
   </div>
 </div>
+
+{% capture banner_content %}
+  <p><a class="learn-account-creation link" href="{{ site.baseurl }}/create-an-account">{% t banner.one-account-for-govt.learn %}</a></p>
+{% endcapture %}
+{% include one_account_banner.html content=banner_content %}


### PR DESCRIPTION
**Why:** To refine content on the [demo.login.gov](https://demo.login.gov)

😎 👉  [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-3628-refinement/)  

## How

**Homepage**
- [x] Update `Sign in to: [LOGIN.GOV]` to `Sign in with [LOGIN.GOV]`
- [x] Add `Login.gov is for you` heading
- [x] Update header blurb to `Use one account and password for secure, private access to participating government agencies`
- [x] Add call-to-action component: `Learn how to create an account`

**What is login.gov?**

- [x] Update `One account` heading with `One account and password`

**Translations**

- [x] Create En/Es/Fr translations for above content

## Review and next steps

- [x] Review with Team Katherine before merging with the demo site
  - [x] To check if the refinement meets the acceptance criteria
- [ ] Discuss with TK about further refinement / new tickets
  - [ ] To find out when to use (or not use) `One account` vs. `One account and password` vs. `One account, one password`
  - [ ] To be consistent with top/bottom margin for the call-to-action component throughout pages
  - [ ] To fix the visibility of CTA component on mobile (it might be set to hidden?)