### PR TITLE
LG-3493: Update `usa-banner` with the new USWDS component

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -14,7 +14,7 @@ banner:
     learn: Learn how to create an account
     tagline: Your one account for government
   text:
-    official: An official website of the United States government.
+    official: An official website of the United States government
     how: Here’s how you know
     gov_heading: The .gov means it’s official.
     gov_description: Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -16,10 +16,10 @@ banner:
   text:
     official: An official website of the United States government
     how: Here’s how you know
-    gov_heading: The .gov means it’s official.
-    gov_description: Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
-    secure_heading: The site is secure.
-    secure_description: "The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely."
+    gov_heading: Official websites use .gov
+    gov_description: A <strong>.gov</strong> website belongs to an official government organization in the United States.
+    secure_heading: Secure .gov websites use HTTPS
+    secure_description: "A <strong>lock</strong> or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites."
 contact_page:
   support_request_form:
     agencies:

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -16,10 +16,10 @@ banner:
   text:
     official: Un sitio web oficial del gobierno de los Estados Unidos
     how: Así es como sabes
-    gov_heading: La .gov significa que es oficial.
-    gov_description: Los sitios web del gobierno federal a menudo terminan en .gov o .mil. Antes de compartir información confidencial, asegúrese de estar en un sitio del gobierno federal.
-    secure_heading: El sitio es seguro.
-    secure_description: "El <strong>https://</strong> garantiza que se está conectando al sitio web oficial y que toda la información que proporciona está encriptada y transmitida de forma segura."
+    gov_heading: Los sitios web oficiales usan .gov
+    gov_description: Un sitio web .gov pertenece a una organización oficial del Gobierno de Estados Unidos.
+    secure_heading: os sitios web seguros .gov usan HTTPS
+    secure_description: "Un <strong>candado</strong> o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros."
 contact_page:
   support_request_form:
     agencies:

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -14,7 +14,7 @@ banner:
     learn: Aprender a crear una cuenta
     tagline: Su única cuenta para el gobierno
   text:
-    official: Un sitio web oficial del gobierno de los Estados Unidos.
+    official: Un sitio web oficial del gobierno de los Estados Unidos
     how: Así es como sabes
     gov_heading: La .gov significa que es oficial.
     gov_description: Los sitios web del gobierno federal a menudo terminan en .gov o .mil. Antes de compartir información confidencial, asegúrese de estar en un sitio del gobierno federal.

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -17,10 +17,10 @@ banner:
   text:
     official: Un site officiel du gouvernement américain
     how: Voici comment vous savez
-    gov_heading: Le .gov signifie que c'est officiel.
-    gov_description: Les sites Web du gouvernement fédéral se terminent souvent par .gov ou .mil. Avant de partager des informations sensibles, assurez-vous que vous êtes sur un site du gouvernement fédéral.
-    secure_heading: Le site est sécurisé.
-    secure_description: "Le <strong>https://</strong> garantit que vous vous connectez au site officiel et que toutes les informations que vous fournissez sont cryptées et transmises en toute sécurité."
+    gov_heading: Les sites Web officiels utilisent .gov
+    gov_description: Un site Web .gov appartient à une organisation gouvernementale officielle des États-Unis.
+    secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
+    secure_description: "Un <strong>verrou</strong> ou <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez des informations sensibles uniquement sur des sites Web officiels et sécurisés."
 contact_page:
   support_request_form:
     agencies:

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -15,7 +15,7 @@ banner:
     learn: Apprendre à créer un compte
     tagline: Votre seul compte pour le gouvernement
   text:
-    official: Un site officiel du gouvernement américain.
+    official: Un site officiel du gouvernement américain
     how: Voici comment vous savez
     gov_heading: Le .gov signifie que c'est officiel.
     gov_description: Les sites Web du gouvernement fédéral se terminent souvent par .gov ou .mil. Avant de partager des informations sensibles, assurez-vous que vous êtes sur un site du gouvernement fédéral.

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -7,13 +7,11 @@
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">{% t banner.text.official %}</p>
-          <p class="usa-banner__header-action" aria-hidden="true">
-            {% t banner.text.how %}
-          </p>
-        </div>
+          <p class="usa-banner__header-action" aria-hidden="true">{% t banner.text.how %}</p>
+        </div>        
         <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
           <span class="usa-banner__button-text">{% t banner.text.how %}</span>
-        </button>
+        </button>   
       </div>
     </div>
     <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -37,6 +37,6 @@
           </div>
         </div>
       </div>
-    </div>
+    </header>
   </div>
 </section>

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -11,7 +11,7 @@
         </div>        
         <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
           <span class="usa-banner__button-text">{% t banner.text.how %}</span>
-        </button>   
+        </button>
       </div>
     </div>
     <div class="usa-banner__content usa-accordion__content container" id="gov-banner">

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -3,11 +3,7 @@
     <div class="usa-banner__header">
       <div class="usa-banner__inner container">
         <div class="grid-col-auto">
-          <img
-            class="usa-banner__header-flag"
-            src="{{ site.baseurl }}/assets/img/us-flag.png"
-            alt="U.S. flag"
-          />
+          <img class="usa-banner__header-flag" src="{{ site.baseurl }}/assets/img/us-flag.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">{% t banner.text.official %}</p>
@@ -15,27 +11,15 @@
             {% t banner.text.how %}
           </p>
         </div>
