### PR TITLE
Render help sidenav subnavigation as nested list

### DIFF
--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -12,13 +12,14 @@
         {% assign is_initially_expanded = 'false' %}
         {% assign is_initially_hidden = 'true' %}
       {% endif %}
-      <li class="usa-sidenav__item usa-parent {% if page.url contains subpage_slug %}usa-current{% else %} {% endif %}"
-        aria-expanded="{{ is_initially_expanded }}">
-        {{ site["translations"][site.lang]["help_subpages"][subpage] }}
-      </li>
-
-      <div aria-hidden="{{ is_initially_hidden }}">
-        <ul class="usa-sidenav__sublist">
+      <li class="usa-sidenav__item usa-parent" aria-expanded="{{ is_initially_expanded }}">
+        <a
+          href="{{ subpage | prepend: '/help/' | prepend: site.baseurl }}"
+          class="{% if page.url contains subpage_slug %}usa-current{% endif %}"
+        >
+          {{ site["translations"][site.lang]["help_subpages"][subpage] }}
+        </a>
+        <ul class="usa-sidenav__sublist" aria-hidden="{{ is_initially_hidden }}">
           {% for question in related_questions %}
           {% if question.url == page.url %}
           {% assign _index = forloop.index | modulo:7 %}
@@ -34,7 +35,7 @@
           </li>
           {% endfor %}
         </ul>
-      </div>
+      </li>
       {% endfor %}
     </ul>
   </nav>

--- a/_sass/components/_nav-sidenav.scss
+++ b/_sass/components/_nav-sidenav.scss
@@ -7,22 +7,20 @@
       font-size: ($base-font-size - 2);
       border-top: none;
       border-bottom: none;
-      
+
       a {
         padding-top: $container-spacing-sm;
         padding-bottom: $container-spacing-sm;
-      }
-
-      &:last-of-type {
-        border-bottom: 1px solid $blue-light;
       }
     }
 
     .usa-parent {
       font-size: $base-font-size;
       border-top: 1px solid $blue-light;
-      border-bottom: 1px solid $blue-light;
-      padding: $container-spacing-sm;
+
+      &:last-child {
+        border-bottom: 1px solid $blue-light;
+      }
     }
 
     .active {


### PR DESCRIPTION
**Why**: `div` or `ul` are not valid child elements of `ul`.

Reference: https://designsystem.digital.gov/components/sidenav/

Discovered via accessibility tests in #469 (currently working to resolve issues toward merging):

```
    Expected the HTML found at $('.usa-sidenav') to have no violations:

    <ul class="usa-accordion usa-sidenav">

    Received:

    "<ul> and <ol> must only directly contain <li>, <script> or <template> elements (list)"

    Fix all of the following:
      List element has direct children that are not allowed inside <li> elements

    You can find more information on this issue here:
    https://dequeuniversity.com/rules/axe/4.1/list?application=axe-puppeteer
```