### PR TITLE
Remove unused CSS dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,11 +2064,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
-    "hint.css": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hint.css/-/hint.css-2.6.0.tgz",
-      "integrity": "sha512-SnCLQOoPQt4fuHbOOvEL3UZwL0SPFtKMN4YIxAvBTe4oFUtBAT4R2Kk1uk3x5hgN+0xzOb6LFEQf5StbYfNm8w=="
-    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -2362,11 +2357,6 @@
       "version": "1.1.67",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
       "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
-    },
-    "normalize.css": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-4.2.0.tgz",
-      "integrity": "sha1-IdZsxVcVTUN5/R4HnsfeWKN5sJk="
     },
     "object-keys": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
     "@babel/preset-env": "^7.12.7",
     "aria-accordion": "^1.1.0",
     "babel-loader": "^8.2.2",
-    "hint.css": "^2.5.0",
     "identity-style-guide": "^2.2.2",
     "jquery": "^3.5.1",
-    "normalize.css": "^4.2.0",
     "webpack": "^5.10.0",
     "webpack-cli": "^4.2.0"
   }


### PR DESCRIPTION
**Why**: Fewer dependencies to maintain. Avoid confusion about source of normalize.css.

These dependencies are not used in source.

In the case of `hint.css`, you can also check for references to `hint--`-prefixed classes ([documentation](https://www.npmjs.com/package/hint.css#get-started)).

Normalize.css is still included, but not directly referenced, and instead inherited through USWDS [[1]](https://github.com/uswds/uswds/blob/b0e7ea3800e5bb5960e0925716cf5363375ee613/config/gulp/sass.js#L60-L61) [[2]](https://github.com/uswds/uswds/blob/3dc296ec56cd621fe52d918701fd94621d96a198/src/stylesheets/packages/_global.scss#L3).

You can confirm it's still included in the output `_site/assets/css/main.css`:

```
make build && cat _site/assets/css/main.css | grep -q normalize.css && echo "Found" || echo "Not found"
```