### PR TITLE
Revert banner header to div

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,6 +1,6 @@
 <section class="usa-banner" aria-label="Official government website">
   <div class="usa-accordion">
-    <header class="usa-banner__header">
+    <div class="usa-banner__header">
       <div class="usa-banner__inner container">
         <div class="grid-col-auto">
           <img class="usa-banner__header-flag" src="{{ site.baseurl }}/assets/img/us-flag.png" alt="U.S. flag">
@@ -37,6 +37,6 @@
           </div>
         </div>
       </div>
-    </header>
+    </div>
   </div>
 </section>

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -1,7 +1,4 @@
 header {
-  .flex-auto {
-    flex: 1 1 auto;
-  }
   &.intro {
     border-bottom: $border-style;
     > p {


### PR DESCRIPTION
**Why**: Resolve invalid nested header while assuring only single banner on page.

See: https://github.com/18F/identity-site/pull/494/files#r549832708

>Only discovered after rebasing the merged changes into my end-to-end testing branch at #469: This is a bit of a problem in that the banner partial is nested into a `<header>` element:
>
>https://github.com/18F/identity-site/blob/42f73f91352d230db072d128835bcff611975b70/_layouts/main.html#L9-L15
>
>Nesting `<header>` is not valid HTML ([see validator result](https://validator.w3.org/nu/?doc=https%3A%2F%2Fdemo.login.gov%2Fwho-uses-login%2F)).
>
>It's also an interesting challenge to resolve this while respecting a few other guidelines around landmarks:
>
>- https://dequeuniversity.com/rules/axe/4.1/region
>- https://dequeuniversity.com/rules/axe/4.1/landmark-no-duplicate-banner
>
>I'm still poking at solutions, but at the moment I'm inclined to suggest we keep the main layout `<header>` wrapping this banner and the rest of the header (navigation, etc), then revert this change back to a `<div>`.

Also includes a quick clean-up for a style referencing non-existent `flex-auto` class, discovered in the course of testing possible regressions.