### PR TITLE
LG-3979: Typography updates

### DIFF
--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -31,7 +31,7 @@
   }
 
   p {
-    font-size: $base-font-sm;
-    line-height: 1.438rem;
+    font-size: $base-font-size;
+    line-height: $line-height;
   }
 }

--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -24,6 +24,7 @@
 
     @include at-media("desktop") {
       font-size: 1.25rem; // 20px
+      line-height: $line-height;
     }
   }
 }

--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -3,7 +3,7 @@
 
   ul {
     li {
-      line-height: 2.25rem;
+      line-height: 1.875rem;
       ul {
         list-style-type: '⁃  ';
         margin-bottom: 0;

--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -3,7 +3,7 @@
 
   ul {
     li {
-      line-height: 1.875rem;
+      line-height: $line-height;
       ul {
         list-style-type: '⁃  ';
         margin-bottom: 0;

--- a/_sass/components/_typography.scss
+++ b/_sass/components/_typography.scss
@@ -30,12 +30,19 @@ article p {
     line-height: $line-height;
   }
 
-  p {
+  p, ul {
     // TODO: Remove this once we assign `$theme-body-line-height` design system variable.
     line-height: $line-height;
 
     // TODO: Consider respecting or customizing `$theme-text-measure` design system variable.
     max-width: none;
+
+    li  {
+      ul {
+        list-style-type: '⁃  ';
+        margin-top: 0.25rem;
+      }
+    }
   }
 }
 

--- a/_sass/pages/_who_uses_login.scss
+++ b/_sass/pages/_who_uses_login.scss
@@ -14,7 +14,7 @@
       @include para-style($size: "sm");
       flex-basis: 0;
       flex-grow: 1;
-      line-height: 1.875rem;
+      line-height: $line-height;
 
       &:first-child {
         background: url(../img/who-uses-login/icon-shield/icon-shield.svg) left

--- a/_sass/pages/_who_uses_login.scss
+++ b/_sass/pages/_who_uses_login.scss
@@ -14,6 +14,7 @@
       @include para-style($size: "sm");
       flex-basis: 0;
       flex-grow: 1;
+      line-height: 1.875rem;
 
       &:first-child {
         background: url(../img/who-uses-login/icon-shield/icon-shield.svg) left


### PR DESCRIPTION
**Why:** Several pages are inconsistent with font-size and line-height, both paragraph and/or list:

- [Who uses login.gov](https://www.login.gov/who-uses-login/)
- [Create an account](https://www.login.gov/create-an-account/)
- [Help center](https://www.login.gov/help/)
- [Privacy & security](https://www.login.gov/policy/) and related pages

👉🏼  [Preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-3979-public-sans-updates/)

**How:**

- Update any font-size inconsistencies to 16px
- Update any line-height inconsistencies to 30px / 1.875rem
- Update list-style-type dash `⁃` for nested list
- **Misc:** Set/increase line-height for hero descriptions (they gotta breathe)

## Before and after

<img width="1240" alt="LG-3979-before-and-after" src="https://user-images.githubusercontent.com/6327082/108769315-74901380-751e-11eb-8b94-284205991b83.png">
