### PR TITLE
LG-4019: Show and scale "One Account" banner for mobile

### DIFF
--- a/_includes/one_account_banner.html
+++ b/_includes/one_account_banner.html
@@ -1,21 +1,23 @@
 {% if page.url == '/create-an-account/' %}
-  {% assign link_class = 'learn-account-creation usa-button usa-button--big' %}
+  {% assign link_class = 'usa-button usa-button--big' %}
   {% assign link_url = 'https://secure.login.gov/sign_up/enter_email' %}
   {% capture link_content %}{% t banner.one-account-for-govt.create %}{% endcapture %}
 {% else %}
-  {% assign link_class = 'learn-account-creation one-account-banner__link' %}
+  {% assign link_class = 'one-account-banner__link' %}
   {% assign link_url = '/create-an-account/' | prepend: site.baseurl %}
   {% capture link_content %}{% t banner.one-account-for-govt.learn %}{% endcapture %}
 {% endif %}
 <aside class="one-account-banner">
-  <div class="one-account-banner__banner">
-    <header class="one-account-banner__tagline">
-      {% t banner.one-account-for-govt.tagline %}
-    </header>
-    <p>
-      <a class="{{ link_class }}" href="{{ link_url }}">
-        {{ link_content }}
-      </a>
-    </p>
+  <div class="one-account-banner__backdrop">
+    <div class="one-account-banner__content">
+      <header class="one-account-banner__tagline">
+        {% t banner.one-account-for-govt.tagline %}
+      </header>
+      <p class="margin-bottom-0">
+        <a class="{{ link_class }}" href="{{ link_url }}">
+          {{ link_content }}
+        </a>
+      </p>
+    </div>
   </div>
 </aside>

--- a/_sass/components/_one-account-banner.scss
+++ b/_sass/components/_one-account-banner.scss
@@ -1,26 +1,50 @@
 .one-account-banner {
   background-color: $white;
-  display: none;
   padding-bottom: ($container-spacing * 2);
-
-  @include at-media("tablet") {
-    display: block;
-  }
+  padding-left: $container-spacing-sm;
+  padding-right: $container-spacing-sm;
 }
 
-.one-account-banner__banner {
+.one-account-banner__backdrop {
   @include lg-grid(false, true);
   align-items: center;
   background-color: $navy;
-  background-image: url(../img/who-uses-login/who-uses-illo-header/who-uses-illo-header.png);
-  background-position: -21.5rem -6rem;
-  background-repeat: no-repeat;
-  background-size: 70%;
   border-radius: 1rem;
   display: flex;
   flex-direction: column;
   height: 11rem;
   justify-content: center;
+  overflow: hidden;
+  padding-left: $container-spacing-sm;
+  padding-right: $container-spacing-sm;
+  position: relative;
+  text-align: center;
+
+  &::before {
+    @include u-pin("all");
+    background-image: url(../img/who-uses-login/who-uses-illo-header/who-uses-illo-header.png);
+    background-position: -22rem -6rem;
+    background-repeat: no-repeat;
+    background-size: 160%;
+    opacity: 0.9;
+    content: '';
+
+    @include at-media("mobile-lg") {
+      background-size: 120%;
+    }
+
+    @include at-media("tablet") {
+      background-size: 90%;
+    }
+
+    @include at-media("desktop") {
+      background-size: 70%;
+    }
+  }
+}
+
+.one-account-banner__content {
+  position: relative;
 }
 
 .one-account-banner__tagline {
@@ -32,4 +56,8 @@
 .one-account-banner__link {
   font-size: 1.2rem;
   color: $white;
+}
+
+.one-account-banner .usa-button--big {
+  width: auto;
 }

--- a/_sass/components/_one-account-banner.scss
+++ b/_sass/components/_one-account-banner.scss
@@ -26,7 +26,7 @@
     background-position: -22rem -6rem;
     background-repeat: no-repeat;
     background-size: 160%;
-    opacity: 0.9;
+    opacity: 0.6;
     content: '';
 
     @include at-media("mobile-lg") {
@@ -35,6 +35,7 @@
 
     @include at-media("tablet") {
       background-size: 90%;
+      opacity: 0.9;
     }
 
     @include at-media("desktop") {


### PR DESCRIPTION
Previously, the "Your One Account" banner was explicitly hidden on smaller viewports. With this pull request, it is now shown on all viewport sizes. The styles have been updated to support his, per design guidance from @nickttng (see ticket for Figma design document). The backdrop opacity was also reduced from 100% to 90% per the original design document.

**Live Preview:** https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/aduth-lg-4019-one-account-mobile/

**Screenshots:**

&nbsp;|Desktop|Mobile
---|---|---
Create Account|![image](https://user-images.githubusercontent.com/1779930/104055609-0cc77880-51bd-11eb-8b3f-d4f4653402a5.png)|![image](https://user-images.githubusercontent.com/1779930/104055596-0802c480-51bd-11eb-901d-aa3cf6507a24.png)
Other|![image](https://user-images.githubusercontent.com/1779930/104055534-f15c6d80-51bc-11eb-9a37-27ac77de9732.png)|![image](https://user-images.githubusercontent.com/1779930/104055556-fcaf9900-51bc-11eb-80fe-49860294e2f0.png)

