### PR TITLE
Make sure DAP is included on 404 page (LG-3629)

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,6 +7,13 @@
     {% include dap.html %}
     {% include google_recaptcha.html %}
   </head>
-  {{ content }}
-  {% include scripts.html %}
+  <body
+    class="{{ layout.class }} {{ page.class }} site lang-{{ site.lang }}"
+    {% if layout.body.spy %}data-spy="{{ layout.body.spy }}"{% endif %}
+    {% if layout.body.target %}data-target="#{{ layout.body.target }}"{% endif %}
+    {% if layout.body.offset %}data-offset="{{ layout.body.offset }}"{% endif %}
+  >
+    {{ content }}
+    {% include scripts.html %}
+  </body>
 </html>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
+  <head>
+    {% include meta.html %}
+    {% include styles.html %}
+    {% include google_analytics.html %}
+    {% include google_recaptcha.html %}
+  </head>
+  {{ content }}
+  {% include dap.html %}
+  {% include scripts.html %}
+</html>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,9 +4,9 @@
     {% include meta.html %}
     {% include styles.html %}
     {% include google_analytics.html %}
+    {% include dap.html %}
     {% include google_recaptcha.html %}
   </head>
   {{ content }}
-  {% include dap.html %}
   {% include scripts.html %}
 </html>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -10,7 +10,7 @@
   <body
     class="{{ layout.class }} {{ page.class }} site lang-{{ site.lang }}"
     {% if layout.body.spy %}data-spy="{{ layout.body.spy }}"{% endif %}
-    {% if layout.body.target %}data-target="#{{ layout.body.target }}"{% endif %}
+    {% if layout.body.target %}data-target="{{ layout.body.target }}"{% endif %}
     {% if layout.body.offset %}data-offset="{{ layout.body.offset }}"{% endif %}
   >
     {{ content }}

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -1,25 +1,17 @@
-<!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
-  <head>
-    {% include meta.html %}
-    {% include styles.html %}
-    {% include google_analytics.html %}
-    {% include google_recaptcha.html %}
-  </head>
-  <body class="{{ layout.class }} {{ page.class }} site lang-{{ site.lang }}" data-spy="scroll" data-target="#pb-nav--side-cntnr" data-offset="48">
-    <header>
-      <div class="temp-wip">This site is for demo purposes only and is under continual development. Please visit
-        <a href="https://www.login.gov" target="_blank">our official website</a>
-        for current information.
-      </div>
-      {% include skip_nav.html %}
-      {% include banner.html %}
-      {% include language_search.html %}
-      {% include header.html %}
-    </header>
-    <main id="main-content">{{ content }}</main>
-    {% include footer.html %}
-  </body>
-  {% include dap.html %}
-  {% include scripts.html %}
-</html>
+---
+layout: base
+---
+<body class="{{ layout.class }} {{ page.class }} site lang-{{ site.lang }}" data-spy="scroll" data-target="#pb-nav--side-cntnr" data-offset="48">
+  <header>
+    <div class="temp-wip">This site is for demo purposes only and is under continual development. Please visit
+      <a href="https://www.login.gov" target="_blank">our official website</a>
+      for current information.
+    </div>
+    {% include skip_nav.html %}
+    {% include banner.html %}
+    {% include language_search.html %}
+    {% include header.html %}
+  </header>
+  <main id="main-content">{{ content }}</main>
+  {% include footer.html %}
+</body>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -1,17 +1,19 @@
 ---
 layout: base
+body:
+  spy: "scroll"
+  target: "#pb-nav--side-cntnr"
+  offset: "48"
 ---
-<body class="{{ layout.class }} {{ page.class }} site lang-{{ site.lang }}" data-spy="scroll" data-target="#pb-nav--side-cntnr" data-offset="48">
-  <header>
-    <div class="temp-wip">This site is for demo purposes only and is under continual development. Please visit
-      <a href="https://www.login.gov" target="_blank">our official website</a>
-      for current information.
-    </div>
-    {% include skip_nav.html %}
-    {% include banner.html %}
-    {% include language_search.html %}
-    {% include header.html %}
-  </header>
-  <main id="main-content">{{ content }}</main>
-  {% include footer.html %}
-</body>
+<header>
+  <div class="temp-wip">This site is for demo purposes only and is under continual development. Please visit
+    <a href="https://www.login.gov" target="_blank">our official website</a>
+    for current information.
+  </div>
+  {% include skip_nav.html %}
+  {% include banner.html %}
+  {% include language_search.html %}
+  {% include header.html %}
+</header>
+<main id="main-content">{{ content }}</main>
+{% include footer.html %}

--- a/_layouts/not_found.html
+++ b/_layouts/not_found.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
   <head>
-    {% include meta.html %} {% include styles.html %} {% include
-    google_analytics.html %}
+    {% include meta.html %}
+    {% include styles.html %}
+    {% include google_analytics.html %}
   </head>
   <body class="not-found">
     <div class="site-wrapper">{{ content }}</div>
   </body>
+  {% include dap.html %}
 </html>

--- a/_layouts/not_found.html
+++ b/_layouts/not_found.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
-  <head>
-    {% include meta.html %}
-    {% include styles.html %}
-    {% include google_analytics.html %}
-  </head>
-  <body class="not-found">
-    <div class="site-wrapper">{{ content }}</div>
-  </body>
-  {% include dap.html %}
-</html>
+---
+layout: base
+---
+<body class="not-found">
+  <div class="site-wrapper">{{ content }}</div>
+</body>

--- a/_layouts/not_found.html
+++ b/_layouts/not_found.html
@@ -1,6 +1,5 @@
 ---
 layout: base
+class: "not-found"
 ---
-<body class="not-found">
-  <div class="site-wrapper">{{ content }}</div>
-</body>
+<div class="site-wrapper">{{ content }}</div>

--- a/spec/_pages/404.html_spec.rb
+++ b/spec/_pages/404.html_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe '/404' do
+  let(:doc) { Nokogiri::HTML(file_at('/404.html')) }
+
+  it 'includes Google Analytics' do
+    expect(doc.to_s).to include('https://www.google-analytics.com/analytics.js')
+  end
+
+  it 'includes DAP' do
+    expect(doc.to_s).to include('https://dap.digitalgov.gov')
+  end
+end


### PR DESCRIPTION
I found one discrepancy between the login.gov Google Analytics and the DAP analytics: the 404 page did not have DAP, so this fixes that

