### PR TITLE
Redirect security top-level URL to policy subpage

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -175,8 +175,8 @@ help_pages:
     overview: |-
       # Trouble signing in?
       Forgot your password? Locked out of your account? We'll help you resolve account access issues.
-      
-      ## Common troubleshooting topics 
+
+      ## Common troubleshooting topics
         * [How to sign in to login.gov](site.baseurl/help/trouble-signing-in/how-to-sign-in)
         * [Forgot your password](site.baseurl/help/trouble-signing-in/forgot-your-password)
         * [Locked out of login.gov account](site.baseurl/help/trouble-signing-in/locked-out-of-login)
@@ -189,7 +189,7 @@ help_pages:
       Every time you sign in to your login.gov account, you will need your email address, your password, and access to one of the two-factor authentication methods you set up.
 
       Follow these steps to sign in to login.gov.
-        1. Enter your email address at [https://secure.login.gov](https://secure.login.gov). 
+        1. Enter your email address at [https://secure.login.gov](https://secure.login.gov).
         1. Enter your password.
         1. Click the “Sign in” button.
         1. Authenticate using one of the methods you set up. Options include:
@@ -199,8 +199,8 @@ help_pages:
             1. Entering a backup code
             1. Using your federal government employee or military ID (PIV or CAC)
         1. You will then be taken to your login.gov account page.
-      
-      ## Related articles 
+
+      ## Related articles
       [Authentication options](#)
       [Verify your identity](#)
     forgot-your-password: |-
@@ -210,11 +210,11 @@ help_pages:
       1. Select the “Forgot your password?” link near the bottom of the page.
       1. On the next screen, enter your email address.
       1. Click the “Continue” button.
-      1. Check your email for a message from login.gov. 
+      1. Check your email for a message from login.gov.
       1. Click the “Reset your password” button in the message. This will take you back to the login.gov website.
       1. Enter your new password.
-          Passwords must be at least 12 characters. That's it! There are no other restrictions. You can even use more than one word with spaces to get to 12 characters. Try using a phrase or a series of words that only you recognize.  
-          
+          Passwords must be at least 12 characters. That's it! There are no other restrictions. You can even use more than one word with spaces to get to 12 characters. Try using a phrase or a series of words that only you recognize.
+
           Your login.gov password should be different from passwords you use for other accounts such as your bank account or email. Using the same password for many accounts makes identity theft easier.
       1. Click the “Change password” button.
     locked-out-of-login: |-
@@ -529,9 +529,6 @@ meta:
     security:
       title: "Privacy & security: Our Security Practices"
       description: Learn the various methods we use to protect this U.S. government service and your data, and to ensure the service remains available to all users.
-  security:
-    title: Security
-    description: Learn how login.gov keeps personal information private.
   what-is-login:
     title: What is login.gov?
     description: A summary of what login.gov is and the service it provides.

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -150,7 +150,7 @@ help_pages:
     overview: |-
       # ¿Problemas al iniciar sesión?
       ¿Olvidaste tu contraseña? ¿Bloqueado tu cuenta? Lo ayudaremos a resolver problemas de acceso a la cuenta.
-      ## Problemas comunes en la solución de problemas 
+      ## Problemas comunes en la solución de problemas
         * [Cómo acceder a login.gov](site.baseurl/help/trouble-signing-in/how-to-sign-in)
         * [Olvidó su contraseña](site.baseurl/help/trouble-signing-in/forgot-your-password)
         * [Bloqueada en la cuenta de login.gov](site.baseurl/help/trouble-signing-in/locked-out-of-login)
@@ -161,9 +161,9 @@ help_pages:
     how-to-sign-in: |-
       # Cómo iniciar sesión en login.gov
       Cada vez que inicie sesión en su cuenta de login.gov, necesitará su dirección de correo electrónico, su contraseña y contar con alguno de los métodos de autenticación en dos pasos que haya configurado.
-      
+
       Siga estos pasos para iniciar sesión en login.gov:
-      
+
       1. Ingrese su dirección de correo electrónico en [https://secure.login.gov](https://secure.login.gov).
       1. Ingrese su contraseña.
       1. Haga clic en el botón "Iniciar sesión".
@@ -187,9 +187,9 @@ help_pages:
       1. Haga clic en el botón "Continuar".
       1. Busque el mensaje de login.gov en su correo electrónico.
       1. Haga clic en el botón "Restablecer su contraseña" en el mensaje, el cual lo redirigirá a la página web de login.gov.
-      1. Introduzca su nueva contraseña.   
+      1. Introduzca su nueva contraseña.
           Las contraseñas deben incluir al menos 12 caracteres. ¡Eso es todo! No hay restricciones adicionales. Incluso puede utilizar más de una palabra con espacios para completar los 12 caracteres. Intente usar una frase o una serie de palabras que solo usted pueda reconocer.
-          
+
           Su contraseña de login.gov debe ser diferente de las contraseñas que usa para otras cuentas, como su cuenta bancaria o correo electrónico. Utilizar la misma contraseña en múltiples cuentas facilita el robo de identidad.
       1. Haga clic en el botón "Modificar contraseña".
     locked-out-of-login: |-
@@ -475,10 +475,6 @@ meta:
     security:
       title: "Privacidad y seguridad: nuestras prácticas de seguridad"
       description: Conozca los diversos métodos que utilizamos para proteger este servicio del gobierno de EE. UU. Y sus datos, y para garantizar que el servicio permanezca disponible para todos los usuarios.
-  security:
-    description: Descubra cómo login.gov mantiene la privacidad de la información
-      personal.
-    title: Seguridad
   what-is-login:
     description: Un resumen de lo que es login.gov y el servicio que brinda.
     title: ¿Qué es login.gov

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -162,7 +162,7 @@ help_page:
 help_pages:
   get-started:
     overview: |-
-      
+
       You can add or delete email addresses from your login.gov Your Account page.
 
       __To add an email address__ to your account, use the steps below:
@@ -183,7 +183,7 @@ help_pages:
     overview: |-
       # Des problèmes de connexion?
       Vous avez oublié votre mot de passe? Verrouillé votre compte? Nous vous aiderons à résoudre les problèmes d’accès au compte.
-      
+
       ## Sujets de dépannage courants
       * [Comment se connecter à login.gov](site.baseurl/help/trouble-signing-in/how-to-sign-in)
       * [Mot de passe oublié](site.baseurl/help/trouble-signing-in/forgot-your-password)
@@ -194,10 +194,10 @@ help_pages:
       * [Problèmes de réinitialisation du mot de passe](site.baseurl/help/trouble-signing-in/password-reset-issues)
     how-to-sign-in: |-
       # Comment se connecter à login.gov
-      Chaque fois que vous vous connecterez à votre compte login.gov, vous aurez besoin de votre adresse électronique, de votre mot de passe et d'un accès à l'une des méthodes d'authentification à deux facteurs que vous aurez mises en place. 
-      
+      Chaque fois que vous vous connecterez à votre compte login.gov, vous aurez besoin de votre adresse électronique, de votre mot de passe et d'un accès à l'une des méthodes d'authentification à deux facteurs que vous aurez mises en place.
+
       Suivez ces étapes pour vous connecter à login.gov.
-      1. Saisissez votre adresse électronique à l'adresse [https://secure.login.gov](https://secure.login.gov). 
+      1. Saisissez votre adresse électronique à l'adresse [https://secure.login.gov](https://secure.login.gov).
       1. Saisissez votre mot de passe.
       1. Cliquez sur le bouton « Se connecter ».
       1. Authentifiez-vous à l'aide d'une des méthodes que vous avez mises en place. Les options comprennent :
@@ -208,22 +208,22 @@ help_pages:
           1. Utilisation de votre carte d'employé du gouvernement fédéral ou de votre carte d'identité militaire (PIV ou CAC))
       1. Vous serez ensuite dirigé vers la page de votre compte login.gov.
 
-      ## Articles connexes 
+      ## Articles connexes
       [Options d'authentification](#)
       [Vérifiez votre identité](#)
     forgot-your-password: |-
       # Mot de passe oublié
       Suivez ces étapes pour réinitialiser votre mot de passe.
-      
+
       1. Rendez-vous sur [https://secure.login.gov/](https://secure.login.gov/)
       1. Sélectionnez le lien « Oublié votre mot de passe » en bas de la page.
       1. Sur l’écran suivant, entrez votre adresse électronique.
       1. Cliquez sur le bouton « Continuer ».
-      1. Vérifiez si votre adresse électronique comporte un message de login.gov. 
+      1. Vérifiez si votre adresse électronique comporte un message de login.gov.
       1. Cliquez sur le bouton « Réinitialiser votre mot de passe » contenu dans le message. Cela vous ramènera au site internet login.gov.
       1. Entrez votre nouveau mot de passe.
-          Les mots de passe doivent comporter au moins 12 caractères. C’est tout! Il n’y a pas d’autres restrictions. Vous pouvez même utiliser plus d’un mot avec des espaces afin d’arriver à obtenir 12 caractères. Essayez d’utiliser une phrase ou une série de mots que vous êtes le seul à reconnaître. 
-          
+          Les mots de passe doivent comporter au moins 12 caractères. C’est tout! Il n’y a pas d’autres restrictions. Vous pouvez même utiliser plus d’un mot avec des espaces afin d’arriver à obtenir 12 caractères. Essayez d’utiliser une phrase ou une série de mots que vous êtes le seul à reconnaître.
+
           Votre mot de passe login.gov doit être différent des mots de passe que vous utilisez pour d’autres comptes tels que votre compte bancaire ou votre courrier électronique. L’utilisation du même mot de passe pour de nombreux comptes facilite l’usurpation d’identité.
       1. Cliquez sur le bouton « Changer le mot de passe ».
     locked-out-of-login: |-
@@ -548,10 +548,6 @@ meta:
     security:
       title: "Confidentialité et sécurité: nos pratiques de sécurité"
       description: Découvrez les différentes méthodes que nous utilisons pour protéger ce service du gouvernement américain et vos données, et pour garantir que le service reste disponible pour tous les utilisateurs.
-  security:
-    description: Découvrez comment login.gov protège la confidentialité des renseignements
-      personnels.
-    title: Sécurité
   what-is-login:
     description: Un résumé de ce qu'est login.gov et du service qu'il fournit.
     title: Qu'est-ce que login.gov?

--- a/_pages/policy/security.md
+++ b/_pages/policy/security.md
@@ -3,6 +3,7 @@ layout: policy
 title: meta.privacy_security_policy.security.title
 description: meta.privacy_security_policy.security.description
 permalink: /policy/our-security-practices/
+redirect_from: /security/
 index: 3
 ---
 

--- a/_pages/security.md
+++ b/_pages/security.md
@@ -1,5 +1,0 @@
----
-title: meta.security.title
-permalink: /security/
-description: meta.security.description
----


### PR DESCRIPTION
**Why**: Previously there was a "Security" standalone top-level page. This appears to have been removed in the redesign. The changes here propose to redirect the page to /policy/security instead.

Related Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1609258661431900

Discovered via accessibility tests in #469 (currently working to resolve issues toward merging):

```
    Expected the HTML found at $('html') to have no violations:

    <html lang="en">

    Received:

    "Page must contain a level-one heading (page-has-heading-one)"

    Fix all of the following:
      Page must have a level-one heading

    You can find more information on this issue here:
    https://dequeuniversity.com/rules/axe/4.1/page-has-heading-one?application=axe-puppeteer
```