### PR TITLE
LG-3627: Remove COVID banner from the demo site

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -18,9 +18,6 @@ banner:
     gov_description: Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
     secure_heading: The site is secure.
     secure_description: "The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely."
-  covid:
-    question: Does your agency have an urgent need related to COVID-19 response efforts?
-    button: Contact login.gov partnerships
 contact_page:
   content: |-
     ## Find help using login.gov

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -18,9 +18,6 @@ banner:
     gov_description: Los sitios web del gobierno federal a menudo terminan en .gov o .mil. Antes de compartir información confidencial, asegúrese de estar en un sitio del gobierno federal.
     secure_heading: El sitio es seguro.
     secure_description: "El <strong>https://</strong> garantiza que se está conectando al sitio web oficial y que toda la información que proporciona está encriptada y transmitida de forma segura."
-  covid:
-    question: ¿Tiene su agencia una necesidad urgente relacionada con los esfuerzos de respuesta de COVID-19?
-    button: Contacto login.gov sociedades
 contact_page:
   content: |-
     Estamos experimentando un tráfico extremadamente alto debido al lanzamiento del programa Trusted Traveler hoy. Gracias por su paciencia mientras trabajamos para mejorar el rendimiento de nuestro sistema.

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -19,9 +19,6 @@ banner:
     gov_description: Les sites Web du gouvernement fédéral se terminent souvent par .gov ou .mil. Avant de partager des informations sensibles, assurez-vous que vous êtes sur un site du gouvernement fédéral.
     secure_heading: Le site est sécurisé.
     secure_description: "Le <strong>https://</strong> garantit que vous vous connectez au site officiel et que toutes les informations que vous fournissez sont cryptées et transmises en toute sécurité."
-  covid:
-    question: Votre agence a-t-elle un besoin urgent lié aux efforts de réponse de COVID-19?
-    button: Contactez les partenariats login.gov
 contact_page:
   content: |-
     Nous connaissons un trafic extrêmement élevé en raison du lancement du programme Trusted Traveler aujourd'hui. Nous vous remercions de votre patience car nous travaillons à améliorer les performances de notre système.

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,13 +1,3 @@
-<section class="flex-justify-center grid-row bg-yellow desktop:padding-x-4 padding-y-2 font-lang-4 center">
-  <div class="covid-prompt">
-    {% t banner.covid.question %}
-  </div>
-  <div class="grid-col-auto covid">
-    <a href="https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e" class="bg-white black text-bold hover:text-no-underline text-decoration-none rounded-lg px1 py-tiny" target="_blank">
-      {% t banner.covid.button %}
-    </a>
-  </div>
-</section>
 <section class="usa-banner" aria-label="Official government website">
   <div class="usa-accordion">
     <div class="usa-banner__header">

--- a/_includes/covid_banner.html
+++ b/_includes/covid_banner.html
@@ -1,8 +1,0 @@
-<!--- begin covid banner --->
-<div class="usa-alert usa-alert--info">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Login.gov is dedicated to supporting relief efforts in response to COVID-19. Our <a href="https://share.hsforms.com/16DIoo--rTU2xbNW1MShkBg3ak9e" target="_blank">partner inquiry form</a> now includes an option to designate inquiries as COVID-19 related.</p>
-  </div>
-</div>
-<br class="clearfix" />
-<!--- end covid banner --->

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -30,16 +30,6 @@ header {
   }
 }
 
-.covid-prompt {
-  margin: 0 0.7em;
-}
-
-@media #{$breakpoint-menu} {
-  .covid {
-    margin-top: 10px;
-  }
-}
-
 .create-account-btn-link {
   margin-top: 2em;
   display: none;


### PR DESCRIPTION
**Why:** The COVID banner will be moving to [partners.login.gov](https://partners.login.gov/).

😎  👉   [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-3627-remove-covid-banner/) 

**How:**

- [x] Remove all content, markup and styles related to the banner
- [ ] When approved, it will be merged to the demo site