-        <button
-          class="usa-accordion__button usa-banner__button"
-          aria-expanded="false"
-          aria-controls="gov-banner"
-        >
+        <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
           <span class="usa-banner__button-text">{% t banner.text.how %}</span>
         </button>
       </div>
     </div>
-    <div
-      class="usa-banner__content usa-accordion__content"
-      id="gov-banner"
-      hidden
-    >
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img
-            class="usa-banner__icon usa-media-block__img"
-            src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg"
-            alt="Dot gov"
-          />
+          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
           <p class="usa-media-block__body">
             <strong>{% t banner.text.gov_heading %}</strong>
             <br />
@@ -43,11 +27,7 @@
           </p>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img
-            class="usa-banner__icon usa-media-block__img"
-            src="{{ site.baseurl }}/assets/img/icon-https.svg"
-            alt="Https"
-          />
+          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="Https">
           <p class="usa-media-block__body">
             <strong>{% t banner.text.secure_heading %}</strong>
             <br />

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -17,7 +17,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
           <p class="usa-media-block__body">
             <strong>{% t banner.text.gov_heading %}</strong>
             <br />

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -14,25 +14,31 @@
         </button>   
       </div>
     </div>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
+    
+    <div class="usa-banner__content usa-accordion__content container" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
-          <p class="usa-media-block__body">
-            <strong>{% t banner.text.gov_heading %}</strong>
-            <br />
-            {% t banner.text.gov_description %}
-          </p>
+          <div class="usa-media-block__body">
+            <p>
+              <strong>{% t banner.text.gov_heading %}</strong>
+              <br />
+              {% t banner.text.gov_description %}
+            </p>
+          </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="Https">
-          <p class="usa-media-block__body">
-            <strong>{% t banner.text.secure_heading %}</strong>
-            <br />
-            {% t banner.text.secure_description %}
-          </p>
+          <div class="usa-media-block__body">
+            <p>
+              <strong>{% t banner.text.secure_heading %}</strong>
+              <br />
+              {% t banner.text.secure_description %}
+            </p>
+          </div>
         </div>
       </div>
     </div>
+
   </div>
 </section>

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,6 +1,6 @@
 <section class="usa-banner" aria-label="Official government website">
   <div class="usa-accordion">
-    <div class="usa-banner__header">
+    <header class="usa-banner__header">
       <div class="usa-banner__inner container">
         <div class="grid-col-auto">
           <img class="usa-banner__header-flag" src="{{ site.baseurl }}/assets/img/us-flag.png" alt="U.S. flag">

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -14,7 +14,6 @@
         </button>   
       </div>
     </div>
-    
     <div class="usa-banner__content usa-accordion__content container" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
@@ -28,7 +27,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="Https">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
             <p>
               <strong>{% t banner.text.secure_heading %}</strong>
@@ -39,6 +38,5 @@
         </div>
       </div>
     </div>
-
   </div>
 </section>

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -8,7 +8,7 @@
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">{% t banner.text.official %}</p>
           <p class="usa-banner__header-action" aria-hidden="true">{% t banner.text.how %}</p>
-        </div>        
+        </div>
         <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
           <span class="usa-banner__button-text">{% t banner.text.how %}</span>
         </button>

--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -1,4 +1,5 @@
 $white: #fff;
+$grey-lightest: color("base-lightest");
 $grey: color("base");
 $grey-darker: color("base-darker");
 $black: color("base-darkest");

--- a/_sass/components/_usa-banner.scss
+++ b/_sass/components/_usa-banner.scss
@@ -1,0 +1,3 @@
+.usa-banner {
+  background-color: $grey-lightest;
+}

--- a/_sass/components/_usa-banner.scss
+++ b/_sass/components/_usa-banner.scss
@@ -1,3 +1,0 @@
-.usa-banner {
-  background-color: $grey-lightest;
-}

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -22,4 +22,3 @@
 @import "layout";
 @import "box-info";
 @import "card";
-@import "usa-banner";

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -22,3 +22,4 @@
 @import "layout";
 @import "box-info";
 @import "card";
+@import "usa-banner";


### PR DESCRIPTION
**Why:** Update text to reflect the latest USWDS banner component per [guidance](https://designsystem.digital.gov/whats-new/updates/2020/09/08/Improvements-banner/).

👉🏼  [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-3493-uswds-usa-banner/)

**How:** This will be merged into `demo`

1. Update text for all EN/ES/FR languages. (Note: ES text is pulled from USWDS while FR is pulled from Google Translate)
2. Correct alignment (See before/after screenshots below)
3. Add `role="img"` and `aria-hidden="true"` (Also, making `alt=""` blank since the graphics are decorative)

**Questions:**

1. **French translation:** How should we get a better French translation? Currently, it's from Google Translate
2. **Lock pad icon:** In the [USWDS component](https://designsystem.digital.gov/components/banner/), there is a lock pad SVG in "A lock (🔒 ) ..." however, my build is timing out when trying to add the snippet below in the yml files. Any ideas on how to resolve? For now, I've omitted the lock pad icon.
 
```
(<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>)
```

---
## Screenshots: Before and after

### Desktop - Before
![desktop-before](https://user-images.githubusercontent.com/6327082/102949753-a2110000-448e-11eb-8ef8-ce8ea5569771.png)

### Desktop - After
![desktop-after](https://user-images.githubusercontent.com/6327082/102949751-a1786980-448e-11eb-8ff5-aceb888599d2.png)

### Mobile - Before (left) and after (right)
![mobile-before-and-after](https://user-images.githubusercontent.com/6327082/102949870-f0260380-448e-11eb-979d-45816f793376.png)


