### PR TITLE
Fix spacing on the language dropdown

### DIFF
--- a/_pages/create_an_account.md
+++ b/_pages/create_an_account.md
@@ -23,15 +23,15 @@ image: /assets/img/login-gov-600x314.png
         <header class="intro">
           {{ site.translations[site.lang]["create-an-account"]["intro"] | replace: 'site.baseurl', site.baseurl | markdownify }}
         </header>
-        <div class="step-1 step">
+        <div class="step-1 step list">
           {{ site.translations[site.lang]["create-an-account"]["step_1"] | replace: 'site.baseurl', site.baseurl | markdownify }}
           <div class="mobile step-1-img"></div>
         </div>
-        <div class="step-2 step">
+        <div class="step-2 step list">
           {{ site.translations[site.lang]["create-an-account"]["step_2"] | replace: 'site.baseurl', site.baseurl | markdownify }}
           <div class="mobile step-2-img"></div>
         </div>
-        <div class="step-3 step">
+        <div class="step-3 step list">
           {{ site.translations[site.lang]["create-an-account"]["step_3"] | replace: 'site.baseurl', site.baseurl | markdownify }}
           <div class="mobile step-3-img"></div>
         </div>

--- a/_pages/who_uses_login.md
+++ b/_pages/who_uses_login.md
@@ -18,7 +18,7 @@ image: /assets/img/login-gov-600x314.png
 
 <div class="bg-primary-lightest">
   <div class="container who-uses-login">
-    <div class="partners">
+    <div class="partners list">
       {{ site.translations[site.lang]["who-uses-login-page"]["partners"] | replace: 'site.baseurl', site.baseurl | markdownify }}
     </div>
   </div>

--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -1,5 +1,17 @@
-ul a {
-  text-decoration: none;
+.list {
+  ul {
+    li {
+      line-height: 2.25rem;
+      ul {
+        list-style-type: "⁃";
+        margin-bottom: 0;
+      }
+    }
+  }
+  
+  a {
+    text-decoration: none;
+  }
 }
 
 .list-arrow {

--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -1,13 +1,3 @@
-ul {
-  li {
-    line-height: 2.25rem;
-    ul {
-      list-style-type: "⁃";
-      margin-bottom: 0;
-    }
-  }
-}
-
 ul a {
   text-decoration: none;
 }

--- a/_sass/pages/_create_an_account.scss
+++ b/_sass/pages/_create_an_account.scss
@@ -5,16 +5,6 @@
   .step {
     background: none;
     padding: 0;
-
-    ul {
-      li {
-        line-height: 2.25rem;
-        ul {
-          list-style-type: "⁃";
-          margin-bottom: 0;
-        }
-      }
-    }
   }
 
   .mobile {

--- a/_sass/pages/_create_an_account.scss
+++ b/_sass/pages/_create_an_account.scss
@@ -5,6 +5,16 @@
   .step {
     background: none;
     padding: 0;
+
+    ul {
+      li {
+        line-height: 2.25rem;
+        ul {
+          list-style-type: "⁃";
+          margin-bottom: 0;
+        }
+      }
+    }
   }
 
   .mobile {


### PR DESCRIPTION
The language dropdown currently looks like this:
![image](https://user-images.githubusercontent.com/381122/100776633-c5d2b000-33d2-11eb-9381-b8738030a110.png)

But it should look like:
![image](https://user-images.githubusercontent.com/381122/100776657-ca976400-33d2-11eb-9385-800d8b50d0ec.png)

The list styling was meant for the Create an Account page. Made the css more specific.

