### PR TITLE
Add sys-status meta tag for current brochure site

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -65,5 +65,4 @@
 <meta name="theme-color" content="#ffffff">
 
 <!-- Monitoring Tag -->
-<meta sys-status=”login.gov site up and running”>
-
+<meta sys-status="login.gov site up and running">

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -63,3 +63,7 @@
 <link rel="manifest" href="{{ '/manifest.json' | relative_url }}">
 <link rel="mask-icon" href="{{ '/safari-pinned-tab.svg' | relative_url }}" color="#e21c3d">
 <meta name="theme-color" content="#ffffff">
+
+<!-- Monitoring Tag -->
+<meta sys-status=”login.gov site up and running”>
+


### PR DESCRIPTION
Adds the following to all pages to allow synthetic monitors to have static text to look for:
~~~
<!-- Monitoring Tag -->
<meta sys-status=”login.gov site up and running”>
~~~

This is needed to ensure the switch from old to new brochure site does not result in false alarms from NewRelic Synthetics.