### PR TITLE
Content updates

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -42,7 +42,7 @@ contact_page:
     footer: |-
       ## Partner with login.gov
 
-      Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) or contact us at [partnerships@login.gov](mailto:partnerships@loging.gov).
+      Interested in using login.gov at your agency? Please [visit our partners website](https://partners.login.gov/) for more information.
 
       ## Report an issue
 


### PR DESCRIPTION
- Removes partners@login.gov email address from contact form 