### PR TITLE
Replace custom mobile menu overlay with USWDS

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -64,5 +64,5 @@
       {% endfor %}
     </ul>
   </nav>
-  <div class="modal-bg"></div>
 </div>
+<div class="usa-overlay"></div>

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -138,6 +138,15 @@
   }
 }
 
+.usa-overlay {
+  // TODO: Reconcile / backport to Login Design System.
+  background: color("base-darker");
+
+  &.is-visible {
+    opacity: opacity(50);
+  }
+}
+
 nav .usa-search {
   position: absolute;
   right: 1.75rem;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -136,15 +136,6 @@
       margin: 0;
     }
   }
-
-  .usa-header .usa-nav.is-visible + .modal-bg {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100vh;
-    background: rgba(0, 0, 0, 0.5);
-  }
 }
 
 nav .usa-search {
@@ -159,7 +150,7 @@ nav .usa-search {
   }
 }
 
-.usa-search--small [type=submit], 
+.usa-search--small [type=submit],
 .usa-search--small .usa-search__submit {
   background-image: none;
   width: 5rem;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -53,10 +53,6 @@ $(function () {
     }
   });
 
-  $('.modal-bg').on('click touch', function (event) {
-    $('.usa-menu-btn').click();
-  });
-
   // Smooth scroll
 
   $('a[href^="#"]').on('click', function (event) {


### PR DESCRIPTION
**Why**:

- Less code to maintain
- Rely on mature, battle-tested offering from USWDS
- Fix issue where text and images appeared vibrantly through the overlay
- Fix issue where background color was incorrect per design:
  - Was 50% `#000000`
  - Should be 50% `#454545` ("base-darker").

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/102801374-25ddc600-4383-11eb-84b5-ecd7f82f525d.png)|![after](https://user-images.githubusercontent.com/1779930/102801729-9be22d00-4383-11eb-98f9-ae63104aaf37.png)
