### PR TITLE
Resize hero images

### DIFF
--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -65,8 +65,8 @@
 
     &.create-an-account {
       background-image: url(../img/create-an-account/header/create-account-illo-header@2x.png);
-      background-position: 76% center;
-      background-size: 30%;
+      background-position: right bottom;
+      background-size: 45%;
       background-repeat: no-repeat;
       > .container {
         background-image: none;

--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -49,7 +49,7 @@
       > .container {
         background-image: url(../img/what-is-login/header/what-is-illo-header@2x.png);
         background-position-y: 2rem;
-        background-size: 50%;
+        background-size: 45%;
       }
     }
 


### PR DESCRIPTION
**Why:** Improve how hero images are displayed (See before and after screenshots below). 

IIRC, this PR is not part of any ticket, but it's a quick fix that I want to address recently (CC @shawnique @akhlaqkhan)

**How:** Configure `background-position` and `background-size`

- Reduce size for _What is login.gov?_ hero image to create more spacing between the hero image and the "— and"
- Reposition and resize _Create an account_ hero image so it doesn't appear unanchored
 
## What is login.gov
<img width="2880" alt="what-is-before-and-after@2x" src="https://user-images.githubusercontent.com/6327082/104230870-c28c0480-5413-11eb-8688-0b7a53d3b80d.png">

## Create an account

<img width="2880" alt="create-an-account-before-and-after@2x" src="https://user-images.githubusercontent.com/6327082/104230914-ccae0300-5413-11eb-8676-7759450fda87.png">
