### PR TITLE
LG-3000: Fix headings

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1150,19 +1150,19 @@ index:
     heading: |-
       ## Login.gov is for you
     developers: |-
-      <h4 class="hdr developers">Agency developers</h4>
+      <h3 class="hdr developers">Agency developers</h3>
 
       Developer resources, real-time support and modern tools to help you implement and deploy your application with login.gov
 
       [See developer guide](https://developers.login.gov){:class="why-more-info" :target="_blank"}
     individuals: |-
-      <h4 class="hdr individuals">Individuals</h4>
+      <h3 class="hdr individuals">Individuals</h3>
 
       Use one account for secure, private access to participating government agencies.
 
       [Learn about login.gov](site.baseurl/what-is-login/){:class="why-more-info"}
     partners: |-
-      <h4 class="hdr partners">Agency partners</h4>
+      <h3 class="hdr partners">Agency partners</h3>
 
       Protect your users' information with the highest standards of digital security and user experience.  Login.gov handles software development, security operations, and customer support so you don't have to.
 

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1149,12 +1149,6 @@ index:
   why:
     heading: |-
       ## Login.gov is for you
-    developers: |-
-      <h3 class="hdr developers">Agency developers</h3>
-
-      Developer resources, real-time support and modern tools to help you implement and deploy your application with login.gov
-
-      [See developer guide](https://developers.login.gov){:class="why-more-info" :target="_blank"}
     individuals: |-
       <h3 class="hdr individuals">Individuals</h3>
 
@@ -1167,6 +1161,12 @@ index:
       Protect your users' information with the highest standards of digital security and user experience.  Login.gov handles software development, security operations, and customer support so you don't have to.
 
       [Become a partner](https://partners.login.gov/){:class="why-more-info" :target="_blank"}
+    developers: |-
+      <h3 class="hdr developers">Agency developers</h3>
+
+      Developer resources, real-time support and modern tools to help you implement and deploy your application with login.gov
+
+      [See developer guide](https://developers.login.gov){:class="why-more-info" :target="_blank"}
 meta:
   about:
     description: More information about login.gov

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1659,7 +1659,7 @@ what-is-login-page:
 
     <div class="mobile one-account-img" aria-hidden="true"></div>
 
-    #### Login.gov is trusted by
+    ### Login.gov is trusted by
 
     * Department of Defense
     * Small Business Administration

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1615,7 +1615,7 @@ what-is-login-page:
 
     <div class="mobile one-account-img" aria-hidden="true"></div>
 
-    #### Login.gov cuenta con la confianza de
+    ### Login.gov cuenta con la confianza de
 
     * Departamento de Defensa
     * Administración de Pequeños Negocios

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1141,19 +1141,19 @@ index:
     heading: |-
       ## Login.gov es para ti
     developers: |-
-      #### Desarrolladores de agencias
+      ### Desarrolladores de agencias
 
       Recursos para desarrolladores, soporte en tiempo real y herramientas modernas para ayudarlo a implementar e implementar su aplicación con login.gov
 
       [Ver guía para desarrolladores](https://developers.login.gov){:class="why-more-info" :target="_blank"}
     individuals: |-
-      #### Individuos
+      ### Individuos
 
       Use una cuenta para tener acceso privado y seguro a las agencias gubernamentales participantes.
 
       [Más información sobre login.gov](site.baseurl/what-is-login/){:class="why-more-info"}
     partners: |-
-      #### Socios de agencias
+      ### Socios de agencias
 
       Proteja la información de sus usuarios con los más altos estándares de seguridad digital y experiencia de usuario. Login.gov maneja el desarrollo de software, las operaciones de seguridad y la atención al cliente para que usted no tenga que hacerlo.
 

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1140,12 +1140,6 @@ index:
   why:
     heading: |-
       ## Login.gov es para ti
-    developers: |-
-      ### Desarrolladores de agencias
-
-      Recursos para desarrolladores, soporte en tiempo real y herramientas modernas para ayudarlo a implementar e implementar su aplicación con login.gov
-
-      [Ver guía para desarrolladores](https://developers.login.gov){:class="why-more-info" :target="_blank"}
     individuals: |-
       ### Individuos
 
@@ -1158,6 +1152,12 @@ index:
       Proteja la información de sus usuarios con los más altos estándares de seguridad digital y experiencia de usuario. Login.gov maneja el desarrollo de software, las operaciones de seguridad y la atención al cliente para que usted no tenga que hacerlo.
 
       [Convertirse en un compañero](https://partners.login.gov){:class="why-more-info" :target="_blank"}
+    developers: |-
+      ### Desarrolladores de agencias
+
+      Recursos para desarrolladores, soporte en tiempo real y herramientas modernas para ayudarlo a implementar e implementar su aplicación con login.gov
+
+      [Ver guía para desarrolladores](https://developers.login.gov){:class="why-more-info" :target="_blank"}
 meta:
   about:
     description: Más información sobre login.gov

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1630,7 +1630,7 @@ what-is-login-page:
 
     <div class="mobile one-account-img" aria-hidden="true"></div>
 
-    #### Login.gov est approuvé par
+    ### Login.gov est approuvé par
 
     * Département de la Défense
     * Administration des petites entreprises

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1186,19 +1186,19 @@ index:
     heading: |-
       ## Login.gov est fait pour vous
     developers: |-
-      #### Développeurs d'agence
+      ### Développeurs d'agence
 
       Ressources de développement, support en temps réel et outils modernes pour vous aider à implémenter et déployer votre application avec login.gov
 
       [Voir le guide du développeur](https://developers.login.gov){:class="why-more-info" :target="_blank"}
     individuals: |-
-      #### Personnes
+      ### Personnes
 
       Utilisez un seul compte pour un accès sécurisé et privé aux agences gouvernementales participantes.
 
       [En savoir plus sur login.gov](site.baseurl/what-is-login/){:class="why-more-info"}
     partners: |-
-      #### Partenaires de l'agence
+      ### Partenaires de l'agence
 
       Protégez les informations de vos utilisateurs avec les plus hauts standards de sécurité numérique et d'expérience utilisateur. Login.gov gère le développement de logiciels, les opérations de sécurité et le support client pour que vous n'ayez pas à le faire.
 

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -1185,12 +1185,6 @@ index:
   why:
     heading: |-
       ## Login.gov est fait pour vous
-    developers: |-
-      ### Développeurs d'agence
-
-      Ressources de développement, support en temps réel et outils modernes pour vous aider à implémenter et déployer votre application avec login.gov
-
-      [Voir le guide du développeur](https://developers.login.gov){:class="why-more-info" :target="_blank"}
     individuals: |-
       ### Personnes
 
@@ -1203,6 +1197,12 @@ index:
       Protégez les informations de vos utilisateurs avec les plus hauts standards de sécurité numérique et d'expérience utilisateur. Login.gov gère le développement de logiciels, les opérations de sécurité et le support client pour que vous n'ayez pas à le faire.
 
       [Devenir un partenaire](https://partners.login.gov){:class="why-more-info" :target="_blank"}
+    developers: |-
+      ### Développeurs d'agence
+
+      Ressources de développement, support en temps réel et outils modernes pour vous aider à implémenter et déployer votre application avec login.gov
+
+      [Voir le guide du développeur](https://developers.login.gov){:class="why-more-info" :target="_blank"}
 meta:
   about:
     description: Plus d'informations sur login.gov


### PR DESCRIPTION
**Why:** To fix headings that skip level on both homepage and 'What is login.gov' pages

😎 👉  [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-3000-a11y-fixes-semantic/)

**How:** This PR will be merged to `demo`, not `master`

- **Homepage:**
  - Correct `h4` to `h3` headings for 'Individuals', 'Agency partners', and 'Agency developers'
  - Update en/es/fr.yml files
- **What is login.gov:** 
  - Correct `h4` to `h3` headings for 'Login.gov is trusted by'
  - Update en/es/fr.yml files

**AC:**

- [x] **Homepage:** Pathways have been updated
- [x] **What is login.gov:** 'Login.gov is trusted by' heading has been updated
- [x] A title that adequately and briefly describes the content of each page has been checked, except 'Help center' and other non-top-nav pages which will be visited later
