### PR TITLE
Add sys-status meta tag for new brochure site

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -88,3 +88,7 @@
   color="#e21c3d"
 />
 <meta name="theme-color" content="#ffffff" />
+
+<!-- Monitoring Tag -->
+<meta sys-status=”login.gov site up and running”>
+

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -90,5 +90,4 @@
 <meta name="theme-color" content="#ffffff" />
 
 <!-- Monitoring Tag -->
-<meta sys-status=”login.gov site up and running”>
-
+<meta sys-status="login.gov site up and running">


### PR DESCRIPTION
Adds the following to all pages to allow synthetic monitors to have static text to look for:
~~~
<!-- Monitoring Tag -->
<meta sys-status=”login.gov site up and running”>
~~~

This is needed to ensure the switch from old to new brochure site does not result in false alarms from NewRelic Synthetics.