### PR TITLE
Translate help landing page

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -206,6 +206,27 @@ help:
 help_page:
   p_1: Browse common topics
   title: How can we help?
+  categories:
+    - title: Get started with login.gov
+      description: Create your account. Learn about authentication options and more account features.
+      url: /help/get-started/overview
+      image: /assets/img/help/get-started.svg
+    - title: Trouble signing in?
+      description: Forgot your password? Locked out of your account? We'll help you resolve access issues.
+      url: /help/trouble-signing-in/overview
+      image: /assets/img/help/trouble-signing-in.svg
+    - title: Manage your account
+      description: Change your account settings including your password, phone number, email, and more.
+      url: /help/manage-your-account/overview
+      image: /assets/img/help/manage-your-account.svg
+    - title: Help with specific agencies
+      description: Get help with USAJOBS, Trusted Traveler Programs (TTP), SAM.gov.
+      url: /help/specific-agencies/overview
+      image: /assets/img/help/help-specific-agencies.svg
+    - title: Verify your identity
+      description: Learn about options for verifying your identity.
+      url: /help/verify-your-identity/overview
+      image: /assets/img/help/verify-your-id.svg
 help_pages:
   get-started:
     overview: |-

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -209,23 +209,23 @@ help_page:
   categories:
     - title: Get started with login.gov
       description: Create your account. Learn about authentication options and more account features.
-      url: /help/get-started/overview
+      url: /help/get-started/overview/
       image: /assets/img/help/get-started.svg
     - title: Trouble signing in?
       description: Forgot your password? Locked out of your account? We'll help you resolve access issues.
-      url: /help/trouble-signing-in/overview
+      url: /help/trouble-signing-in/overview/
       image: /assets/img/help/trouble-signing-in.svg
     - title: Manage your account
       description: Change your account settings including your password, phone number, email, and more.
-      url: /help/manage-your-account/overview
+      url: /help/manage-your-account/overview/
       image: /assets/img/help/manage-your-account.svg
     - title: Help with specific agencies
       description: Get help with Trusted Traveler Programs (TTP) and SAM.gov.
-      url: /help/specific-agencies/overview
+      url: /help/specific-agencies/overview/
       image: /assets/img/help/help-specific-agencies.svg
     - title: Verify your identity
       description: Learn about options for verifying your identity.
-      url: /help/verify-your-identity/overview
+      url: /help/verify-your-identity/overview/
       image: /assets/img/help/verify-your-id.svg
 help_pages:
   get-started:

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -220,7 +220,7 @@ help_page:
       url: /help/manage-your-account/overview
       image: /assets/img/help/manage-your-account.svg
     - title: Help with specific agencies
-      description: Get help with USAJOBS, Trusted Traveler Programs (TTP), SAM.gov.
+      description: Get help with Trusted Traveler Programs (TTP) and SAM.gov.
       url: /help/specific-agencies/overview
       image: /assets/img/help/help-specific-agencies.svg
     - title: Verify your identity

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -163,6 +163,27 @@ help:
 help_page:
   p_1: Explore los temas comunes
   title: ¿Cómo podemos ayudar?
+  categories:
+    - title: Empiece con login.gov
+      description: Cree su cuenta. Conozca las opciones de autenticación y más características de la cuenta.
+      url: /help/get-started/overview/
+      image: /assets/img/help/get-started.svg
+    - title: ¿Tiene problemas para iniciar sesión?
+      description: ¿Olvidó su contraseña? ¿Se bloqueó su cuenta? Le ayudaremos a solucionar los problemas de acceso.
+      url: /help/trouble-signing-in/overview/
+      image: /assets/img/help/trouble-signing-in.svg
+    - title: Administrar su cuenta
+      description: Cambia la configuración de la cuenta, incluida la contraseña, el teléfono, el correo electrónico y más.
+      url: /help/manage-your-account/overview/
+      image: /assets/img/help/manage-your-account.svg
+    - title: Asistencia de agencias específicas
+      description: Obtenga ayuda con Trusted Traveler Programs (TTP), SAM.gov.
+      url: /help/specific-agencies/overview/
+      image: /assets/img/help/help-specific-agencies.svg
+    - title: Verifique su identidad
+      description: Aprenda sobre las opciones para verificar su identidad.
+      url: /help/verify-your-identity/overview/
+      image: /assets/img/help/verify-your-id.svg
 help_pages:
   get-started:
     overview: |-

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -194,6 +194,27 @@ help:
 help_page:
   p_1: Parcourir les sujets communs
   title: Comment pouvons nous aider?
