### PR TITLE
LG-4021: Add focus styling to "Sign in with login.gov" button

### DIFF
--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -124,6 +124,10 @@
     background-color: $white;
   }
 
+  &:focus {
+    @include focus-outline;
+  }
+
   span {
     color: transparent;
     background: url(../img/logo_sign_in.svg) no-repeat;


### PR DESCRIPTION
**Why**: Focus should always be visible.

See: https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html

**Implementation notes:**

Focus styling would normally be present, but since it relies on `box-shadow`, and the `.sign-in-logo` button styling applies custom `box-shadow`, it overrides. Restore by re-applying focus style with more specific selector in `:focus` state.

**Screenshot:**

![Screen Shot 2021-01-11 at 12 45 03 PM](https://user-images.githubusercontent.com/1779930/104218727-25c56900-540b-11eb-9cbc-c2eeb1e92ba8.png)
