### PR TITLE
Fix English landing page layout

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -18,7 +18,7 @@ backend:
 #
 # backend:
 #   name: git-gateway
-#   branch: jd-more-bug-fixes
+#   branch: JD-lg-4499-english-landing-page
 #   proxy_url: http://localhost:8081/api/v1
 # local_backend: true
 
@@ -100,7 +100,7 @@ collections:
     filter: { field: 'layout', value: 'landing' }
     sortable_fields: ['commit_date', 'title', 'commit_author']
     fields:
-      - { label: 'Layout', name: 'layout', widget: 'hidden', default: 'main' }
+      - { label: 'Layout', name: 'layout', widget: 'hidden', default: 'landing' }
       - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1', i18n: true }
       - { label: 'Description', name: 'description', widget: 'string', i18n: true }
       - label: 'Two Column'


### PR DESCRIPTION
This PR fixes the layout problem that would happen when english landing pages are created. Before, you would see no content on an english landing page despite it being created from the landing page collection. Now, the expected behavior of english landing pages having the correct layout shows up.