+  categories:
+    - title: Commencez avec login.gov
+      description: Créez votre compte. Découvrez les options d'authentification et d'autres caractéristiques du compte.
+      url: /help/get-started/overview
+      image: /assets/img/help/get-started.svg
+    - title: Des problèmes pour vous connecter?
+      description: Vous avez oublié votre mot de passe ? Votre compte est bloqué ? Nous vous aiderons à résoudre vos problèmes d'accès.
+      url: /help/trouble-signing-in/overview
+      image: /assets/img/help/trouble-signing-in.svg
+    - title: Gérez votre compte
+      description: Modifiez les paramètres de votre compte, notamment votre mot de passe, votre numéro de téléphone, votre adresse électronique, etc.
+      url: /help/manage-your-account/overview
+      image: /assets/img/help/manage-your-account.svg
+    - title: Assistance auprès des agences spécifiques
+      description: Obtenez de l'aide avec Trusted Traveler Programs (TTP), SAM.gov.
+      url: /help/specific-agencies/overview
+      image: /assets/img/help/help-specific-agencies.svg
+    - title: Vérifiez votre identité
+      description: Découvrez les différentes options de vérification de votre identité.
+      url: /help/verify-your-identity/overview
+      image: /assets/img/help/verify-your-id.svg
 help_pages:
   get-started:
     overview: |-

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -197,23 +197,23 @@ help_page:
   categories:
     - title: Commencez avec login.gov
       description: Créez votre compte. Découvrez les options d'authentification et d'autres caractéristiques du compte.
-      url: /help/get-started/overview
+      url: /help/get-started/overview/
       image: /assets/img/help/get-started.svg
     - title: Des problèmes pour vous connecter?
       description: Vous avez oublié votre mot de passe ? Votre compte est bloqué ? Nous vous aiderons à résoudre vos problèmes d'accès.
-      url: /help/trouble-signing-in/overview
+      url: /help/trouble-signing-in/overview/
       image: /assets/img/help/trouble-signing-in.svg
     - title: Gérez votre compte
       description: Modifiez les paramètres de votre compte, notamment votre mot de passe, votre numéro de téléphone, votre adresse électronique, etc.
-      url: /help/manage-your-account/overview
+      url: /help/manage-your-account/overview/
       image: /assets/img/help/manage-your-account.svg
     - title: Assistance auprès des agences spécifiques
       description: Obtenez de l'aide avec Trusted Traveler Programs (TTP), SAM.gov.
-      url: /help/specific-agencies/overview
+      url: /help/specific-agencies/overview/
       image: /assets/img/help/help-specific-agencies.svg
     - title: Vérifiez votre identité
       description: Découvrez les différentes options de vérification de votre identité.
-      url: /help/verify-your-identity/overview
+      url: /help/verify-your-identity/overview/
       image: /assets/img/help/verify-your-id.svg
 help_pages:
   get-started:

--- a/_pages/help.md
+++ b/_pages/help.md
@@ -13,12 +13,12 @@ hero: true
       <div class="grid-row flex-row tablet:flex-align-center">
         <div class="grid-col-2">
           <div class="usa-card__img">
-            <img alt="" src="{{ item.image }}">
+            <img alt="" src="{{ item.image | prepend: site.baseurl }}">
           </div>
         </div>
         <div class="grid-col-10 padding-left-1 tablet:padding-left-3">
           <h2 class="margin-bottom-05">
-            <a href="{{ item.url }}">{{ item.title }}</a>
+            <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
           </h2>
           <p class="margin-top-05">{{ item.description }}</p>
         </div>

