### PR TITLE
LG-3980: Add translations for Contact Us page

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -22,31 +22,32 @@ banner:
     secure_description: "A <strong>lock</strong> or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites."
 contact_page:
   content:
-    intro:
-      - text: |-
-          Login.gov is here to help you create, sign in and manage your login.gov account.
+    intro: |-
+      Login.gov is here to help you create, sign in and manage your login.gov account.
 
-          As a security measure, we do not have access to delete your login.gov account or change your password on your behalf.
+      As a security measure, we do not have access to delete your login.gov account or change your password on your behalf.
 
-          Our operating hours are Monday - Friday, 8:00 a.m. - 8:00 p.m. ET. Please note that it could take up to two business days for our customer support agents to respond to your question. Thank you for your patience.
+      Our operating hours are Monday - Friday, 8:00 a.m. - 8:00 p.m. ET. Please note that it could take up to two business days for our customer support agents to respond to your question. Thank you for your patience.
 
-          If you need assistance with your login.gov account, check out our help center articles for help with common issues.
+      If you need assistance with your login.gov account, check out our help center articles for help with common issues.
 
-          - [I can’t sign in to my account](site.baseurl/help/trouble-signing-in/overview)
-          - [I need help verifying my identity](site.baseurl/help/verify-your-identity/overview)
-          - [I need to change my information or manage my account](site.baseurl/help/manage-your-account/overview)
-          - [Browse more help articles](site.baseurl/help)
-          {: .help-question-list}
-      - heading: Do you have a question about your agency account?
-        text: |-
-          Login.gov is a sign in service to access government agency websites. If you have questions about the agency website, which may include questions about your application status, membership, eligibility, benefits or other specific concerns related to your account with that government agency, please contact that agency.
-    footer:
-      - heading: Partner with login.gov
-        text: |-
-          Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) or contact us at [partnerships@login.gov](mailto:partnerships@loging.gov).
-      - heading: Report an issue
-        text: |-
-          If you want to report an issue, please review our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/) and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
+      - [I can’t sign in to my account](site.baseurl/help/trouble-signing-in/overview)
+      - [I need help verifying my identity](site.baseurl/help/verify-your-identity/overview)
+      - [I need to change my information or manage my account](site.baseurl/help/manage-your-account/overview)
+      - [Browse more help articles](site.baseurl/help)
+      {: .help-question-list}
+
+      ## Do you have a question about your agency account?
+
+      Login.gov is a sign in service to access government agency websites. If you have questions about the agency website, which may include questions about your application status, membership, eligibility, benefits or other specific concerns related to your account with that government agency, please contact that agency.
+    footer: |-
+      ## Partner with login.gov
+
+      Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) or contact us at [partnerships@login.gov](mailto:partnerships@loging.gov).
+
+      ## Report an issue
+
+      If you want to report an issue, please review our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/) and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs
@@ -700,8 +701,15 @@ nav:
   anchor_to_top: Back to top
   about_us: About us
   become_a_partner: Become a partner
-  contact: Contact
-  contact_us: Contact us
+  contact_us:
+    title: Contact us
+    sections:
+      - name: Do you have a question about your agency account?
+        url: /contact/#do-you-have-a-question-about-your-agency-account
+      - name: Partner with login.gov
+        url: /contact/#partner-with-logingov
+      - name: Report an issue
+        url: /contact/#report-an-issue
   contact_login_gov: Contact Login.gov
   create_an_account: Create an account
   developer_guide: Developer guide
@@ -1202,9 +1210,6 @@ why-login-gov_page:
       li_4: The convenience of identity verification from home
       li_5: Simple tools to manage and update their account
       li_6: Descriptive help content, and a staffed contact center for user support
-contact:
-  hero:
-    heading: Contact us
 create-an-account:
   hero:
     heading: Create an account

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -22,29 +22,31 @@ banner:
     secure_description: "A <strong>lock</strong> or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites."
 contact_page:
   content:
-    - text: |-
-        Login.gov is here to help you create, sign in and manage your login.gov account.
+    intro:
+      - text: |-
+          Login.gov is here to help you create, sign in and manage your login.gov account.
 
-        As a security measure, we do not have access to delete your login.gov account or change your password on your behalf.
+          As a security measure, we do not have access to delete your login.gov account or change your password on your behalf.
 
-        Our operating hours are Monday - Friday, 8:00 a.m. - 8:00 p.m. ET. Please note that it could take up to two business days for our customer support agents to respond to your question. Thank you for your patience.
+          Our operating hours are Monday - Friday, 8:00 a.m. - 8:00 p.m. ET. Please note that it could take up to two business days for our customer support agents to respond to your question. Thank you for your patience.
 
-        If you need assistance with your login.gov account, check out our help center articles for help with common issues.
+          If you need assistance with your login.gov account, check out our help center articles for help with common issues.
 
-        - [I can’t sign in to my account](site.baseurl/help/trouble-signing-in/overview)
-        - [I need help verifying my identity](site.baseurl/help/verify-your-identity/overview)
-        - [I need to change my information or manage my account](site.baseurl/help/manage-your-account/overview)
-        - [Browse more help articles](site.baseurl/help)
-        {: .help-question-list}
-    - heading: Do you have a question about your agency account?
-      text: |-
-        Login.gov is a sign in service to access government agency websites. If you have questions about the agency website, which may include questions about your application status, membership, eligibility, benefits or other specific concerns related to your account with that government agency, please contact that agency.
-    - heading: Partner with login.gov
-      text: |-
-        Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) or contact us at [partnerships@login.gov](mailto:partnerships@loging.gov).
-    - heading: Report an issue
-      text: |-
-        If you want to report an issue, please review our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/) and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
+          - [I can’t sign in to my account](site.baseurl/help/trouble-signing-in/overview)
+          - [I need help verifying my identity](site.baseurl/help/verify-your-identity/overview)
+          - [I need to change my information or manage my account](site.baseurl/help/manage-your-account/overview)
+          - [Browse more help articles](site.baseurl/help)
+          {: .help-question-list}
+      - heading: Do you have a question about your agency account?
+        text: |-
+          Login.gov is a sign in service to access government agency websites. If you have questions about the agency website, which may include questions about your application status, membership, eligibility, benefits or other specific concerns related to your account with that government agency, please contact that agency.
+    footer:
+      - heading: Partner with login.gov
+        text: |-
+          Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) or contact us at [partnerships@login.gov](mailto:partnerships@loging.gov).
+      - heading: Report an issue
+        text: |-
+          If you want to report an issue, please review our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/) and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -21,6 +21,30 @@ banner:
     secure_heading: Secure .gov websites use HTTPS
     secure_description: "A <strong>lock</strong> or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites."
 contact_page:
+  content:
+    - text: |-
+        Login.gov is here to help you create, sign in and manage your login.gov account.
+
+        As a security measure, we do not have access to delete your login.gov account or change your password on your behalf.
+
+        Our operating hours are Monday - Friday, 8:00 a.m. - 8:00 p.m. ET. Please note that it could take up to two business days for our customer support agents to respond to your question. Thank you for your patience.
+
+        If you need assistance with your login.gov account, check out our help center articles for help with common issues.
+
+        - [I can’t sign in to my account](site.baseurl/help/trouble-signing-in/overview)
+        - [I need help verifying my identity](site.baseurl/help/verify-your-identity/overview)
+        - [I need to change my information or manage my account](site.baseurl/help/manage-your-account/overview)
+        - [Browse more help articles](site.baseurl/help)
+        {: .help-question-list}
+    - heading: Do you have a question about your agency account?
+      text: |-
+        Login.gov is a sign in service to access government agency websites. If you have questions about the agency website, which may include questions about your application status, membership, eligibility, benefits or other specific concerns related to your account with that government agency, please contact that agency.
+    - heading: Partner with login.gov
+      text: |-
+        Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) or contact us at [partnerships@login.gov](mailto:partnerships@loging.gov).
+    - heading: Report an issue
+      text: |-
+        If you want to report an issue, please review our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/) and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs
@@ -39,7 +63,9 @@ contact_page:
     errors:
       captcha_required: You must complete the spam prevention challenge.
     form_helpers:
-      select: "- Select -"
+      select_topic: "- Select a topic -"
+      select_issue: "- Select a specific issue -"
+      select_agency: "- Select an agency application -"
     labels:
       agency_application: Agency application
       agency_application_all: All Applications
@@ -100,8 +126,6 @@ contact_page:
       unwanted_otp: I am receiving security codes from login.gov that I didn't request
       verify_identity_error: I got a failure trying to verify my identity
       wrong_account_update: Wrong account update
-    alert_banner:
-    alert_banner_link:
     topics:
       account_linking: Linking your login.gov account to your profile
       changing_settings: Changing your login.gov information
@@ -167,7 +191,7 @@ help:
     forgot-your-email-address: Forgot your email address
     security-code-issues: Security code issues
     password-reset-issues: Password reset issues
-  manage-your-account: 
+  manage-your-account:
     overview: Overview
     change-your-password: Change your password
     delete-your-account: Delete your account
@@ -306,69 +330,69 @@ help_pages:
     change-your-password: |-
       # Change your password
       Follow these steps to change your login.gov password.
