### PR TITLE
Fix spacing of search field in mobile navigation

### DIFF
--- a/_sass/components/_layout.scss
+++ b/_sass/components/_layout.scss
@@ -34,6 +34,7 @@ article.container,
 
 .usa-header .usa-nav {
   .usa-search {
+    flex-shrink: 0;
     right: 0;
   }
 }


### PR DESCRIPTION
Resolves an issue where...

- in Safari on iOS
- in mobile navigations where content is lengthy (e.g. Help section with expanded subsections)

...the display of the search field in mobile navigation would shrink unexpectedly.

See: https://github.com/uswds/uswds/pull/3932

Before|After
---|---
![before screenshot](https://user-images.githubusercontent.com/1779930/104198294-0ec74c80-53f4-11eb-963b-e1c714508078.png)|![after screenshot](https://user-images.githubusercontent.com/1779930/104198302-10911000-53f4-11eb-8990-7e1f0f1c8ee7.png)
