### PR TITLE
Remove unused scrollspy attributes

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,10 +9,7 @@
     {% include google_recaptcha.html %}
   </head>
 
-  <body class="{{ layout.body.class }} {{ page.body.class }} site lang-{{ site.lang }}"
-    {% if layout.body.spy %}data-spy="{{ layout.body.spy }}" {% endif %}
-    {% if layout.body.target %}data-target="{{ layout.body.target }}" {% endif %}
-    {% if layout.body.offset %}data-offset="{{ layout.body.offset }}" {% endif %}>
+  <body class="{{ layout.body.class }} {{ page.body.class }} site lang-{{ site.lang }}">
     {{ content }}
     {% include scripts.html %}
   </body>

--- a/_layouts/help_landing.html
+++ b/_layouts/help_landing.html
@@ -2,9 +2,6 @@
 layout: base
 body:
   class: "help-page"
-  spy: "scroll"
-  target: "#pb-nav--side-cntnr"
-  offset: "48"
 ---
 <header>
   {% include wip.html %}

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -1,10 +1,5 @@
 ---
 layout: base
-body:
-  class: ""
-  spy: "scroll"
-  target: "#pb-nav--side-cntnr"
-  offset: "48"
 ---
 <header>
   {% include wip.html %}


### PR DESCRIPTION
**Why**: Cleanup. Lingering remnants of removed Bootstrap scrollspy behavior.

See: 6c97a118044299e3427edfb002b66e5ac816aa7b