### PR TITLE
Run Webpack in development mode when using `make run`

### DIFF
--- a/Makefile.server
+++ b/Makefile.server
@@ -7,4 +7,4 @@ jekyll: _config.dev.yml
 	bundle exec jekyll serve --watch --incremental --config _config.yml,_config.dev.yml
 
 npm-watch-js:
-	npm run watch-js
+	NODE_ENV=development npm run watch-js


### PR DESCRIPTION
**Why**: Avoid minifying output in development environment for easier debugging.

Support already available in our Webpack configuration:

https://github.com/18F/identity-site/blob/72bf40df6911041a54deac66564f61aa230ce78c/webpack.config.js#L1