### PR TITLE
Configure autoprefixer for Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'jekyll', '>= 4.0.0'
 gem 'jekyll-redirect-from', '>= 0.15.0'
 gem 'jekyll-multiple-languages-plugin', '>= 1.6.1'
 gem 'jekyll-sitemap', '>= 1.4.0'
+gem "jekyll-autoprefixer", "~> 1.0"
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    autoprefixer-rails (9.8.6.5)
+      execjs
     coderay (1.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.1.6)
@@ -13,6 +15,7 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    execjs (2.7.0)
     ffi (1.14.2)
     forwardable-extended (2.6.0)
     html-proofer (3.18.5)
@@ -41,6 +44,8 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
+    jekyll-autoprefixer (1.0.2)
+      autoprefixer-rails (~> 9.3)
     jekyll-multiple-languages-plugin (1.7.0)
       jekyll (>= 2.0, < 5.0)
     jekyll-redirect-from (0.16.0)
@@ -111,6 +116,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer (>= 3.15.3)
   jekyll (>= 4.0.0)
+  jekyll-autoprefixer (~> 1.0)
   jekyll-multiple-languages-plugin (>= 1.6.1)
   jekyll-redirect-from (>= 0.15.0)
   jekyll-sitemap (>= 1.4.0)

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,11 @@ sass:
     - _sass
     - node_modules
 
+autoprefixer:
+  browsers:
+    - last 2 versions
+    - ie 11
+
 # Build settings
 kramdown:
   hard_wrap: true
@@ -71,6 +76,7 @@ plugins:
   - jekyll-redirect-from
   - jekyll-multiple-languages-plugin
   - jekyll-sitemap
+  - jekyll-autoprefixer
 
 help_pages:
 - trouble-signing-in


### PR DESCRIPTION
**Why**:

- Required by USWDS
  - See: https://github.com/uswds/uswds#sass-compilation-requirements
- Prerequisite to fix visual defect of search fields in iOS (rounded corners)
  - Discovered in course of compiling screenshots for design approval of #511