### PR TITLE
Deduplicate Webpack build in `make run`

### DIFF
--- a/Makefile.server
+++ b/Makefile.server
@@ -1,9 +1,6 @@
 run: jekyll npm-watch-js
 
-assets/js/build/bundle.js: assets/js/main.js
-	npm run build-js
-
-jekyll: assets/js/build/bundle.js
+jekyll:
 	bundle exec jekyll serve --watch
 
 npm-watch-js:


### PR DESCRIPTION
**Why**: Webpack run in watch mode will already perform an initial build. Without these changes, two Webpack builds occur when running `make run`.

Only difference would be if someone were to run `make jekyll` directly, it will no longer build JavaScript. It doesn't appear we run or recommend this, nor does it seem "expected" that a Jekyll task would build JavaScript.