### PR TITLE
Translate Touchpoints via script.onload callback

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -8,7 +8,7 @@
   {% assign _src = _script.src | default: _script %}
 <script src="{{ _src | relative_url }}"></script>
 {% endfor %}{% endfor %}
-{% if page.layout == "help" and page.category != "verify-your-identity" %}
-  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js"></script>
+{% if layout.include_touchpoints and page.category != "verify-your-identity" %}
   <script src="{{'/assets/js/touchpoints_translations.js' | relative_url}}"></script>
-{% endif %}  
+  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" async onload="translateTouchpoints()"></script>
+{% endif %}

--- a/assets/js/touchpoints_translations.js
+++ b/assets/js/touchpoints_translations.js
@@ -1,13 +1,20 @@
-const yesButton = document.querySelector('input[type=submit][value=yes]');
-const noButton = document.querySelector('input[type=submit][value=no]');
+/**
+ * Attached to Touchpoints script tag as an onload callback
+ */
+function translateTouchpoints() {
+  const yesButton = document.querySelector('input[type=submit][value=yes]');
+  const noButton = document.querySelector('input[type=submit][value=no]');
 
-if (document.documentElement.lang === 'es') {
-  if (yesButton) {
-    yesButton.value = 'si';
-  }
-} else if (document.documentElement.lang === 'fr') {
   if (yesButton && noButton) {
-    yesButton.value = 'oui';
-    noButton.value = 'non';
+    if (document.documentElement.lang === 'es') {
+      if (yesButton) {
+        yesButton.value = 'si';
+      }
+    } else if (document.documentElement.lang === 'fr') {
+      if (yesButton && noButton) {
+        yesButton.value = 'oui';
+        noButton.value = 'non';
+      }
+    }
   }
 }


### PR DESCRIPTION
I had an idea for a way to reliably call our translation code after the Touchpoints JS load: an `onload` callback

Another idea I experimented with: `setTimeout` + checking the DOM + retry + backoff + attempts limit, but I think this is more reliable
