### PR TITLE
LG-4142: Update leftover Source Sans to Public Sans 

### DIFF
--- a/_sass/components/_btn.scss
+++ b/_sass/components/_btn.scss
@@ -1,4 +1,6 @@
 .language-picker__label {
+  // TODO: Remove font-family once we assign `$theme-font-sans` design system variable to Public Sans.
+  font-family: $sans-serif-font-family;
   display: flex;
   align-items: center;
   padding: 0.75em;

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -8,7 +8,7 @@ header {
 }
 
 .usa-banner__header, .usa-banner__content, .usa-menu-btn {
-    // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
+  // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
   font-family: $sans-serif-font-family;
 }
 

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -7,6 +7,11 @@ header {
   }
 }
 
+.usa-banner__header, .usa-banner__content {
+    // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
+  font-family: $sans-serif-font-family;
+}
+
 .create-account-btn-link {
   margin-top: 2em;
   display: none;

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -7,7 +7,7 @@ header {
   }
 }
 
-.usa-banner__header, .usa-banner__content {
+.usa-banner__header, .usa-banner__content, .usa-menu-btn {
     // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
   font-family: $sans-serif-font-family;
 }

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -7,7 +7,7 @@ header {
   }
 }
 
-.usa-banner__header, .usa-banner__content, .usa-menu-btn {
+.usa-banner__header, .usa-banner__content, .usa-menu-btn, .usa-link {
   // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
   font-family: $sans-serif-font-family;
 }

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -104,6 +104,8 @@
 }
 
 .sign-in-logo.usa-button {
+  // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
+  font-family: $sans-serif-font-family;
   color: $black;
   font-weight: bold;
   margin: 0;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -82,6 +82,8 @@
 }
 
 .usa-logo__help {
+  // TODO: Remove this once we assign `$theme-font-sans` design system variable to Public Sans.
+  font-family: $sans-serif-font-family;
   font-size: 0.8125rem;
   font-weight: bold;
   color: $navy;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -202,6 +202,11 @@
 }
 
 @include at-media-max("desktop") {
+  .usa-nav, .usa-nav__primary {
+    // TODO: Remove font-family once we assign `$theme-font-sans` design system variable to Public Sans.
+    font-family: $sans-serif-font-family;
+  }
+
   .usa-nav__primary {
     margin-left: -1rem;
     margin-right: -1rem;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -119,7 +119,7 @@
   display: inline-block;
   white-space: nowrap;
   padding: 0.85rem;
-  padding: 0.75rem 0.6rem;
+  padding: 0.75rem 0.5rem;
   box-shadow: inset 0 0 0 1px #bbb;
 
   &:hover {

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -119,7 +119,7 @@
   display: inline-block;
   white-space: nowrap;
   padding: 0.85rem;
-  padding: 0.75rem;
+  padding: 0.6rem;
   box-shadow: inset 0 0 0 1px #bbb;
 
   &:hover {

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -240,6 +240,8 @@
   }
 
   .usa-nav__link span {
+    // TODO: Remove font-family once we assign `$theme-font-sans` design system variable to Public Sans.
+    font-family: $sans-serif-font-family;
     text-transform: none;
     display: inline-block;
     padding: 0 0 1rem 0;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -119,7 +119,7 @@
   display: inline-block;
   white-space: nowrap;
   padding: 0.85rem;
-  padding: 0.6rem;
+  padding: 0.75rem 0.6rem;
   box-shadow: inset 0 0 0 1px #bbb;
 
   &:hover {


### PR DESCRIPTION
**Why:** To transition from Source Sans Pro to Public Sans

😎 _/¯ [Preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-4142-replace-source-sans/)

**Context:** After the soft launch, there are leftover components and elements that still use Source Sans Pro. However, the Login Design System hasn't yet made a transition to Public Sans. For this reason, the issue is to individually target components and elements. After the design system update, we will remove `font-family` once we assign `$theme-font-sans` design system variable to Public Sans.

**What has been updated:** See below for a comparison between the two font families

- `usa-banner` component
- Language options button
- Sign-in button
- Navbar - desktop
- Mobile/tablet menu button
- Mobile/tablet menu navigation

<img width="2920" alt="LG-4142-before-and-after" src="https://user-images.githubusercontent.com/6327082/107331377-6c44cc80-6a78-11eb-8ed9-07ea3464d145.png">

