### PR TITLE
Restore (and improve) honeypot field to demo site contact form

### DIFF
--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -344,6 +344,8 @@
     const noAnswer = document.querySelector("#contact-us-form #information");
     if (noAnswer) {
       noAnswer.removeAttribute("required");
+      noAnswer.tabIndex = -1;
+      noAnswer.parentElement.setAttribute('aria-hidden', 'true');
       noAnswer.parentElement.style.position = "absolute";
       noAnswer.parentElement.style.left = "-7000px";
     }
@@ -437,6 +439,21 @@
     maxlength="32000"
     class="usa-textarea"
   ></textarea>
+  <!-- END: Description -->
+
+  <!-- START: Description -->
+  <div>
+    <label class="usa-label" for="information">Additional Info:</label>
+    <textarea
+      id="information"
+      name="00Nt0000000FsTK"
+      required
+      rows="1"
+      cols="50"
+      maxlength="80"
+      class="usa-textarea"
+    ></textarea>
+  </div>
   <!-- END: Description -->
 
   <!-- START: reCAPTCHA -->


### PR DESCRIPTION
**Why**: Mistakenly removed in #486 as it was not understood to be a honeypot field. Honeypots are a hardening measure to prevent spam from some spam bots.

See: https://help.salesforce.com/articleView?id=pardot_forms_add_honeypot.htm
See: #338

Improvements have been made to address usability and accessibility issues:

- The field is no longer focusable by users navigating the page using a keyboard
- The field is no longer exposed to assistive technology