### PR TITLE
Remove `USAJOBS` reference from Help landing page

### DIFF
--- a/_pages/help.md
+++ b/_pages/help.md
@@ -64,7 +64,7 @@ hero: true
           <h2 class="margin-bottom-05">
             <a href="{{ site.baseurl }}/help/specific-agencies/overview">Help with specific agencies</a>
           </h2>
-          <p class="margin-top-05">Get help with USAJOBS, Trusted Traveler Program (TTP), SAM.gov.</p>
+          <p class="margin-top-05">Get help with Trusted Traveler Program (TTP) and SAM.gov.</p>
         </div>
       </div>
     </li>


### PR DESCRIPTION
**Why:** Per #547, we are removing content about USAJOBS. So, this PR removes the reference about the USAJOBS from the Help Center landing page

**Note:** We don't have Spanish and French translations yet for the landing page, so we will need to revisit this issue in the future. //cc @shawnique @akhlaqkhan  