### PR TITLE
Opt-in Partners section for accessibility scan

### DIFF
--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -12,7 +12,6 @@ const TEST_TIMEOUT_MS = 10000;
 const EXCLUDE_PATTERNS = [
   /\.pdf$/, // Puppeteer Chromium cannot preview PDF files
   /^\/404\.html$/, // See: LG-3455 (TODO: Remove with implementation of LG-3455)
-  /^\/partners\//, // TODO: Remove with https://github.com/18F/identity-site/pull/483
 ];
 
 describe('accessibility', () => {


### PR DESCRIPTION
**Why**: Because issues have been resolved, and the tests pass. We want as few (ideally zero) exceptions in these tests as possible.