### PR TITLE
Add accessible label for help side navigation

### DIFF
--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -1,6 +1,6 @@
 <div class="grid-col grid-col-3 grid-offset-2">
   {% include search.html size="small" %}
-  <nav class="margin-y-4 sidenav">
+  <nav class="margin-y-4 sidenav" aria-label="{% t accessible_labels.secondary_navigation %}">
     <ul class="usa-accordion usa-sidenav">
       {% for subpage in site.help_pages %}
       {% assign subpage_slug = subpage | slugify %}


### PR DESCRIPTION
**Why**: So that users who navigate by page landmarks can distinguish between multiple landmarks of the same role.

Discovered via accessibility tests in #469 (currently working to resolve issues toward merging):

```
    Expected the HTML found at $('.margin-y-4') to have no violations:

    <nav class="margin-y-4 sidenav">

    Received:

    "Ensures landmarks are unique (landmark-unique)"

    Fix any of the following:
      The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable

    You can find more information on this issue here: 
    https://dequeuniversity.com/rules/axe/4.1/landmark-unique?application=axe-puppeteer
```

Reuses implementation from Contact Us page navigation (#486).