### PR TITLE
LG-4027: Add "Optional" label for optional contact form fields

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -80,6 +80,7 @@ contact_page:
       pii_warning: Please do **not** include sensitive or identifying information in this section such as your full name, birth date or social security number.
       subtopic: Issue
       topic: Topic
+      optional: optional
     reset: Clear form
     submit: Submit
     subtopics:

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -80,6 +80,7 @@ contact_page:
       pii_warning: "**No** incluya información sensible o de identificación en esta sección, como su nombre completo, fecha de nacimiento o número de seguro social."
       subtopic: Problema
       topic: Tema
+      optional: opcional
     reset: Limpiar formulario
     submit: Enviar
     subtopics:

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -81,6 +81,7 @@ contact_page:
       pii_warning: Veuillez **ne pas** inclure d'informations sensibles ou d'identification dans cette section telles que votre nom complet, votre date de naissance ou votre numéro de sécurité sociale.
       subtopic: Problème
       topic: Sujet
+      optional: optionnel
     reset: Formulaire clair
     submit: Soumettre
     subtopics:

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -374,7 +374,7 @@
 
   <!-- START: Subtopic -->
   <label class="usa-label text-normal" for="sub-topic">
-    <b>{% t contact_page.support_request_form.labels.subtopic %}</b>
+    <span class="text-bold">{% t contact_page.support_request_form.labels.subtopic %}</span>
     <span class="usa-hint">({% t contact_page.support_request_form.labels.optional %})</span>
   </label>
   <select id="sub-topic" name="00NU0000004z905" class="usa-select"></select>

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -373,7 +373,10 @@
   <!-- END: Topic -->
 
   <!-- START: Subtopic -->
-  <label class="usa-label" for="sub-topic">{% t contact_page.support_request_form.labels.subtopic %}</label>
+  <label class="usa-label text-normal" for="sub-topic">
+    <b>{% t contact_page.support_request_form.labels.subtopic %}</b>
+    <span class="usa-hint">({% t contact_page.support_request_form.labels.optional %})</span>
+  </label>
   <select id="sub-topic" name="00NU0000004z905" class="usa-select"></select>
   <!-- END: Subtopic -->
 

--- a/_sass/components/_form.scss
+++ b/_sass/components/_form.scss
@@ -6,6 +6,10 @@
   margin-top: units(4);
 }
 
+.usa-label.text-normal {
+  @include u-text("normal");
+}
+
 .usa-input,
 .usa-input--lg-password,
 .usa-textarea,


### PR DESCRIPTION
**Why**: As a member of public, I should be able to identify what fields are optional when filling in Contact form for login.gov so that I can submit the form intuitively with minimum friction and time.

**References:**:

- https://designsystem.digital.gov/components/form-templates/#name-form

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/104241476-bd3ab400-542b-11eb-9cb1-d676c104060d.png)