### PR TITLE
Improve local development rebuild performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 .DS_Store
 .jekyll-cache
 .snyk
+_config.dev.yml

--- a/Makefile.server
+++ b/Makefile.server
@@ -1,7 +1,7 @@
 run: jekyll npm-watch-js
 
 jekyll:
-	bundle exec jekyll serve --watch
+	bundle exec jekyll serve --watch --config _config.yml,_config.dev.yml
 
 npm-watch-js:
 	npm run watch-js

--- a/Makefile.server
+++ b/Makefile.server
@@ -1,6 +1,9 @@
 run: jekyll npm-watch-js
 
-jekyll:
+_config.dev.yml:
+	touch _config.dev.yml
+
+jekyll: _config.dev.yml
 	bundle exec jekyll serve --watch --incremental --config _config.yml,_config.dev.yml
 
 npm-watch-js:

--- a/Makefile.server
+++ b/Makefile.server
@@ -1,7 +1,7 @@
 run: jekyll npm-watch-js
 
 jekyll:
-	bundle exec jekyll serve --watch --config _config.yml,_config.dev.yml
+	bundle exec jekyll serve --watch --incremental --config _config.yml,_config.dev.yml
 
 npm-watch-js:
 	npm run watch-js

--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ Then, to start serving the site locally in development:
 make run
 ```
 
-You can use the file `_config.dev.yml` to add configuration which should only apply for local development. By default, this includes:
-
-- Configuring SASS to not be minified while in development, to facilitate debugging.
-- Building only the English version of the site, to improve rebuild times. Since you will want to test the site in non-English locales, you can do so by un-commenting those locale slugs in your local configuration.
+Optionally, you can add a `_config.dev.yml` file to the root directory to list configuration which should only apply for local development. Any settings in this file will override an equivalent setting in the base Jekyll `_config.yml` configuration. For example, you may want to configure Sass `style` to `expanded` to debug the non-minified styles, or temporarily disable non-English locales to improve rebuild times.
 
 To develop locally in conjunction with [`identity-style-guide`](https://github.com/18F/identity-style-guide/), run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ This is a Jekyll-built static site. To install dependencies:
 make setup
 ```
 
-To run locally in conjunction with [`identity-style-guide`](https://github.com/18F/identity-style-guide/), run the following commands:
-
-0. In the `identity-style-guide` directory, run `npm link`. This will create a symlink that will make changes to this repo accessible in `identity-site`
-
 Then, to start serving the site locally in development:
 
 ```
 make run
 ```
 
-This will start multiple processes that will watch for changes in your local `identity-style-guide` repository.
+To develop locally in conjunction with [`identity-style-guide`](https://github.com/18F/identity-style-guide/), run the following commands:
+
+1. In the `identity-style-guide` directory, run `npm link`. This will create a symlink that will make changes to this repo accessible in `identity-site`.
+2. In the `identity-site` directory, run `npm link identity-style-guide`. This will use the copy from your local machine in place of the one downloaded from NPM.
+
+While developing, you may want to automatically rebuild changes made to the style guide by running `npm start` in the `identity-style-guide` directory. Changes made in your local `identity-style-guide` repository will automatically trigger the static site to build.
 
 To run specs:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Then, to start serving the site locally in development:
 make run
 ```
 
+You can use the file `_config.dev.yml` to add configuration which should only apply for local development. By default, this includes:
+
+- Configuring SASS to not be minified while in development, to facilitate debugging.
+- Building only the English version of the site, to improve rebuild times. Since you will want to test the site in non-English locales, you can do so by un-commenting those locale slugs in your local configuration.
+
 To develop locally in conjunction with [`identity-style-guide`](https://github.com/18F/identity-style-guide/), run the following commands:
 
 1. In the `identity-style-guide` directory, run `npm link`. This will create a symlink that will make changes to this repo accessible in `identity-site`.

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,9 +1,0 @@
-# Use this file to override default site configuration during local development.
-
-languages:
-  - en
-  # - es
-  # - fr
-
-sass:
-  style: expanded

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,0 +1,9 @@
+# Use this file to override default site configuration during local development.
+
+languages:
+  - en
+  # - es
+  # - fr
+
+sass:
+  style: expanded


### PR DESCRIPTION
**Why**: As a developer, I don't want to sit and wait 10 seconds after I save a file to be able to see my changes reflected on the page, so that I'm not wasting time.

**Implementation Notes:**

Disabling translations is a bit of a sticky point, considering that...

- We will want to be able to test non-English locales
- The current language picker does not render correctly / at all when only English is available as an option

The proposed implementation seeks to try to find a balance here where the options are still included in the base configuration as an example of how to re-enable them for development testing.

_Ideally_, the build performance of multiple languages would be fast enough that we could always build all locales.