### PR TITLE
Add spacing after nested list bullets

### DIFF
--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -5,7 +5,7 @@
     li {
       line-height: 2.25rem;
       ul {
-        list-style-type: '⁃';
+        list-style-type: '⁃  ';
         margin-bottom: 0;
       }
     }


### PR DESCRIPTION
Honestly, I'm surprised this works 😬 

Based on the PIV/CAC bullet, it appears this wraps correctly across multiple lines as well

| before | after |
| --- | --- |
| <img width="775" alt="Screen Shot 2021-01-11 at 9 42 58 AM" src="https://user-images.githubusercontent.com/458784/104218470-a0818a80-53f1-11eb-8fbd-a688290e2355.png"> | <img width="775" alt="Screen Shot 2021-01-11 at 9 43 52 AM" src="https://user-images.githubusercontent.com/458784/104218463-9eb7c700-53f1-11eb-981c-8c7aa9a800e4.png"> |
