### PR TITLE
make help navigation sticky

### DIFF
--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -1,5 +1,5 @@
 {% include search.html size="small" id="sidenav" %}
-<nav class="margin-y-4 sidenav" aria-label="{% t accessible_labels.secondary_navigation %}">
+<nav class="margin-y-4 sidenav position-sticky pin-top" aria-label="{% t accessible_labels.secondary_navigation %}">
   <ul class="usa-accordion usa-sidenav">
     {% for subpage in site.help_pages %}
     {% assign subpage_slug = subpage | slugify %}

--- a/_sass/components/_site.scss
+++ b/_sass/components/_site.scss
@@ -1,4 +1,5 @@
 html,
 body {
   height: 100%;
+  overflow-x: visible;
 }


### PR DESCRIPTION
As a product owner, I want sticky navigation on the help center pages so that there is consistency with other side navigation menus.