### PR TITLE
Extract "One Account" banner to adjacent aside top-level element

### DIFF
--- a/_includes/one_account_banner.html
+++ b/_includes/one_account_banner.html
@@ -1,4 +1,21 @@
-<aside class="banner tagline-content">
-  <header class="tagline">{% t banner.one-account-for-govt.tagline %}</header>
-  {{ include.content }}
+{% if page.url == '/create-an-account/' %}
+  {% assign link_class = 'learn-account-creation usa-button usa-button--big' %}
+  {% assign link_url = 'https://secure.login.gov/sign_up/enter_email' %}
+  {% capture link_content %}{% t banner.one-account-for-govt.create %}{% endcapture %}
+{% else %}
+  {% assign link_class = 'learn-account-creation one-account-banner__link' %}
+  {% assign link_url = create_account_path %}
+  {% capture link_content %}{% t banner.one-account-for-govt.learn %}{% endcapture %}
+{% endif %}
+<aside class="one-account-banner">
+  <div class="one-account-banner__banner">
+    <header class="one-account-banner__tagline">
+      {% t banner.one-account-for-govt.tagline %}
+    </header>
+    <p>
+      <a class="{{ link_class }}" href="{{ link_url }}">
+        {{ link_content }}
+      </a>
+    </p>
+  </div>
 </aside>

--- a/_includes/one_account_banner.html
+++ b/_includes/one_account_banner.html
@@ -4,7 +4,7 @@
   {% capture link_content %}{% t banner.one-account-for-govt.create %}{% endcapture %}
 {% else %}
   {% assign link_class = 'learn-account-creation one-account-banner__link' %}
-  {% assign link_url = create_account_path %}
+  {% assign link_url = '/create-an-account/' | prepend: site.baseurl %}
   {% capture link_content %}{% t banner.one-account-for-govt.learn %}{% endcapture %}
 {% endif %}
 <aside class="one-account-banner">

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -14,4 +14,7 @@ body:
   {% include header.html %}
 </header>
 <main id="main-content">{{ content }}</main>
+{% if page.one_account_banner == true %}
+  {% include one_account_banner.html %}
+{% endif %}
 {% include footer.html %}

--- a/_pages/create_an_account.md
+++ b/_pages/create_an_account.md
@@ -4,6 +4,7 @@ description: meta.create-an-account.description
 permalink: /create-an-account/
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
+one_account_banner: true
 ---
 
 {% capture heading %}
@@ -44,10 +45,3 @@ image: /assets/img/login-gov-600x314.png
     </div>
   </div>
 </div>
-
-{% capture banner_content %}
-
-<p><a class="learn-account-creation usa-button usa-button--big"
-    href="https://secure.login.gov/sign_up/enter_email">{% t banner.one-account-for-govt.create %}</a></p>
-{% endcapture %}
-{% include one_account_banner.html content=banner_content %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -3,6 +3,7 @@ title: meta.home.title
 permalink: /
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
+one_account_banner: true
 ---
 
 {% capture heading %}
@@ -29,9 +30,3 @@ image: /assets/img/login-gov-600x314.png
     </div>
   </div>
 </article>
-
-{% capture banner_content %}
-
-  <p><a class="learn-account-creation link" href="{{ site.baseurl }}/create-an-account">{% t banner.one-account-for-govt.learn %}</a></p>
-{% endcapture %}
-{% include one_account_banner.html content=banner_content %}

--- a/_pages/who_uses_login.md
+++ b/_pages/who_uses_login.md
@@ -4,6 +4,7 @@ description: meta.who-uses-login.description
 permalink: /who-uses-login/
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
+one_account_banner: true
 ---
 
 {% capture heading %}
@@ -31,9 +32,3 @@ image: /assets/img/login-gov-600x314.png
     </div>
   </div>
 </div>
-
-{% capture banner_content %}
-
-  <p><a class="learn-account-creation link" href="{{ site.baseurl }}/create-an-account">{% t banner.one-account-for-govt.learn %}</a></p>
-{% endcapture %}
-{% include one_account_banner.html content=banner_content %}

--- a/_sass/components/_one-account-banner.scss
+++ b/_sass/components/_one-account-banner.scss
@@ -1,32 +1,35 @@
-.tagline-content {
-  @include lg-grid(false, true);
-  background-color: $navy;
-  margin-bottom: ($container-spacing * 2);
+.one-account-banner {
+  background-color: $white;
   display: none;
+  padding-bottom: ($container-spacing * 2);
+
+  @include at-media("tablet") {
+    display: block;
+  }
 }
 
-@include at-media("tablet") {
-  .tagline-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-image: url(../img/who-uses-login/who-uses-illo-header/who-uses-illo-header.png);
-    background-position: -21.5rem -6rem;
-    background-repeat: no-repeat;
-    background-size: 70%;
-    border-radius: 1rem;
-    height: 11rem;
+.one-account-banner__banner {
+  @include lg-grid(false, true);
+  align-items: center;
+  background-color: $navy;
+  background-image: url(../img/who-uses-login/who-uses-illo-header/who-uses-illo-header.png);
+  background-position: -21.5rem -6rem;
+  background-repeat: no-repeat;
+  background-size: 70%;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  height: 11rem;
+  justify-content: center;
+}
 
-    .tagline {
-      color: white;
-      font-size: 1.35rem;
-      font-weight: bold;
-    }
+.one-account-banner__tagline {
+  color: $white;
+  font-size: 1.35rem;
+  font-weight: bold;
+}
 
-    .link {
-      font-size: 1.2rem;
-      color: white;
-    }
-  }
+.one-account-banner__link {
+  font-size: 1.2rem;
+  color: $white;
 }


### PR DESCRIPTION
**Why**: Resolves issue where aside contained in main element is flagged as violation of guidelines.

Rather than change element from `aside` to `div`, treat as proper accompanying complementary content to main content by extracting as sibling to `main`, aligning with intent of the guideline.

Discovered via accessibility tests in #469 (currently working to resolve issues toward merging):

```
    Expected the HTML found at $('.banner') to have no violations:

    <aside class="banner tagline-content">
      <header class="tagline">Your one account for government</header>

    <p><a class="learn-account-creation usa-button usa-button--big" href="https://secure.login.gov/sign_up/enter_email">Create an account</a></p>

    </aside>

    Received:

    "Aside must not be contained in another landmark (landmark-complementary-is-top-level)"

    Fix any of the following:
      The complementary landmark is contained in another landmark.

    You can find more information on this issue here:
    https://dequeuniversity.com/rules/axe/4.1/landmark-complementary-is-top-level?application=axe-puppeteer
```