--- a/_pages/help.md
+++ b/_pages/help.md
@@ -8,80 +8,22 @@ hero: true
 ---
 <article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
+    {% for item in site.translations[site.lang]["help_page"]["categories"] %}
     <li class="card">
       <div class="grid-row flex-row tablet:flex-align-center">
         <div class="grid-col-2">
           <div class="usa-card__img">
-            <img alt="" src="{{ site.baseurl }}/assets/img/help/get-started.svg">
+            <img alt="" src="{{ item.image }}">
           </div>
         </div>
         <div class="grid-col-10 padding-left-1 tablet:padding-left-3">
           <h2 class="margin-bottom-05">
-            <a href="{{ site.baseurl }}/help/get-started/overview">Get started with login.gov</a>
+            <a href="{{ item.url }}">{{ item.title }}</a>
           </h2>
-          <p class="margin-top-05">Create your account. Learn about authentication options and more account features.</p>
+          <p class="margin-top-05">{{ item.description }}</p>
         </div>
       </div>
     </li>
-    <li class="card">
-      <div class="grid-row flex-row tablet:flex-align-center">
-        <div class="grid-col-2">
-          <div class="usa-card__img">
-            <img alt="" src="{{ site.baseurl }}/assets/img/help/verify-your-id.svg">
-          </div>
-        </div>
-        <div class="grid-col-10 padding-left-1 tablet:padding-left-3">
-          <h2 class="margin-bottom-05">
-            <a href="{{ site.baseurl }}/help/verify-your-identity/overview">Verify your identity</a>
-          </h2>
-          <p class="margin-top-05">Learn about options for verifying your identity.</p>
-        </div>
-      </div>
-    </li>
-    <li class="card">
-      <div class="grid-row flex-row tablet:flex-align-center">
-        <div class="grid-col-2">
-          <div class="usa-card__img">
-            <img alt="" src="{{ site.baseurl }}/assets/img/help/trouble-signing-in.svg">
-          </div>
-        </div>
-        <div class="grid-col-10 padding-left-1 tablet:padding-left-3">
-          <h2 class="margin-bottom-05">
-            <a href="{{ site.baseurl }}/help/trouble-signing-in/overview">Trouble signing in?</a>
-          </h2>
-          <p class="margin-top-05">Forgot your password? Locked out of your account? We'll help you resolve access issues.</p>
-        </div>
-      </div>
-    </li>
-    <li class="card">
-      <div class="grid-row flex-row tablet:flex-align-center">
-        <div class="grid-col-2">
-          <div class="usa-card__img">
-            <img alt="" src="{{ site.baseurl }}/assets/img/help/help-specific-agencies.svg">
-          </div>
-        </div>
-        <div class="grid-col-10 padding-left-1 tablet:padding-left-3">
-          <h2 class="margin-bottom-05">
-            <a href="{{ site.baseurl }}/help/specific-agencies/overview">Help with specific agencies</a>
-          </h2>
-          <p class="margin-top-05">Get help with Trusted Traveler Program (TTP) and SAM.gov.</p>
-        </div>
-      </div>
-    </li>
-    <li class="card">
-      <div class="grid-row flex-row tablet:flex-align-center">
-        <div class="grid-col-2">
-          <div class="usa-card__img">
-            <img alt="" src="{{ site.baseurl }}/assets/img/help/manage-your-account.svg">
-          </div>
-        </div>
-        <div class="grid-col-10 padding-left-1 tablet:padding-left-3">
-          <h2 class="margin-bottom-05">
-            <a href="{{ site.baseurl }}/help/manage-your-account/overview">Manage your account</a>
-          </h2>
-          <p class="margin-top-05">Change your account settings including your password, phone number, email, and more.</p>
-        </div>
-      </div>
-    </li>
+    {% endfor %}
   </ul>
 </article>


### PR DESCRIPTION
As a user, I should see help page information in my language (Spanish or French). 

AC:
* Text is translated.
* Links go to translated pages.