### PR TITLE
LG-4008: Fix smooth scroll for sidenav layouts

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -691,13 +691,13 @@ nav:
     title: Accessibility statement
     sections:
       - name: Our Commitment
-        url: /accessibility/#our-commitment
+        url: "#our-commitment"
       - name: Standards
-        url: /accessibility/#standards
+        url: "#standards"
       - name: Evaluation
-        url: /accessibility/#evaluation
+        url: "#evaluation"
       - name: Known limitations
-        url: /accessibility/#known-limitations
+        url: "#known-limitations"
   anchor_to_top: Back to top
   about_us: About us
   become_a_partner: Become a partner
@@ -705,11 +705,11 @@ nav:
     title: Contact us
     sections:
       - name: Do you have a question about your agency account?
-        url: /contact/#do-you-have-a-question-about-your-agency-account
+        url: "#do-you-have-a-question-about-your-agency-account"
       - name: Partner with login.gov
-        url: /contact/#partner-with-logingov
+        url: "#partner-with-logingov"
       - name: Report an issue
-        url: /contact/#report-an-issue
+        url: "#report-an-issue"
   contact_login_gov: Contact Login.gov
   create_an_account: Create an account
   developer_guide: Developer guide

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -612,13 +612,13 @@ nav:
     title: Accesibilidad
     sections:
       - name: Nuestro compromiso
-        url: /accessibility/#nuestro-compromiso
+        url: "#nuestro-compromiso"
       - name: Estándares
-        url: /accessibility/#estándares
+        url: "#estándares"
       - name: Evaluación
-        url: /accessibility/#evaluación
+        url: "#evaluación"
       - name: Limitaciones conocidas
-        url: /accessibility/#políticas-de-accesibilidad
+        url: "#políticas-de-accesibilidad"
   about_us: Sobre nosotros
   anchor_to_top: Volver arriba
   become_a_partner: Convertirse en un compañero
@@ -626,11 +626,11 @@ nav:
     title: Contacta con nosotros
     sections:
       - name: ¿Tiene alguna pregunta sobre la cuenta de su agencia?
-        url: /contact/#tiene-alguna-pregunta-sobre-la-cuenta-de-su-agencia
+        url: "#tiene-alguna-pregunta-sobre-la-cuenta-de-su-agencia"
       - name: Asociarse con login.gov
-        url: /contact/#asociarse-con-logingov
+        url: "#asociarse-con-logingov"
       - name: Reportar un problema
-        url: /contact/#reportar-un-problema
+        url: "#reportar-un-problema"
   contact_login_gov: Póngase en contacto con Login.gov
   create_an_account: Crea una cuenta
   developer_guide: Guía para desarrolladores
@@ -650,15 +650,15 @@ nav:
     title: Privacidad y seguridad
     sections:
       - name: Nuestro compromiso con su privacidad y seguridad
-        url: /policy/
+        url: /es/policy/
       - name: ¿Cómo funciona?
-        url: /policy/how-does-it-work/
+        url: /es/policy/how-does-it-work/
       - name: Nuestra declaración de la ley de privacidad
-        url: /policy/our-privacy-act-statement/
+        url: /es/policy/our-privacy-act-statement/
       - name: Nuestras prácticas de seguridad
-        url: /policy/our-security-practices/
+        url: /es/policy/our-security-practices/
       - name: Términos y condiciones de mensajería
-        url: /policy/messaging-terms-and-conditions/
+        url: /es/policy/messaging-terms-and-conditions/
   principles: Principios
   privacy_&_security: Privacidad y seguridad
   security: Seguridad

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -685,13 +685,13 @@ nav:
     title: Accessibilité
     sections:
       - name: Notre engagement
-        url: /accessibility/#notre-engagement
+        url: "#notre-engagement"
       - name: Normes
-        url: /accessibility/#normes
+        url: "#normes"
       - name: Évaluation
-        url: /accessibility/#évaluation
+        url: "#évaluation"
       - name: Limites connues
-        url: /accessibility/#limites-connues
+        url: "#limites-connues"
   about_us: À propos de nous
   anchor_to_top: Retour au sommet
   become_a_partner: Devenir un partenaire
@@ -699,11 +699,11 @@ nav:
     title: Nous contacter
     sections:
       - name: Avez-vous une question concernant votre compte d’agence?
-        url: /contact/#avez-vous-une-question-concernant-votre-compte-dagence
+        url: "#avez-vous-une-question-concernant-votre-compte-dagence"
       - name: Partenaire avec login.gov
-        url: /contact/#partenaire-avec-logingov
+        url: "#partenaire-avec-logingov"
       - name: Signaler un problème
-        url: /contact/#signaler-un-problème
+        url: "#signaler-un-problème"
   contact_login_gov: Contactez Login.gov
   create_an_account: Créer un compte
   developer_guide: Guide du développeur
@@ -723,15 +723,15 @@ nav:
     title: Confidentialité et sécurité
     sections:
       - name: Notre engagement envers votre confidentialité et votre sécurité
-        url:  /policy/
+        url: /fr/policy/
       - name: Comment ça marche?
-        url:  /policy/how-does-it-work/
+        url: /fr/policy/how-does-it-work/
       - name: Notre déclaration de confidentialité
-        url:  /policy/our-privacy-act-statement/
+        url: /fr/policy/our-privacy-act-statement/
       - name: Nos pratiques de sécurité
-        url:  /policy/our-security-practices/
+        url: /fr/policy/our-security-practices/
       - name: Termes et conditions de la messagerie
-        url:  /policy/messaging-terms-and-conditions/
+        url: /fr/policy/messaging-terms-and-conditions/
   principles: Principes
   privacy_&_security: Confidentialité et sécurité
   security: Sécurité

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -15,7 +15,7 @@ layout: main
           url:  /policy/
         - name: Another link
           url: /policy/#another-policy-link
-  
+
   The page.sidenav value will be passed to the sidenav for loop below.
 
   Note: This does not apply to Help pages, which is far more complex.
@@ -32,7 +32,7 @@ layout: main
             {% for item in site.translations[site.lang]["nav"][page.sidenav]["sections"]%}
             <li class="usa-sidenav__item">
             <!-- TODO: Add active item -->
-              <a href="{{ item.url | prepend: site.baseurl }}">{{ item.name }}</a>
+              <a href="{{ item.url }}">{{ item.name }}</a>
             </li>
             {% endfor %}
           </ul>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -59,7 +59,7 @@ $(function () {
     if (this.hash !== '') {
       event.preventDefault();
 
-      var hash = this.hash;
+      var hash = this.getAttribute('href');
 
       $('html, body').animate(
         {


### PR DESCRIPTION
Because links were fully-qualified, they were not detected by the smooth scroll selector. Change links to hash fragments, which previously did not work only because in non-English locales, prepending base URL would cause hash to resolve from root. Avoid prepending by assigning nav URL as locale-specific.