### PR TITLE
Conditionally display demo site banner by site configuration

### DIFF
--- a/_layouts/help_landing.html
+++ b/_layouts/help_landing.html
@@ -4,7 +4,9 @@ body:
   class: "help-page"
 ---
 <header>
-  {% include wip.html %}
+  {% if site.demo_banner %}
+    {% include wip.html %}
+  {% endif %}
   {% include skip_nav.html %}
   {% include banner.html %}
   {% include header--help.html %}

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -2,7 +2,9 @@
 layout: base
 ---
 <header>
-  {% include wip.html %}
+  {% if site.demo_banner %}
+    {% include wip.html %}
+  {% endif %}
   {% include skip_nav.html %}
   {% include banner.html %}
   {% include header.html %}


### PR DESCRIPTION
**Why**: Demo banner should not be shown on live site. Federalist allows per-environment site configuration values. It would be assumed that this change would be paired with adding `demo_banner: true` as a site configuration for demo and preview branch environments.

https://federalist.18f.gov/documentation/#advanced-settings