### PR TITLE
Include policy pages in accessibility test

### DIFF
--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -11,7 +11,6 @@ const EXCLUDE_PATTERNS = [
   /\.pdf$/, // Puppeteer Chromium cannot preview PDF files
   /^\/about\/$/, // See: LG-3809 (TODO: Remove with implementation of LG-3809)
   /^\/404\.html$/, // See: LG-3455 (TODO: Remove with implementation of LG-3455)
-  /^\/policy\//, // See: LG-3982 (TODO: Remove with implementation of LG-3982)
   /^\/partners\//, // TODO: Remove with https://github.com/18F/identity-site/pull/483
 ];
 


### PR DESCRIPTION
**Why**: As of #512, the Privacy layout is no longer broken and passes accessibility scan.