### PR TITLE
Add readme to Help sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The lint task will check to see that SVG images are optimized. To optimize image
 npm run optimize-assets
 ```
 
+To build **Help Center** pages, follow the guidelines in the [Help README](_help/README.md).
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for additional information.

--- a/_help/README.md
+++ b/_help/README.md
@@ -1,0 +1,96 @@
+# Maintaining Help Section
+
+The Help section of login.gov a slightly different from others. It is the core of the site mobile navigation. 
+
+Here are helpful hints for maintaining this section.
+
+## The _help files location
+For now, the help section is a direct subdirectory of the identity-site. They are located outside of the _pages directory. Our goal is to move this section to the _pages directory in a future pull request, where we can view the impact of such a move.
+
+## The Help.html template
+tbd
+
+## The Help.md landing page
+tbd
+
+## The nav__sidenav.html component
+tbd
+
+## Adding a new help page
+1. Navigate to en.yml.
+    1. Find the `help` variable. Add the new page under an existing category:
+        ```
+          get-started:
+            overview: Overview
+            new-page-slug: New page title
+        ```
+        > Here, the new page is added to the get-started collection of pages.
+    1. Add the new page to the `help_pages` variable:
+        ```
+          get-started:
+            overview: |-
+              You can add or delete email addresses from your login.gov Your Account page...
+            new-page-slug: |-
+              This is the content of the new Help page...
+        ```
+        Remember to combine the yaml literal operator and the strip operator `|-` to keep line breaks but remove ending empty lines from the content.
+
+        **DO NOT USE HTML.** Content should include markdown syntax only. This applies to headings, lists, images and links. If special styling is required for content _within_ the help article, consider using general CSS selectors. Do not use ids created by markdown, because these ids will be translated and will not apply to translated pages.
+
+        To make sure that any links within the content, use the ``{{ site.baseurl/ }}`` prefix. This code converts to `login.gov/es` and `login.gov/fr` respectively.
+1. Repeat the above steps in es.yml. Use the same slug (untranslated) as the id.
+1. Repeat the above steps in fr.yml.
+
+## Adding a new help category
+1. Navigate to config.yml.
+1. Add the new category to the `help_pages` collection:
+    ```
+    help_pages:
+    - get-started
+    - trouble-signing-in
+    - new-category-slug
+    ```
+1. Navigate to en.yml.
+1. Add the new category to the `help_subpages` variable:
+    ```
+    help_subpages:
+      get-started: Get started with login.gov
+      trouble-signing-in: Trouble signing in?
+      new-category-slug: Title of new category
+    ```
+    These values are used by [...] 
+    
+    Titles in login.gov use sentence case instead of title case. Make sure category titles have the first letter capitalized.
+    
+    @TODO: Combine help_pages collection in config.yml with help_subpages. DRY.
+    @TODO: Rename help_subpages to help_catogories to improve semantic meaning.
+1. Add the new category to the `help_subpages` variable in es.yml and fr.yml.
+
+## Translations
+tbd
+
+## Redirects
+You'll notice there are several directories that aren't used on the brochure site:
+  * usajobs
+  * trusted-traveler-programs
+  * sam
+These pages were part of the former site, included in the navigation. Unfortunately, redirects on a Federalist site cannot be implemented on the server level. We have to create placeholders for these pages and specify where they should be redirected to.
+
+__If you remove a Help directory, please follow the following steps:__
+  1. Create an `index.md` page (if one doesn't already exist).
+  1. As the front matter for the index.md page, add a `redirect_from` variable. List the pages to be removed under this variable.
+      ```
+      redirect_from: 
+      - /help/directory/page-1
+      - /help/directory/page-2
+      ```
+  1. Delete the pages listed in index.md
+  1. Add these urls to the `OLD_URLS.yml` file.
+  1. Run `make test-urls` locally. If this check passes, you will receive the confirmation `No missing urls!`
+
+__If you remove a Help page, please follow the following steps:__
+  1. Find the index.md in the page's section. 
+  1. Add this page to the `redirect_from` list of pages.
+  1. Delete the page.
+  1. Add this url to the `OLD_URLS.yml` file.
+  1. Run `make test-urls` locally. If this check passes, you will receive the confirmation `No missing urls!`

--- a/_help/README.md
+++ b/_help/README.md
@@ -1,8 +1,6 @@
 # Maintaining Help Section
 
-The Help section of login.gov a slightly different from others. It is the core of the site mobile navigation. 
-
-Here are helpful hints for maintaining this section.
+The Help section of login.gov a slightly different from others. Here are helpful hints for maintaining this section.
 
 ## The _help files location
 For now, the help section is a direct subdirectory of the identity-site. They are located outside of the _pages directory. Our goal is to move this section to the _pages directory in a future pull request, where we can view the impact of such a move.
@@ -15,6 +13,31 @@ tbd
 
 ## The nav__sidenav.html component
 tbd
+
+## Adding a new help category
+1. Navigate to config.yml.
+1. Add the new category to the `help_pages` collection:
+    ```
+    help_pages:
+    - get-started
+    - trouble-signing-in
+    - new-category-slug
+    ```
+1. Navigate to en.yml.
+1. Add the new category to the `help_subpages` variable:
+    ```
+    help_subpages:
+      get-started: Get started with login.gov
+      trouble-signing-in: Trouble signing in?
+      new-category-slug: Title of new category
+    ```
+    These values are used by [tbd] 
+    
+    Titles in login.gov use sentence case instead of title case. Make sure category titles have the first letter capitalized.
+    
+    * @TODO: Combine help_pages collection in config.yml with help_subpages. DRY.
+    * @TODO: Rename help_subpages to help_catogories to improve semantic meaning.
+1. Add the new category to the `help_subpages` variable in es.yml and fr.yml.
 
 ## Adding a new help page
 1. Navigate to en.yml.
@@ -40,31 +63,6 @@ tbd
         To make sure that any links within the content, use the ``{{ site.baseurl }}/`` prefix. This code converts to `login.gov/es` and `login.gov/fr` respectively.
 1. Repeat the above steps in es.yml. Use the same slug (untranslated) as the id.
 1. Repeat the above steps in fr.yml.
-
-## Adding a new help category
-1. Navigate to config.yml.
-1. Add the new category to the `help_pages` collection:
-    ```
-    help_pages:
-    - get-started
-    - trouble-signing-in
-    - new-category-slug
-    ```
-1. Navigate to en.yml.
-1. Add the new category to the `help_subpages` variable:
-    ```
-    help_subpages:
-      get-started: Get started with login.gov
-      trouble-signing-in: Trouble signing in?
-      new-category-slug: Title of new category
-    ```
-    These values are used by [...] 
-    
-    Titles in login.gov use sentence case instead of title case. Make sure category titles have the first letter capitalized.
-    
-    @TODO: Combine help_pages collection in config.yml with help_subpages. DRY.
-    @TODO: Rename help_subpages to help_catogories to improve semantic meaning.
-1. Add the new category to the `help_subpages` variable in es.yml and fr.yml.
 
 ## Translations
 tbd


### PR DESCRIPTION
Since Help is structured differently from the rest of the site, give future developers a heads-up on maintenance.