### PR TITLE
Assign sidenav ARIA attributes as trimmed strings

### DIFF
--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -17,7 +17,7 @@
         {{ site["translations"][site.lang]["help_subpages"][subpage] }}
       </li>
 
-      <div aria-hidden={{ is_initially_hidden }}>
+      <div aria-hidden="{{ is_initially_hidden }}">
         <ul class="usa-sidenav__sublist">
           {% for question in related_questions %}
           {% if question.url == page.url %}

--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -5,14 +5,13 @@
       {% for subpage in site.help_pages %}
       {% assign subpage_slug = subpage | slugify %}
       {% assign related_questions = site.help | where_exp: "item", "item.url contains subpage_slug" | sort: 'order' %}
-      {% capture is_initially_expanded %}
-      {% if page.url contains subpage_slug %}true{% else %}false
+      {% if page.url contains subpage_slug %}
+        {% assign is_initially_expanded = 'true' %}
+        {% assign is_initially_hidden = 'false' %}
+      {% else %}
+        {% assign is_initially_expanded = 'false' %}
+        {% assign is_initially_hidden = 'true' %}
       {% endif %}
-      {% endcapture %}
-      {% capture is_initially_hidden %}
-      {% if page.url contains subpage_slug %}false{% else %}true
-      {% endif %}
-      {% endcapture %}
       <li class="usa-sidenav__item usa-parent {% if page.url contains subpage_slug %}usa-current{% else %} {% endif %}"
         aria-expanded="{{ is_initially_expanded }}">
         {{ site["translations"][site.lang]["help_subpages"][subpage] }}


### PR DESCRIPTION
**Why**: Avoid invalid values being assigned as attributes, where capture will capture with whitespace included.

Discovered via accessibility tests in #469 (currently working to resolve issues toward merging):

```
Expected the HTML found at $('.usa-parent') to have no violations:

    <li class="usa-sidenav__item usa-parent usa-current" aria-expanded="
          true
          ">
            Trouble signing in?
          </li>

    Received:

    "ARIA attributes must conform to valid values (aria-valid-attr-value)"

    Fix all of the following:
      Invalid ARIA attribute value: aria-expanded="
            true
            "

    You can find more information on this issue here: 
    https://dequeuniversity.com/rules/axe/4.1/aria-valid-attr-value?application=axe-puppeteer
```