### PR TITLE
fix href attribute

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -8,7 +8,7 @@ permalink: /404.html
   <div class="cover-container">
     <div class="masthead clearfix">
       <div class="inner">
-        <a href="{{ site.baseurl }}"><img src="{{ site.baseurl }}/assets/img/logo-white.svg" width="150" alt="login.gov logo" class='masthead-brand'/></a>
+        <a href="{{ '/' | prepend: site.baseurl }}"><img src="{{ site.baseurl }}/assets/img/logo-white.svg" width="150" alt="login.gov logo" class='masthead-brand'/></a>
       </div>
     </div>
     <div class="inner cover">


### PR DESCRIPTION
When manually testing the 404 page, I found that clicking the logo would lead to a 404 as the `href` attribute was missing. This is an attempt to fix that bug.