-      
-      1. Enter your email address at [https://secure.login.gov](https://secure.login.gov). 
+
+      1. Enter your email address at [https://secure.login.gov](https://secure.login.gov).
       1. Enter your password.
-      1. Click the “Sign in” button. 
-      1. Authenticate using one of the methods you set up. You will then be taken to your account page. 
+      1. Click the “Sign in” button.
+      1. Authenticate using one of the methods you set up. You will then be taken to your account page.
       1. Select “Edit” next to the password field.
       1. Enter your new password.
-          Passwords must be at least 12 characters. That's it! There are no other restrictions. You can even use more than one word with spaces to get to 12 characters. Try using a phrase or a series of words that only you recognize.  
-          
+          Passwords must be at least 12 characters. That's it! There are no other restrictions. You can even use more than one word with spaces to get to 12 characters. Try using a phrase or a series of words that only you recognize.
+
           Your login.gov password should be different from passwords you use for other accounts such as your bank account or email. Using the same password for many accounts makes identity theft easier.
       1. Click the “Change password” button.
     delete-your-account: |-
       # Delete your account
-      
+
       __There might be different reasons why you need to delete an account:__
-      
-      * You realize you have multiple accounts using different email addresses and you want to have one account  
-      * You are locked out of your account and have lost access to your authentication methods 
-      * You no longer need a login.gov account 
-      
+
+      * You realize you have multiple accounts using different email addresses and you want to have one account
+      * You are locked out of your account and have lost access to your authentication methods
+      * You no longer need a login.gov account
+
       __If you delete your account:__
       * We'll delete your email address, password, and phone number
-      * You won't be able to securely access partner agencies who require a login.gov account 
-      
+      * You won't be able to securely access partner agencies who require a login.gov account
+
       After you delete your account, you will not be able to sign in to the government applications that you normally use your login.gov account to access. You will not lose your information in those applications, but you will need a new login.gov account to be able to sign in to those applications.
-      
+
       __If you do have access to your authentication methods, follow these steps to delete your account:__
-      
-      1. Enter your email address at [https://secure.login.gov](https://secure.login.gov). 
+
+      1. Enter your email address at [https://secure.login.gov](https://secure.login.gov).
       1. Enter your password.
-      1. Click the “Sign in” button. 
+      1. Click the “Sign in” button.
       1. Authenticate using one of the methods you set up.
-      1. On your account page, select “Delete account” from the menu on the left side of the page  
+      1. On your account page, select “Delete account” from the menu on the left side of the page
       1. Select “Delete account” from the “Your account” menu.
       1. Enter your password to confirm that you want to delete your account.
-      
-      __Follow these steps to delete your account if you do NOT have access to your authentication methods:__ 
-      
-      As a security measure, Login.gov requires a two-step process and 24 hour waiting period if you have lost access to your authentication methods and need to delete your account. 
-      
+
+      __Follow these steps to delete your account if you do NOT have access to your authentication methods:__
+
+      As a security measure, Login.gov requires a two-step process and 24 hour waiting period if you have lost access to your authentication methods and need to delete your account.
+
       1. Go to your government application sign in page or to [https://secure.login.gov/](https://secure.login.gov/)
       1. Sign in with your email and password
       1. On the authentication page (enter your security, app, or backup code; PIV/CAC card; or security key), click on “Choose another security option”
       1. Scroll to the bottom and click on the “deleting your account” link
       1. Read through all the information carefully to make sure deleting your account is your only option
       1. Click on “Yes, continue deletion”
-      1. You will receive two emails. 
-          1. The first email confirms we received your request. Your account is not yet deleted. Additional action is required. 
-          1. The second email is sent to you 24 hours later. Follow the directions in that email to complete the deletion process. 
+      1. You will receive two emails.
+          1. The first email confirms we received your request. Your account is not yet deleted. Additional action is required.
+          1. The second email is sent to you 24 hours later. Follow the directions in that email to complete the deletion process.
     change-your-phone-number: |-
       # Change the phone number associated with your account
       Follow these steps to change the phone number associated with your account.
-      
-      1. Enter your email address at [https://secure.login.gov](https://secure.login.gov). 
+
+      1. Enter your email address at [https://secure.login.gov](https://secure.login.gov).
       1. Enter your password.
-      1. Click the “Sign in” button. 
-      1. Authenticate using one of the methods you set up. You will then be taken to your account page. 
-      1. Select “Add phone” from the “Your account” page. 
+      1. Click the “Sign in” button.
+      1. Authenticate using one of the methods you set up. You will then be taken to your account page.
+      1. Select “Add phone” from the “Your account” page.
       1. Enter the new phone number.
       1. Check the “Default phone number” box if you want this number to be your default.
       1. Click “Continue” and follow the prompts to confirm your changes.
-      
-      ## Related article 
+
+      ## Related article
       [Phone or authentication methods not available](#)
   verify-your-identity:
     overview: |-

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -22,29 +22,31 @@ banner:
     secure_description: "Un <strong>candado</strong> o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros."
 contact_page:
   content:
-    - text: |-
-        Login.gov está aquí para ayudarlo a crear y administrar su cuenta de login.gov e iniciar sesión en la misma.
+    intro:
+      - text: |-
+          Login.gov está aquí para ayudarlo a crear y administrar su cuenta de login.gov e iniciar sesión en la misma.
 
-        Como medida de seguridad, no tenemos acceso para eliminar su cuenta de login.gov o cambiar su contraseña por usted.
+          Como medida de seguridad, no tenemos acceso para eliminar su cuenta de login.gov o cambiar su contraseña por usted.
 
-        Nuestro horario de atención es de lunes a viernes de 8:00 a. m. a 8:00 p. m. hora del este. Por favor, tenga en cuenta que nuestros agentes de atención al cliente pueden tardar hasta dos días hábiles en responder a su pregunta. Gracias por su paciencia.
+          Nuestro horario de atención es de lunes a viernes de 8:00 a. m. a 8:00 p. m. hora del este. Por favor, tenga en cuenta que nuestros agentes de atención al cliente pueden tardar hasta dos días hábiles en responder a su pregunta. Gracias por su paciencia.
 
-        Si necesita ayuda con su cuenta de login.gov, consulte los artículos de nuestro centro de ayuda para obtener asistencia sobre problemas comunes.
+          Si necesita ayuda con su cuenta de login.gov, consulte los artículos de nuestro centro de ayuda para obtener asistencia sobre problemas comunes.
 
-        - [No puedo iniciar sesión en mi cuenta](site.baseurl/help/trouble-signing-in/overview)
-        - [Necesito ayuda para verificar mi identidad](site.baseurl/help/verify-your-identity/overview)
-        - [Necesito cambiar mi información o administrar mi cuenta](site.baseurl/help/manage-your-account/overview)
-        - [Explorar más artículos de ayuda](site.baseurl/help)
-        {: .help-question-list}
-    - heading: ¿Tiene alguna pregunta sobre la cuenta de su agencia?
-      text: |-
-        Login.gov es un servicio de inicio de sesión que permite acceder a los sitios web de las agencias gubernamentales. Si tiene preguntas sobre el sitio web de la agencia, las cuales pueden incluir dudas sobre el estado de su solicitud, la membresía, la elegibilidad, los beneficios u otras cuestiones específicas relacionadas con la cuenta que tiene en dicha agencia gubernamental, comuníquese con esa agencia.
-    - heading: Asociarse con login.gov
-      text: |-
-        ¿Está interesado en utilizar login.gov en su agencia? [Visite el sitio web para socios](https://partners.login.gov/) o contáctenos a través de [partnership@login.gov](mailto:partnerships@loging.gov).
-    - heading: Reportar un problema
-      text: |-
-        Si desea reportar un problema, revise nuestra [política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/) y contáctenos utilizando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
+          - [No puedo iniciar sesión en mi cuenta](site.baseurl/help/trouble-signing-in/overview)
+          - [Necesito ayuda para verificar mi identidad](site.baseurl/help/verify-your-identity/overview)
+          - [Necesito cambiar mi información o administrar mi cuenta](site.baseurl/help/manage-your-account/overview)
+          - [Explorar más artículos de ayuda](site.baseurl/help)
+          {: .help-question-list}
+      - heading: ¿Tiene alguna pregunta sobre la cuenta de su agencia?
+        text: |-
+          Login.gov es un servicio de inicio de sesión que permite acceder a los sitios web de las agencias gubernamentales. Si tiene preguntas sobre el sitio web de la agencia, las cuales pueden incluir dudas sobre el estado de su solicitud, la membresía, la elegibilidad, los beneficios u otras cuestiones específicas relacionadas con la cuenta que tiene en dicha agencia gubernamental, comuníquese con esa agencia.
+    footer:
+      - heading: Asociarse con login.gov
+        text: |-
+          ¿Está interesado en utilizar login.gov en su agencia? [Visite el sitio web para socios](https://partners.login.gov/) o contáctenos a través de [partnership@login.gov](mailto:partnerships@loging.gov).
+      - heading: Reportar un problema
+        text: |-
+          Si desea reportar un problema, revise nuestra [política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/) y contáctenos utilizando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -21,6 +21,30 @@ banner:
     secure_heading: os sitios web seguros .gov usan HTTPS
     secure_description: "Un <strong>candado</strong> o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros."
 contact_page:
+  content:
+    - text: |-
+        Login.gov está aquí para ayudarlo a crear y administrar su cuenta de login.gov e iniciar sesión en la misma.
+
+        Como medida de seguridad, no tenemos acceso para eliminar su cuenta de login.gov o cambiar su contraseña por usted.
+
+        Nuestro horario de atención es de lunes a viernes de 8:00 a. m. a 8:00 p. m. hora del este. Por favor, tenga en cuenta que nuestros agentes de atención al cliente pueden tardar hasta dos días hábiles en responder a su pregunta. Gracias por su paciencia.
+
+        Si necesita ayuda con su cuenta de login.gov, consulte los artículos de nuestro centro de ayuda para obtener asistencia sobre problemas comunes.
+
+        - [No puedo iniciar sesión en mi cuenta](site.baseurl/help/trouble-signing-in/overview)
+        - [Necesito ayuda para verificar mi identidad](site.baseurl/help/verify-your-identity/overview)
+        - [Necesito cambiar mi información o administrar mi cuenta](site.baseurl/help/manage-your-account/overview)
+        - [Explorar más artículos de ayuda](site.baseurl/help)
+        {: .help-question-list}
+    - heading: ¿Tiene alguna pregunta sobre la cuenta de su agencia?
+      text: |-
+        Login.gov es un servicio de inicio de sesión que permite acceder a los sitios web de las agencias gubernamentales. Si tiene preguntas sobre el sitio web de la agencia, las cuales pueden incluir dudas sobre el estado de su solicitud, la membresía, la elegibilidad, los beneficios u otras cuestiones específicas relacionadas con la cuenta que tiene en dicha agencia gubernamental, comuníquese con esa agencia.
+    - heading: Asociarse con login.gov
+      text: |-
+        ¿Está interesado en utilizar login.gov en su agencia? [Visite el sitio web para socios](https://partners.login.gov/) o contáctenos a través de [partnership@login.gov](mailto:partnerships@loging.gov).
+    - heading: Reportar un problema
+      text: |-
+        Si desea reportar un problema, revise nuestra [política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/) y contáctenos utilizando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs
@@ -37,22 +61,24 @@ contact_page:
       usajobs: USAJOBS
       veterans_affairs: Veterans Affairs
     errors:
-      captcha_required: You must complete the spam prevention challenge. # TODO: Translate
+      captcha_required: Debe completar el desafío de prevención de spam. # TODO: Translate
     form_helpers:
-      select: "- Select -" # TODO: Translate
+      select_topic: "- Seleccione un tema -"
+      select_issue: "- Seleccione un problema específico -"
+      select_agency: "- Seleccione una solicitud de agencia -"
     labels:
       agency_application: Aplicación de agencia
       agency_application_all: Todas las aplicaciones
       agency_application_common: Aplicaciones comunes
       agency_application_other: Otras aplicaciones
-      description: Provide more detail about your question # TODO: Translate
+      description: Proporcione más detalles sobre su pregunta # TODO: Translate
       email: Correo electrónico
       first_name: Nombre
       last_name: Apellido
       pii_warning: "**No** incluya información sensible o de identificación en esta sección, como su nombre completo, fecha de nacimiento o número de seguro social."
-      subtopic: Issue # TODO: Translate
-      topic: Topic # TODO: Translate
-    reset: Clear form # TODO: Translate
+      subtopic: Problema
+      topic: Tema
+    reset: Forma clara # TODO: Translate
     submit: Enviar
     subtopics:
       add_family_member: ¿Cómo agrego un familiar a mi cuenta login.gov?
@@ -92,8 +118,6 @@ contact_page:
       site_navigation: Navegación en la página web
       unwanted_otp: Múltiples pedidos de pago
       wrong_account_update: Actualización de la cuenta errónea
-    alert_banner:
-    alert_banner_link:
     topics:
       account_linking: Vinculación de cuenta
       changing_settings: Cambiando ajustes
@@ -125,7 +149,7 @@ help:
     forgot-your-email-address: Olvidó su dirección de correo electrónico
     security-code-issues: Problemas con el código de seguridad
     password-reset-issues: Problemas con el restablecimiento de la contraseña
-  manage-your-account: 
+  manage-your-account:
     overview: Visión general
     change-your-password: Cambiar su contraseña
     delete-your-account: Eliminar su cuenta
@@ -249,22 +273,22 @@ help_pages:
     change-your-password: |-
       # Cambie su contraseña
       Siga estos pasos para cambiar su contraseña en login.gov.
-      
-      1. Ingrese su correo electrónico en https://secure.login.gov. 
+
+      1. Ingrese su correo electrónico en https://secure.login.gov.
       1. Ingrese su contraseña.
-      1. Haga clic en el botón «Iniciar sesión». 
-      1. Autentíquese mediante uno de los métodos configurados. Será redirigido a la página de su cuenta. 
+      1. Haga clic en el botón «Iniciar sesión».
+      1. Autentíquese mediante uno de los métodos configurados. Será redirigido a la página de su cuenta.
       1. Seleccione «Editar» junto al campo de la contraseña.
       1. Ingrese su nueva contraseña.
-          La contraseña debe tener al menos 12 caracteres. ¡Eso es todo! No hay otras restricciones. Incluso puede usar más de una palabra con espacios para alcanzar los 12 caracteres. Pruebe usar una frase o una serie de palabras que solo usted reconozca.  
-          
+          La contraseña debe tener al menos 12 caracteres. ¡Eso es todo! No hay otras restricciones. Incluso puede usar más de una palabra con espacios para alcanzar los 12 caracteres. Pruebe usar una frase o una serie de palabras que solo usted reconozca.
+
           Su contraseña de login.gov debe ser diferente de las contraseñas que utiliza en otras cuentas, como su cuenta bancaria o correo electrónico. Usar la misma contraseña en muchas cuentas facilita el robo de identidad.
       1. Haga clic en el botón «Cambiar contraseña».
     delete-your-account: |-
       # Eliminar su cuenta
       __Quizá tenga que eliminar una cuenta por diferentes razones:__
-      * Advierte que tiene varias cuentas con diferentes direcciones de correo electrónico y quiere tener una sola cuenta  
-      * Se ha bloqueado su cuenta y ha perdido el acceso a sus métodos de autenticación 
+      * Advierte que tiene varias cuentas con diferentes direcciones de correo electrónico y quiere tener una sola cuenta
+      * Se ha bloqueado su cuenta y ha perdido el acceso a sus métodos de autenticación
       * Ya no necesita una cuenta de login.gov
 
       __Si elimina su cuenta:__
@@ -272,38 +296,38 @@ help_pages:
       * Usted no podrá acceder de forma segura a las agencias asociadas que requieren una cuenta de login.gov
 
       Después de que elimine su cuenta, no podrá acceder a las aplicaciones gubernamentales a las que suele acceder con su cuenta de login.gov. Sin embargo, no perderá su información en esas aplicaciones, pero necesitará una cuenta nueva de login.gov para poder iniciar sesión en esas aplicaciones.
-      
+
       __Si tiene acceso a sus métodos de autenticación, realice los siguientes pasos para eliminar su cuenta:__
-      
+
       1. Escriba su dirección de correo electrónico en [https://secure.login.gov](https://secure.login.gov).
       1. Introduzca su contraseña.
       1. Haga clic en el botón "Iniciar sesión".
       1. Valide su información con alguno de los métodos que ha establecido.
-      1. En la página de su cuenta, seleccione "Eliminar cuenta" en el menú a la izquierda de la página  
+      1. En la página de su cuenta, seleccione "Eliminar cuenta" en el menú a la izquierda de la página
       1. Seleccione "Eliminar cuenta en el menú "Su cuenta".
       1. Escriba su contraseña para confirmar que desea eliminar su cuenta.
 
       __Si NO cuenta con los métodos de autenticación siga los siguientes pasos para eliminar la cuenta:__
       Por motivos de seguridad, Login.gov requiere un procedimiento de dos pasos y de un período de espera de 24 horas en caso de que haya perdido el acceso a sus métodos de autenticación y tenga que eliminar su cuenta.
-      
+
       1. Visite la página de inicio de sesión de su solicitud de gobierno o en [https://secure.login.gov/](https://secure.login.gov/)
       1. Ingrese con su correo electrónico y contraseña
       1. En la página de autenticación (escriba su código de seguridad, aplicación o copia de seguridad; tarjeta PIV/CAC; o clave de seguridad), haga clic en "Elegir otra opción de seguridad"
       1. Vaya a la parte inferior y haga clic en el enlace "eliminar su cuenta".
       1. Lea atentamente toda la información y asegúrese de que eliminar su cuenta es su única opción.
       1. Haga clic en "Sí, continuar con la eliminación"
-      1. Usted recibirá dos correos electrónicos. 
-          1. El primer correo electrónico confirma que hemos recibido su solicitud. Su cuenta aún no ha sido eliminada. Es necesario tomar medidas adicionales. 
-          1. La segunda carta le será enviada 24 horas más tarde. Observa las instrucciones de ese correo electrónico para completar el proceso de eliminación. 
+      1. Usted recibirá dos correos electrónicos.
+          1. El primer correo electrónico confirma que hemos recibido su solicitud. Su cuenta aún no ha sido eliminada. Es necesario tomar medidas adicionales.
+          1. La segunda carta le será enviada 24 horas más tarde. Observa las instrucciones de ese correo electrónico para completar el proceso de eliminación.
   verify-your-identity:
     overview: |-
       # Verificación de identidad
 
-      Algunos organismos participantes requieren que usted complete un proceso de verificación de identidad. La verificación de la identidad es un proceso en el que usted demuestra que es realmente usted y no alguien que pretende ser usted. 
+      Algunos organismos participantes requieren que usted complete un proceso de verificación de identidad. La verificación de la identidad es un proceso en el que usted demuestra que es realmente usted y no alguien que pretende ser usted.
 
-      Solo es necesario verificar su identidad una vez para su cuenta de login.gov. Después de verificar su identidad con login.gov para una solicitud gubernamental, no es necesario hacerlo nuevamente para otras solicitudes gubernamentales que utilicen login.gov y requieran verificación de identidad. 
+      Solo es necesario verificar su identidad una vez para su cuenta de login.gov. Después de verificar su identidad con login.gov para una solicitud gubernamental, no es necesario hacerlo nuevamente para otras solicitudes gubernamentales que utilicen login.gov y requieran verificación de identidad.
 
-      Utilice esta sección de ayuda para conocer el proceso y los requisitos relacionados con la verificación de la identidad. 
+      Utilice esta sección de ayuda para conocer el proceso y los requisitos relacionados con la verificación de la identidad.
 
       ## Solución de problemas frecuentes
        * [Cómo verificar su identidad](site.baseurl/help/verify-your-identity/how-to-verify-your-identity/)
@@ -581,7 +605,7 @@ meta:
     description: Las agencias gubernamentales de EE. UU. Pueden aprovechar la plataforma de autenticación y verificación de identidad de login.gov. Obtenga más información sobre las ofertas y oportunidades de login.gov.
     title: Por qué login.gov
 nav:
-  accessibility: 
+  accessibility:
     title: Accesibilidad
     sections:
       - name: Nuestro compromiso
@@ -591,7 +615,7 @@ nav:
       - name: Evaluación
         url: /accessibility/#evaluación
       - name: Limitaciones conocidas
-        url: /accessibility/#políticas-de-accesibilidad  
+        url: /accessibility/#políticas-de-accesibilidad
   about_us: Sobre nosotros
   anchor_to_top: Volver arriba
   become_a_partner: Convertirse en un compañero
@@ -624,7 +648,7 @@ nav:
       - name: Nuestras prácticas de seguridad
         url: /policy/our-security-practices/
       - name: Términos y condiciones de mensajería
-        url: /policy/messaging-terms-and-conditions/  
+        url: /policy/messaging-terms-and-conditions/
   principles: Principios
   privacy_&_security: Privacidad y seguridad
   security: Seguridad

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -22,31 +22,32 @@ banner:
     secure_description: "Un <strong>candado</strong> o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros."
 contact_page:
   content:
-    intro:
-      - text: |-
-          Login.gov está aquí para ayudarlo a crear y administrar su cuenta de login.gov e iniciar sesión en la misma.
+    intro: |-
+      Login.gov está aquí para ayudarlo a crear y administrar su cuenta de login.gov e iniciar sesión en la misma.
 
-          Como medida de seguridad, no tenemos acceso para eliminar su cuenta de login.gov o cambiar su contraseña por usted.
+      Como medida de seguridad, no tenemos acceso para eliminar su cuenta de login.gov o cambiar su contraseña por usted.
 
-          Nuestro horario de atención es de lunes a viernes de 8:00 a. m. a 8:00 p. m. hora del este. Por favor, tenga en cuenta que nuestros agentes de atención al cliente pueden tardar hasta dos días hábiles en responder a su pregunta. Gracias por su paciencia.
+      Nuestro horario de atención es de lunes a viernes de 8:00 a. m. a 8:00 p. m. hora del este. Por favor, tenga en cuenta que nuestros agentes de atención al cliente pueden tardar hasta dos días hábiles en responder a su pregunta. Gracias por su paciencia.
 
-          Si necesita ayuda con su cuenta de login.gov, consulte los artículos de nuestro centro de ayuda para obtener asistencia sobre problemas comunes.
+      Si necesita ayuda con su cuenta de login.gov, consulte los artículos de nuestro centro de ayuda para obtener asistencia sobre problemas comunes.
 
-          - [No puedo iniciar sesión en mi cuenta](site.baseurl/help/trouble-signing-in/overview)
-          - [Necesito ayuda para verificar mi identidad](site.baseurl/help/verify-your-identity/overview)
-          - [Necesito cambiar mi información o administrar mi cuenta](site.baseurl/help/manage-your-account/overview)
-          - [Explorar más artículos de ayuda](site.baseurl/help)
-          {: .help-question-list}
-      - heading: ¿Tiene alguna pregunta sobre la cuenta de su agencia?
-        text: |-
-          Login.gov es un servicio de inicio de sesión que permite acceder a los sitios web de las agencias gubernamentales. Si tiene preguntas sobre el sitio web de la agencia, las cuales pueden incluir dudas sobre el estado de su solicitud, la membresía, la elegibilidad, los beneficios u otras cuestiones específicas relacionadas con la cuenta que tiene en dicha agencia gubernamental, comuníquese con esa agencia.
-    footer:
-      - heading: Asociarse con login.gov
-        text: |-
-          ¿Está interesado en utilizar login.gov en su agencia? [Visite el sitio web para socios](https://partners.login.gov/) o contáctenos a través de [partnership@login.gov](mailto:partnerships@loging.gov).
-      - heading: Reportar un problema
-        text: |-
-          Si desea reportar un problema, revise nuestra [política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/) y contáctenos utilizando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
+      - [No puedo iniciar sesión en mi cuenta](site.baseurl/help/trouble-signing-in/overview)
+      - [Necesito ayuda para verificar mi identidad](site.baseurl/help/verify-your-identity/overview)
+      - [Necesito cambiar mi información o administrar mi cuenta](site.baseurl/help/manage-your-account/overview)
+      - [Explorar más artículos de ayuda](site.baseurl/help)
+      {: .help-question-list}
+
+      ## ¿Tiene alguna pregunta sobre la cuenta de su agencia?
+
+      Login.gov es un servicio de inicio de sesión que permite acceder a los sitios web de las agencias gubernamentales. Si tiene preguntas sobre el sitio web de la agencia, las cuales pueden incluir dudas sobre el estado de su solicitud, la membresía, la elegibilidad, los beneficios u otras cuestiones específicas relacionadas con la cuenta que tiene en dicha agencia gubernamental, comuníquese con esa agencia.
+    footer: |-
+      ## Asociarse con login.gov
+
+      ¿Está interesado en utilizar login.gov en su agencia? [Visite el sitio web para socios](https://partners.login.gov/) o contáctenos a través de [partnership@login.gov](mailto:partnerships@loging.gov).
+
+      ## Reportar un problema
+
+      Si desea reportar un problema, revise nuestra [política de divulgación de vulnerabilidades](https://18f.gsa.gov/vulnerability-disclosure-policy/) y contáctenos utilizando nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs
@@ -621,8 +622,15 @@ nav:
   about_us: Sobre nosotros
   anchor_to_top: Volver arriba
   become_a_partner: Convertirse en un compañero
-  contact: Contacto
-  contact_us: Contacta con nosotros
+  contact_us:
+    title: Contacta con nosotros
+    sections:
+      - name: ¿Tiene alguna pregunta sobre la cuenta de su agencia?
+        url: /contact/#tiene-alguna-pregunta-sobre-la-cuenta-de-su-agencia
+      - name: Asociarse con login.gov
+        url: /contact/#asociarse-con-logingov
+      - name: Reportar un problema
+        url: /contact/#reportar-un-problema
   contact_login_gov: Póngase en contacto con Login.gov
   create_an_account: Crea una cuenta
   developer_guide: Guía para desarrolladores

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -61,7 +61,7 @@ contact_page:
       usajobs: USAJOBS
       veterans_affairs: Veterans Affairs
     errors:
-      captcha_required: Debe completar el desafío de prevención de spam. # TODO: Translate
+      captcha_required: Debes superar el desafío de prevención de spam.
     form_helpers:
       select_topic: "- Seleccione un tema -"
       select_issue: "- Seleccione un problema específico -"
@@ -71,14 +71,14 @@ contact_page:
       agency_application_all: Todas las aplicaciones
       agency_application_common: Aplicaciones comunes
       agency_application_other: Otras aplicaciones
-      description: Proporcione más detalles sobre su pregunta # TODO: Translate
+      description: Proporciona más detalles acerca de tu pregunta
       email: Correo electrónico
       first_name: Nombre
       last_name: Apellido
       pii_warning: "**No** incluya información sensible o de identificación en esta sección, como su nombre completo, fecha de nacimiento o número de seguro social."
       subtopic: Problema
       topic: Tema
-    reset: Forma clara # TODO: Translate
+    reset: Limpiar formulario
     submit: Enviar
     subtopics:
       add_family_member: ¿Cómo agrego un familiar a mi cuenta login.gov?

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -23,29 +23,31 @@ banner:
     secure_description: "Un <strong>verrou</strong> ou <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez des informations sensibles uniquement sur des sites Web officiels et sécurisés."
 contact_page:
   content:
-    - text: |-
-        Login.gov est là pour vous aider à créer, à vous connecter et à gérer votre compte login.gov.
+    intro:
+      - text: |-
+          Login.gov est là pour vous aider à créer, à vous connecter et à gérer votre compte login.gov.
 
-        Par mesure de sécurité, nous n’avons pas la possibilité de supprimer votre compte login.gov ou de changer votre mot de passe en votre nom.
+          Par mesure de sécurité, nous n’avons pas la possibilité de supprimer votre compte login.gov ou de changer votre mot de passe en votre nom.
 
-        Nos heures d’ouverture sont du lundi au vendredi, de 8 h à 20 h (heure de l’Est). Veuillez noter que nos agents du service clientèle peuvent prendre jusqu’à deux jours ouvrables pour répondre à votre question. Nous vous remercions de votre patience.
+          Nos heures d’ouverture sont du lundi au vendredi, de 8 h à 20 h (heure de l’Est). Veuillez noter que nos agents du service clientèle peuvent prendre jusqu’à deux jours ouvrables pour répondre à votre question. Nous vous remercions de votre patience.
 
-        Si vous avez besoin d’aide pour votre compte login.gov, consultez les articles de notre centre d’aide pour obtenir de l’aide sur des questions courantes.
+          Si vous avez besoin d’aide pour votre compte login.gov, consultez les articles de notre centre d’aide pour obtenir de l’aide sur des questions courantes.
 
-        - [Je ne peux pas me connecter à mon compte](site.baseurl/help/trouble-signing-in/overview)
-        - [J’ai besoin d’aide pour vérifier mon identité](site.baseurl/help/verify-your-identity/overview)
-        - [Je dois modifier mes informations ou gérer mon compte](site.baseurl/help/manage-your-account/overview)
-        - [Parcourir d’autres articles d’aide](site.baseurl/help)
-        {: .help-question-list}
-    - heading: Avez-vous une question concernant votre compte d’agence?
-      text: |-
-        Login.gov est un service d’identification permettant d’accéder aux sites web des agences gouvernementales. Si vous avez des questions sur le site web de l’agence, qui peuvent porter sur le statut de votre demande, votre adhésion, votre éligibilité, vos avantages ou d’autres questions spécifiques liées à votre compte auprès de cette agence gouvernementale, veuillez contacter cette agence.
-    - heading: Partenaire avec login.gov
-      text: |-
-        Souhaitez-vous utiliser login.gov dans votre agence? Veuillez [consulter le site web de nos partenaires](https://partners.login.gov/) ou nous contacter à l’adresse [partnerships@login.gov](mailto:partnerships@loging.gov).
-    - heading: Signaler un problème
-      text: |-
-        Si vous souhaitez signaler un problème, veuillez consulter notre [politique de divulgation de la vulnérabilité](https://18f.gsa.gov/vulnerability-disclosure-policy/) et nous contacter en utilisant notre [formulaire de divulgation de la vulnérabilité](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
+          - [Je ne peux pas me connecter à mon compte](site.baseurl/help/trouble-signing-in/overview)
+          - [J’ai besoin d’aide pour vérifier mon identité](site.baseurl/help/verify-your-identity/overview)
+          - [Je dois modifier mes informations ou gérer mon compte](site.baseurl/help/manage-your-account/overview)
+          - [Parcourir d’autres articles d’aide](site.baseurl/help)
+          {: .help-question-list}
+      - heading: Avez-vous une question concernant votre compte d’agence?
+        text: |-
+          Login.gov est un service d’identification permettant d’accéder aux sites web des agences gouvernementales. Si vous avez des questions sur le site web de l’agence, qui peuvent porter sur le statut de votre demande, votre adhésion, votre éligibilité, vos avantages ou d’autres questions spécifiques liées à votre compte auprès de cette agence gouvernementale, veuillez contacter cette agence.
+    footer:
+      - heading: Partenaire avec login.gov
+        text: |-
+          Souhaitez-vous utiliser login.gov dans votre agence? Veuillez [consulter le site web de nos partenaires](https://partners.login.gov/) ou nous contacter à l’adresse [partnerships@login.gov](mailto:partnerships@loging.gov).
+      - heading: Signaler un problème
+        text: |-
+          Si vous souhaitez signaler un problème, veuillez consulter notre [politique de divulgation de la vulnérabilité](https://18f.gsa.gov/vulnerability-disclosure-policy/) et nous contacter en utilisant notre [formulaire de divulgation de la vulnérabilité](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -62,7 +62,7 @@ contact_page:
       usajobs: USAJOBS
       veterans_affairs: Veterans Affairs
     errors:
-      captcha_required: Vous devez relever le défi de la prévention du spam. # TODO: Translate
+      captcha_required: Vous devez relever le défi de la prévention du pourriel.
     form_helpers:
       select_topic: "- Sélectionnez un sujet -"
       select_issue: "- Sélectionnez une question spécifique -"
@@ -72,14 +72,14 @@ contact_page:
       agency_application_all: Toutes les applications
       agency_application_common: Applications courantes
       agency_application_other: Autres applications
-      description: Fournissez plus de détails sur votre question # TODO: Translate
+      description: Donnez plus de détails sur votre question
       email: E-mail
       first_name: Prénom
       last_name: Nom
       pii_warning: Veuillez **ne pas** inclure d'informations sensibles ou d'identification dans cette section telles que votre nom complet, votre date de naissance ou votre numéro de sécurité sociale.
       subtopic: Problème
       topic: Sujet
-    reset: Forme claire # TODO: Translate
+    reset: Formulaire clair
     submit: Soumettre
     subtopics:
       add_family_member: Comment ajouter un membre de la famille à mon compte login.gov?

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -23,31 +23,32 @@ banner:
     secure_description: "Un <strong>verrou</strong> ou <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez des informations sensibles uniquement sur des sites Web officiels et sécurisés."
 contact_page:
   content:
-    intro:
-      - text: |-
-          Login.gov est là pour vous aider à créer, à vous connecter et à gérer votre compte login.gov.
+    intro: |-
+      Login.gov est là pour vous aider à créer, à vous connecter et à gérer votre compte login.gov.
 
-          Par mesure de sécurité, nous n’avons pas la possibilité de supprimer votre compte login.gov ou de changer votre mot de passe en votre nom.
+      Par mesure de sécurité, nous n’avons pas la possibilité de supprimer votre compte login.gov ou de changer votre mot de passe en votre nom.
 
-          Nos heures d’ouverture sont du lundi au vendredi, de 8 h à 20 h (heure de l’Est). Veuillez noter que nos agents du service clientèle peuvent prendre jusqu’à deux jours ouvrables pour répondre à votre question. Nous vous remercions de votre patience.
+      Nos heures d’ouverture sont du lundi au vendredi, de 8 h à 20 h (heure de l’Est). Veuillez noter que nos agents du service clientèle peuvent prendre jusqu’à deux jours ouvrables pour répondre à votre question. Nous vous remercions de votre patience.
 
-          Si vous avez besoin d’aide pour votre compte login.gov, consultez les articles de notre centre d’aide pour obtenir de l’aide sur des questions courantes.
+      Si vous avez besoin d’aide pour votre compte login.gov, consultez les articles de notre centre d’aide pour obtenir de l’aide sur des questions courantes.
 
-          - [Je ne peux pas me connecter à mon compte](site.baseurl/help/trouble-signing-in/overview)
-          - [J’ai besoin d’aide pour vérifier mon identité](site.baseurl/help/verify-your-identity/overview)
-          - [Je dois modifier mes informations ou gérer mon compte](site.baseurl/help/manage-your-account/overview)
-          - [Parcourir d’autres articles d’aide](site.baseurl/help)
-          {: .help-question-list}
-      - heading: Avez-vous une question concernant votre compte d’agence?
-        text: |-
-          Login.gov est un service d’identification permettant d’accéder aux sites web des agences gouvernementales. Si vous avez des questions sur le site web de l’agence, qui peuvent porter sur le statut de votre demande, votre adhésion, votre éligibilité, vos avantages ou d’autres questions spécifiques liées à votre compte auprès de cette agence gouvernementale, veuillez contacter cette agence.
-    footer:
-      - heading: Partenaire avec login.gov
-        text: |-
-          Souhaitez-vous utiliser login.gov dans votre agence? Veuillez [consulter le site web de nos partenaires](https://partners.login.gov/) ou nous contacter à l’adresse [partnerships@login.gov](mailto:partnerships@loging.gov).
-      - heading: Signaler un problème
-        text: |-
-          Si vous souhaitez signaler un problème, veuillez consulter notre [politique de divulgation de la vulnérabilité](https://18f.gsa.gov/vulnerability-disclosure-policy/) et nous contacter en utilisant notre [formulaire de divulgation de la vulnérabilité](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
+      - [Je ne peux pas me connecter à mon compte](site.baseurl/help/trouble-signing-in/overview)
+      - [J’ai besoin d’aide pour vérifier mon identité](site.baseurl/help/verify-your-identity/overview)
+      - [Je dois modifier mes informations ou gérer mon compte](site.baseurl/help/manage-your-account/overview)
+      - [Parcourir d’autres articles d’aide](site.baseurl/help)
+      {: .help-question-list}
+
+      ## Avez-vous une question concernant votre compte d’agence?
+
+      Login.gov est un service d’identification permettant d’accéder aux sites web des agences gouvernementales. Si vous avez des questions sur le site web de l’agence, qui peuvent porter sur le statut de votre demande, votre adhésion, votre éligibilité, vos avantages ou d’autres questions spécifiques liées à votre compte auprès de cette agence gouvernementale, veuillez contacter cette agence.
+    footer: |-
+      ## Partenaire avec login.gov
+
+      Souhaitez-vous utiliser login.gov dans votre agence? Veuillez [consulter le site web de nos partenaires](https://partners.login.gov/) ou nous contacter à l’adresse [partnerships@login.gov](mailto:partnerships@loging.gov).
+
+      ## Signaler un problème
+
+      Si vous souhaitez signaler un problème, veuillez consulter notre [politique de divulgation de la vulnérabilité](https://18f.gsa.gov/vulnerability-disclosure-policy/) et nous contacter en utilisant notre [formulaire de divulgation de la vulnérabilité](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs
@@ -694,8 +695,15 @@ nav:
   about_us: À propos de nous
   anchor_to_top: Retour au sommet
   become_a_partner: Devenir un partenaire
-  contact: Contact
-  contact_us: Nous contacter
+  contact_us:
+    title: Nous contacter
+    sections:
+      - name: Avez-vous une question concernant votre compte d’agence?
+        url: /contact/#avez-vous-une-question-concernant-votre-compte-dagence
+      - name: Partenaire avec login.gov
+        url: /contact/#partenaire-avec-logingov
+      - name: Signaler un problème
+        url: /contact/#signaler-un-problème
   contact_login_gov: Contactez Login.gov
   create_an_account: Créer un compte
   developer_guide: Guide du développeur

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -22,6 +22,30 @@ banner:
     secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
     secure_description: "Un <strong>verrou</strong> ou <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez des informations sensibles uniquement sur des sites Web officiels et sécurisés."
 contact_page:
+  content:
+    - text: |-
+        Login.gov est là pour vous aider à créer, à vous connecter et à gérer votre compte login.gov.
+
+        Par mesure de sécurité, nous n’avons pas la possibilité de supprimer votre compte login.gov ou de changer votre mot de passe en votre nom.
+
+        Nos heures d’ouverture sont du lundi au vendredi, de 8 h à 20 h (heure de l’Est). Veuillez noter que nos agents du service clientèle peuvent prendre jusqu’à deux jours ouvrables pour répondre à votre question. Nous vous remercions de votre patience.
+
+        Si vous avez besoin d’aide pour votre compte login.gov, consultez les articles de notre centre d’aide pour obtenir de l’aide sur des questions courantes.
+
+        - [Je ne peux pas me connecter à mon compte](site.baseurl/help/trouble-signing-in/overview)
+        - [J’ai besoin d’aide pour vérifier mon identité](site.baseurl/help/verify-your-identity/overview)
+        - [Je dois modifier mes informations ou gérer mon compte](site.baseurl/help/manage-your-account/overview)
+        - [Parcourir d’autres articles d’aide](site.baseurl/help)
+        {: .help-question-list}
+    - heading: Avez-vous une question concernant votre compte d’agence?
+      text: |-
+        Login.gov est un service d’identification permettant d’accéder aux sites web des agences gouvernementales. Si vous avez des questions sur le site web de l’agence, qui peuvent porter sur le statut de votre demande, votre adhésion, votre éligibilité, vos avantages ou d’autres questions spécifiques liées à votre compte auprès de cette agence gouvernementale, veuillez contacter cette agence.
+    - heading: Partenaire avec login.gov
+      text: |-
+        Souhaitez-vous utiliser login.gov dans votre agence? Veuillez [consulter le site web de nos partenaires](https://partners.login.gov/) ou nous contacter à l’adresse [partnerships@login.gov](mailto:partnerships@loging.gov).
+    - heading: Signaler un problème
+      text: |-
+        Si vous souhaitez signaler un problème, veuillez consulter notre [politique de divulgation de la vulnérabilité](https://18f.gsa.gov/vulnerability-disclosure-policy/) et nous contacter en utilisant notre [formulaire de divulgation de la vulnérabilité](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
   support_request_form:
     agencies:
       cbp_jobs: Customs and Border Protection Jobs
@@ -38,22 +62,24 @@ contact_page:
       usajobs: USAJOBS
       veterans_affairs: Veterans Affairs
     errors:
-      captcha_required: You must complete the spam prevention challenge. # TODO: Translate
+      captcha_required: Vous devez relever le défi de la prévention du spam. # TODO: Translate
     form_helpers:
-      select: "- Select -" # TODO: Translate
+      select_topic: "- Sélectionnez un sujet -"
+      select_issue: "- Sélectionnez une question spécifique -"
+      select_agency: "- Sélectionnez une agence -"
     labels:
       agency_application: Demande à une agence
       agency_application_all: Toutes les applications
       agency_application_common: Applications courantes
       agency_application_other: Autres applications
-      description: Provide more detail about your question # TODO: Translate
+      description: Fournissez plus de détails sur votre question # TODO: Translate
       email: E-mail
       first_name: Prénom
       last_name: Nom
       pii_warning: Veuillez **ne pas** inclure d'informations sensibles ou d'identification dans cette section telles que votre nom complet, votre date de naissance ou votre numéro de sécurité sociale.
-      subtopic: Issue # TODO: Translate
-      topic: Topic # TODO: Translate
-    reset: Clear form # TODO: Translate
+      subtopic: Problème
+      topic: Sujet
+    reset: Forme claire # TODO: Translate
     submit: Soumettre
     subtopics:
       add_family_member: Comment ajouter un membre de la famille à mon compte login.gov?
@@ -93,8 +119,6 @@ contact_page:
       site_navigation: Navigation du site
       unwanted_otp: Multiples OTP
       wrong_account_update: Mise à jour de compte erronée
-    alert_banner:
-    alert_banner_link:
     topics:
       account_linking: Lien vers le compte
       changing_settings: Modifier les paramètres
@@ -304,7 +328,7 @@ help_pages:
     overview: |-
       # Gérez votre compte
       Gérez les paramètres de votre compte, notamment votre mot de passe, votre numéro de téléphone, votre adresse électronique, etc.
-      
+
       ## Sujets de dépannage courants
       * [Changez votre mot de passe](#)
       * [Modifiez le numéro de téléphone associé à votre compte](#)
@@ -314,59 +338,59 @@ help_pages:
     change-your-password: |-
       # Changer votre mot de passe
       Suivez les étapes suivantes pour changer votre mot de passe login.gov.
-      
-      1. Saisissez votre adresse de courriel sur https://secure.login.gov. 
+
+      1. Saisissez votre adresse de courriel sur https://secure.login.gov.
       1. Saisissez votre mot de passe.
       1. Cliquez sur le bouton « Se connecter ».
-      1. Authentifiez-vous à l'aide d'une des méthodes que vous avez configurées. Vous serez ensuite dirigé vers la page de votre compte. 
+      1. Authentifiez-vous à l'aide d'une des méthodes que vous avez configurées. Vous serez ensuite dirigé vers la page de votre compte.
       1. Sélectionnez « Modifier » à côté du champ de mot de passe.
       1. Saisissez votre nouveau mot de passe.
-            Les mots de passe doivent comporter au moins 12 caractères. C'est tout! Il n'y a aucune autre restriction. Vous pouvez même utiliser plus d'un mot avec des espaces pour arriver à 12 caractères. Essayez d'utiliser une phrase ou une série de mots que vous êtes le seul à reconnaître.  
-      
+            Les mots de passe doivent comporter au moins 12 caractères. C'est tout! Il n'y a aucune autre restriction. Vous pouvez même utiliser plus d'un mot avec des espaces pour arriver à 12 caractères. Essayez d'utiliser une phrase ou une série de mots que vous êtes le seul à reconnaître.
+
             Votre mot de passe login.gov doit être différent des mots de passe que vous utilisez pour d'autres comptes tels que votre compte bancaire ou votre adresse de courriel. L'utilisation du même mot de passe pour plusieurs comptes facilite l'usurpation d'identité.
       1. Cliquez sur le bouton « Changer le mot de passe ».
     delete-your-account: |-
       #  Supprimer votre compte
       __Plusieurs raisons peuvent justifier le besoin de supprimer votre compte:__
-      * Vous réalisez que vous avez plusieurs comptes avec différentes adresses de courriel et vous souhaitez avoir un seul compte. 
-      * Vous ne pouvez plus accéder à votre compte et vous n'avez plus accès à vos méthodes d'authentification. 
-      * Vous n'avez plus besoin d'avoir un compte login.gov 
-      
+      * Vous réalisez que vous avez plusieurs comptes avec différentes adresses de courriel et vous souhaitez avoir un seul compte.
+      * Vous ne pouvez plus accéder à votre compte et vous n'avez plus accès à vos méthodes d'authentification.
+      * Vous n'avez plus besoin d'avoir un compte login.gov
+
       __Si vous supprimez votre compte:__
       * Nous supprimerons votre adresse courriel, votre mot de passe et votre numéro de téléphone.
-      * Vous ne pourrez plus accéder de manière sécurisée aux agences partenaires qui exigent un compte login.gov. 
-      
-      Après la suppression de votre compte, vous ne pourrez plus accéder aux applications gouvernementales auxquelles vous pouvez accéder 
+      * Vous ne pourrez plus accéder de manière sécurisée aux agences partenaires qui exigent un compte login.gov.
+
+      Après la suppression de votre compte, vous ne pourrez plus accéder aux applications gouvernementales auxquelles vous pouvez accéder
       normalement en utilisant votre compte login.gov. Vous ne perdrez pas vos informations dans ces applications, mais vous aurez besoin d'un * compte login.gov pour pouvoir vous connecter à ces applications.
 
       __Si vous avez accès à vos méthodes d'authentification, suivez les étapes suivantes pour supprimer votre compte:__
-      1. Saisissez votre adresse courriel sur [https://secure.login.gov](https://secure.login.gov). 
+      1. Saisissez votre adresse courriel sur [https://secure.login.gov](https://secure.login.gov).
       1. Saisissez votre mot de passe.
-      1. Cliquez sur le bouton « Connexion ». 
+      1. Cliquez sur le bouton « Connexion ».
       1. Authentifiez-vous en utilisant l'une des méthodes que vous avez configurées.
-      1. Sur la page de votre compte, sélectionnez « Supprimer le compte » à partir du menu à gauche de la page. 
+      1. Sur la page de votre compte, sélectionnez « Supprimer le compte » à partir du menu à gauche de la page.
       1. Sélectionnez « Supprimer le compte » à partir du menu « Votre compte ».
       1. Saisissez votre mot de passe pour confirmer votre souhait de supprimer le compte.
 
       __Si vous n'avez pas accès à vos méthodes d'authentification, suivez les étapes suivantes pour supprimer votre compte:__
-      Par mesure de sécurité, Login.gov impose un processus en 2 étapes et une période d'attente de 24 heures, si vous n'avez plus accès à vos méthodes d'authentification et avez besoin de supprimer votre compte.  
+      Par mesure de sécurité, Login.gov impose un processus en 2 étapes et une période d'attente de 24 heures, si vous n'avez plus accès à vos méthodes d'authentification et avez besoin de supprimer votre compte.
 
-      1. Accédez à la page de connexion de l'application de votre gouvernement ou allez à l'adresse [https://secure.login.gov/](https://secure.login.gov/). 
+      1. Accédez à la page de connexion de l'application de votre gouvernement ou allez à l'adresse [https://secure.login.gov/](https://secure.login.gov/).
       1. Connectez-vous en utilisant votre adresse courriel et votre mot de passe.
       1. Sur la page d'authentification (saisir votre code de sécurité, d'application ou de sauvegarde ; carte PIV/CAC ; ou clé de sécurité), cliquez sur « Choisir une autre option de sécurité ».
       1. Faites défiler jusqu'au bas et cliquez sur le lien de suppression de votre compte.
       1. Lisez toutes les informations attentivement pour vous assurer que la suppression de votre compte est la seule option qui s'offre à vous.
       1. Cliquez sur « Oui, continuer la suppression »
-      1. Vous recevrez deux courriels. 
-          1. Le premier confirme que nous avons reçu votre demande. Votre compte n'est pas encore supprimé. Une action supplémentaire est nécessaire. 
-          1. Le deuxième courriel vous est envoyé 24 heures après le premier. Suivez les instructions énoncées dans le courriel pour terminer la suppression. 
+      1. Vous recevrez deux courriels.
+          1. Le premier confirme que nous avons reçu votre demande. Votre compte n'est pas encore supprimé. Une action supplémentaire est nécessaire.
+          1. Le deuxième courriel vous est envoyé 24 heures après le premier. Suivez les instructions énoncées dans le courriel pour terminer la suppression.
   verify-your-identity:
     overview: |-
       # Vérifiez votre identité
 
-      Certaines agences qui participent au programme exigent que vous vous soumettiez à un processus de vérification d’identité. La vérification de l’identité est le processus par lequel vous prouvez que c’est bien vous — et une tierce personne qui se fait passer pour vous. 
+      Certaines agences qui participent au programme exigent que vous vous soumettiez à un processus de vérification d’identité. La vérification de l’identité est le processus par lequel vous prouvez que c’est bien vous — et une tierce personne qui se fait passer pour vous.
 
-      La vérification de votre identité ne doit être effectuée qu’une seule fois pour votre compte « login.gov ». Une fois que votre identité a été vérifiée avec « login.gov » pour une application gouvernementale, vous n’avez pas besoin de le refaire pour les autres applications gouvernementales qui utilisent « login.gov » et qui nécessitent une vérification d’identité. 
+      La vérification de votre identité ne doit être effectuée qu’une seule fois pour votre compte « login.gov ». Une fois que votre identité a été vérifiée avec « login.gov » pour une application gouvernementale, vous n’avez pas besoin de le refaire pour les autres applications gouvernementales qui utilisent « login.gov » et qui nécessitent une vérification d’identité.
 
       Utilisez cette rubrique d’aide pour comprendre le processus et les exigences en matière de vérification d’identité.
 
@@ -654,7 +678,7 @@ meta:
     description: Les agences gouvernementales américaines peuvent tirer parti de la plate-forme d'authentification et de vérification d'identité de login.gov. En savoir plus sur les offres et les opportunités de login.gov.
     title: Pourquoi login.gov
 nav:
-  accessibility: 
+  accessibility:
     title: Accessibilité
     sections:
       - name: Notre engagement
@@ -664,7 +688,7 @@ nav:
       - name: Évaluation
         url: /accessibility/#évaluation
       - name: Limites connues
-        url: /accessibility/#limites-connues    
+        url: /accessibility/#limites-connues
   about_us: À propos de nous
   anchor_to_top: Retour au sommet
   become_a_partner: Devenir un partenaire
@@ -1104,7 +1128,7 @@ accessibility:
   content: |-
     ## Notre engagement
     Login.gov s’engage à être inclusif et accessible à tous nos utilisateurs. Notre objectif consiste à améliorer continuellement la façon dont les personnes en situation de handicap ou non peuvent utiliser Login.gov pour accéder facilement aux applications et aux services du gouvernement.
-    
+
     ## Normes
      Login.gov entend se conformer aux [Directives du W3C sur l’accessibilité des contenus Web (WCAG) version 2.1 niveau AA](https://www.w3.org/TR/WCAG21/).
 

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -266,7 +266,7 @@
     let field = document.getElementById(topicID);
     field.options.length = 0;
     field.options[0] = new Option(
-      "{% t contact_page.support_request_form.form_helpers.select %}",
+      "{% t contact_page.support_request_form.form_helpers.select_topic %}",
       "",
       false,
       true
@@ -282,7 +282,7 @@
 
     let sub = document.getElementById("sub-topic");
     sub.options[0] = new Option(
-      "{% t contact_page.support_request_form.form_helpers.select %}",
+      "{% t contact_page.support_request_form.form_helpers.select_issue %}",
       null,
       false,
       true
@@ -305,7 +305,7 @@
         console.log(topicMap[i]);
         options.push(
           new Option(
-            "{% t contact_page.support_request_form.form_helpers.select %}",
+            "{% t contact_page.support_request_form.form_helpers.select_issue %}",
             "",
             false,
             true
@@ -382,7 +382,7 @@
     {% t contact_page.support_request_form.labels.agency_application %}
   </label>
   <select id="00Nt0000000OYA2" name="00Nt0000000OYA2" required class="usa-select">
-    <option value="" selected hidden>{% t contact_page.support_request_form.form_helpers.select %}</option>
+    <option value="" selected hidden>{% t contact_page.support_request_form.form_helpers.select_agency %}</option>
     <optgroup label="{% t contact_page.support_request_form.labels.agency_application_common %}">
       <option value="USAJOBS">{% t contact_page.support_request_form.agencies.usajobs %}</option>
       <option value="SBA DLAP">{% t contact_page.support_request_form.agencies.sba_dlap %}</option>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@
             <section>
               <h6>{% t nav.groups.support %}</h6>
               <a class="font-xs" href="{{ site.baseurl }}/help/">{% t nav.help_center %}</a>
-              <a class="font-xs" href="{{ site.baseurl }}/contact/">{% t nav.contact_us %}</a>
+              <a class="font-xs" href="{{ site.baseurl }}/contact/">{% t nav.contact_us.title %}</a>
             </section>
           </div>
           <div class="system-status">

--- a/_includes/language_search.html
+++ b/_includes/language_search.html
@@ -40,7 +40,7 @@
       {% endif %}
 
       {% if include.contact %}
-        <a href="{{ site.baseurl }}/contact/" class="contact-link">{% t nav.contact_us %}</a>
+        <a href="{{ site.baseurl }}/contact/" class="contact-link">{% t nav.contact_us.title %}</a>
       {% endif %}
     </div>
   </div>

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -16,14 +16,16 @@ scripts:
       <li class="usa-sidenav__item">
         <a href="/contact/" class="usa-current">{% t meta.contact_us.title %}</a>
         <ul class="usa-sidenav__sublist">
-          {% for section in site.translations[site.lang].contact_page.content %}
-            {% if section.heading %}
-              <li class="usa-sidenav__item">
-                <a href="#{{ section.heading | slugify: 'ascii' }}">
-                  {{ section.heading }}
-                </a>
-              </li>
-            {% endif %}
+          {% for areas in site.translations[site.lang].contact_page.content %}
+            {% for section in areas[1] %}
+              {% if section.heading %}
+                <li class="usa-sidenav__item">
+                  <a href="#{{ section.heading | slugify: 'ascii' }}">
+                    {{ section.heading }}
+                  </a>
+                </li>
+              {% endif %}
+            {% endfor %}
           {% endfor %}
         </ul>
       </li>
@@ -39,7 +41,7 @@ scripts:
       {{ sidenav }}
     </div>
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
-      {% for section in site.translations[site.lang].contact_page.content %}
+      {% for section in site.translations[site.lang].contact_page.content.intro %}
         {% if section.heading %}
           <h2 id="{{ section.heading | slugify: 'ascii' }}">
             {{ section.heading }}
@@ -50,6 +52,14 @@ scripts:
       <div class="desktop:grid-col-9">
         {% include contact_form.html %}
       </div>
+      <footer class="page-content__footer">
+        {% for section in site.translations[site.lang].contact_page.content.footer %}
+          <h2 id="{{ section.heading | slugify: 'ascii' }}">
+            {{ section.heading }}
+          </h2>
+          {{ section.text | replace: 'site.baseurl', site.baseurl | markdownify }}
+        {% endfor %}
+      </footer>
       <a href="#" class="anchor-to-top">{% t nav.anchor_to_top %}</a>
     </div>
     <div class="display-none desktop:display-block grid-offset-1 grid-col-3">

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -16,15 +16,15 @@ scripts:
       <li class="usa-sidenav__item">
         <a href="/contact/" class="usa-current">{% t meta.contact_us.title %}</a>
         <ul class="usa-sidenav__sublist">
-          <li class="usa-sidenav__item">
-            <a href="#do-you-need-more-help">Do you need more help?</a>
-          </li>
-          <li class="usa-sidenav__item">
-            <a href="#partner-with-login-gov">Partner with login.gov</a>
-          </li>
-          <li class="usa-sidenav__item">
-            <a href="#report-a-security-issue">Report a security issue</a>
-          </li>
+          {% for section in site.translations[site.lang].contact_page.content %}
+            {% if section.heading %}
+              <li class="usa-sidenav__item">
+                <a href="#{{ section.heading | slugify }}">
+                  {{ section.heading }}
+                </a>
+              </li>
+            {% endif %}
+          {% endfor %}
         </ul>
       </li>
     </ul>
@@ -39,27 +39,17 @@ scripts:
       {{ sidenav }}
     </div>
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
-      <p>Login.gov is here to help. If you need assistance with your login.gov account, check out these articles on common issues.</p>
-      <ul class="help-question-list">
-        <li><a href="{{ site.baseurl }}/help/trouble-signing-in/locked-out-of-login">I’m locked out of my account</a></li>
-        <li><a href="{{ site.baseurl }}/help/trouble-signing-in/forgot-your-password">I forgot my password</a></li>
-        <li><a href="{{ site.baseurl }}/help/changing-settings/change-my-password">I need to change my password</a></li>
-        <li><a href="{{ site.baseurl }}/help/changing-settings/change-my-phone-number">I need to change my phone number</a></li>
-        <li><a href="{{ site.baseurl }}/help/trouble-signing-in/how-to-sign-in">I can’t sign in</a></li>
-        <li><a href="{{ site.baseurl }}/help">Browse more help articles</a></li>
-      </ul>
-      <h2 id="do-you-need-more-help">Do you need more help? Contact login.gov customer support</h2>
-      <p>Please note, to protect your account security, our customer support agents can’t make changes to your login.gov account. <strong>Agents can’t change your password or access any part of your account.</strong> Agents can help you resolve issues with <a href="{{ site.baseurl }}/help/trouble-signing-in/how-to-sign-in">signing in to login.gov</a> or <a href="{{ site.baseurl }}/help/creating-an-account/how-to-create-an-account">creating your login.gov account</a>.</p>
-      <p>Agents are available to respond to messages Monday - Friday, 8:00 a.m. - 8:00 p.m. ET. Please note that it could take up to two days for our customer support agents to respond to your question. Thank you for your patience.</p>
+      {% for section in site.translations[site.lang].contact_page.content %}
+        {% if section.heading %}
+          <h2 id="{{ section.heading | slugify }}">
+            {{ section.heading }}
+          </h2>
+        {% endif %}
+        {{ section.text | replace: 'site.baseurl', site.baseurl | markdownify }}
+      {% endfor %}
       <div class="desktop:grid-col-9">
         {% include contact_form.html %}
       </div>
-      <footer class="page-content__footer">
-        <h2 id="partner-with-login-gov">Partner with login.gov</h2>
-        <p>If you're a federal government employee and your agency is interested in login.gov services, please visit our <a href="https://partners.login.gov/">partners page</a>.</p>
-        <h2 id="report-a-security-issue">Report a security issue</h2>
-        <p>If you want to report a security vulnerability, please review our <a href="https://18f.gsa.gov/vulnerability-disclosure-policy/">vulnerability disclosure policy</a> and contact us using our <a href="https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform">vulnerability disclosure form</a>.</p>
-      </footer>
       <a href="#" class="anchor-to-top">{% t nav.anchor_to_top %}</a>
     </div>
     <div class="display-none desktop:display-block grid-offset-1 grid-col-3">

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,69 +1,17 @@
 ---
 title: meta.contact_us.title
+layout: sidenav
 permalink: /contact/
 description: meta.contact_us.description
+sidenav: contact_us
 scripts:
   - /assets/js/build/contact.js
 ---
 
-{% capture heading %}
-  {% t contact.hero.heading %}
-{% endcapture %}
+{{ site.translations[site.lang].contact_page.content.intro | replace: 'site.baseurl', site.baseurl | markdownify }}
 
-{% capture sidenav %}
-  <nav aria-label="{% t accessible_labels.secondary_navigation %}">
-    <ul class="usa-sidenav">
-      <li class="usa-sidenav__item">
-        <a href="/contact/" class="usa-current">{% t meta.contact_us.title %}</a>
-        <ul class="usa-sidenav__sublist">
-          {% for areas in site.translations[site.lang].contact_page.content %}
-            {% for section in areas[1] %}
-              {% if section.heading %}
-                <li class="usa-sidenav__item">
-                  <a href="#{{ section.heading | slugify: 'ascii' }}">
-                    {{ section.heading }}
-                  </a>
-                </li>
-              {% endif %}
-            {% endfor %}
-          {% endfor %}
-        </ul>
-      </li>
-    </ul>
-  </nav>
-{% endcapture %}
+{% include contact_form.html %}
 
-{% include hero.html heading=heading class="bg-none" %}
-
-<div class="container">
-  <article class="page-content grid-row">
-    <div class="desktop:display-none grid-col-12 margin-bottom-3">
-      {{ sidenav }}
-    </div>
-    <div class="page-content__prose grid-col-12 desktop:grid-col-8">
-      {% for section in site.translations[site.lang].contact_page.content.intro %}
-        {% if section.heading %}
-          <h2 id="{{ section.heading | slugify: 'ascii' }}">
-            {{ section.heading }}
-          </h2>
-        {% endif %}
-        {{ section.text | replace: 'site.baseurl', site.baseurl | markdownify }}
-      {% endfor %}
-      <div class="desktop:grid-col-9">
-        {% include contact_form.html %}
-      </div>
-      <footer class="page-content__footer">
-        {% for section in site.translations[site.lang].contact_page.content.footer %}
-          <h2 id="{{ section.heading | slugify: 'ascii' }}">
-            {{ section.heading }}
-          </h2>
-          {{ section.text | replace: 'site.baseurl', site.baseurl | markdownify }}
-        {% endfor %}
-      </footer>
-      <a href="#" class="anchor-to-top">{% t nav.anchor_to_top %}</a>
-    </div>
-    <div class="display-none desktop:display-block grid-offset-1 grid-col-3">
-      {{ sidenav }}
-    </div>
-  </article>
-</div>
+<footer class="page-content__footer">
+  {{ site.translations[site.lang].contact_page.content.footer | replace: 'site.baseurl', site.baseurl | markdownify }}
+</footer>

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -10,7 +10,9 @@ scripts:
 
 {{ site.translations[site.lang].contact_page.content.intro | replace: 'site.baseurl', site.baseurl | markdownify }}
 
-{% include contact_form.html %}
+<div class="desktop:grid-col-9">
+  {% include contact_form.html %}
+</div>
 
 <footer class="page-content__footer">
   {{ site.translations[site.lang].contact_page.content.footer | replace: 'site.baseurl', site.baseurl | markdownify }}

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -19,7 +19,7 @@ scripts:
           {% for section in site.translations[site.lang].contact_page.content %}
             {% if section.heading %}
               <li class="usa-sidenav__item">
-                <a href="#{{ section.heading | slugify }}">
+                <a href="#{{ section.heading | slugify: 'ascii' }}">
                   {{ section.heading }}
                 </a>
               </li>
@@ -41,7 +41,7 @@ scripts:
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
       {% for section in site.translations[site.lang].contact_page.content %}
         {% if section.heading %}
-          <h2 id="{{ section.heading | slugify }}">
+          <h2 id="{{ section.heading | slugify: 'ascii' }}">
             {{ section.heading }}
           </h2>
         {% endif %}


### PR DESCRIPTION
**Why**: As a French or Spanish visitor to login.gov, I want to be able to read and submit a contact form submission in my native language, so that I have the most likelihood of resolving my issue.

**Live Preview:** https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/aduth-contact-us-translations/contact/

**Questions:**

- @nickttng The given content from the ticket LG-3980 is not organized as per the design implemented in LG-3496. Can you please advise if the current layout needs adjustment? For example, the "Partner with login.gov" and "Report a security issue" (now "Report an issue") sections were previously displayed below the form.
- @Danielle-Lee Noting a couple strings for which translations were not available. Currently I've used Google Translate as an intermediate solution, with a note to replace with professional translation:
   - >You must complete the spam prevention challenge.
      - Context: Shown when user tries to submit the form without completing the ReCaptcha challenge.
   - >Provide more detail about your question
      - Context: Label of form freeform textarea field
   - >Clear form
      - Context: Button text for secondary form reset action

Additionally, since Topics / Subtopics are still marked as "TBD" in content documents, I've kept those the same as existed previously, which I expect are the same as in the current production site.