### PR TITLE
Fix help section mobile primary menu subitem rendering

### DIFF
--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -48,7 +48,7 @@
               {% for article in articles %}
                 <li class="usa-nav__submenu-item">
                   <a
-                    href="{{ article.url }}"
+                    href="{{ article.url | prepend: site.baseurl }}"
                     class="{% if page.url == article.url %}usa-current{% endif %}"
                   >
                     {% if article.meta_title %}

--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -51,7 +51,11 @@
                     href="{{ article.url }}"
                     class="{% if page.url == article.url %}usa-current{% endif %}"
                   >
-                    {{ article.title }}
+                    {% if article.meta_title %}
+                      {{ article.meta_title }}
+                    {% else %}
+                      {{ article.title }}
+                    {% endif %}
                   </a>
                 </li>
               {% endfor %}

--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -29,11 +29,9 @@
             {% assign subpage_url = '/help/' | append: subpage_slug | append: '/' | prepend: site.baseurl %}
             {% assign path_split_subpage = page.path | split: subpage_url %}
             {% assign subpage_has_current = 'false' %}
-            {% assign articles = site.data[page.lang].settings.help[subpage_slug] %}
+            {% assign articles = site[page.lang] | where_exp: "item", "item.category == subpage_slug and item.lang == page.lang" | sort:'order' %}
             {% for article in articles %}
-              {% assign article_slug = article[0] %}
-              {% assign article_url = subpage_url | append:article_slug | append: '/' %}
-              {% if page.url == article_url %}
+              {% if page.url == article.url %}
                 {% assign subpage_has_current = 'true' %}
               {% endif %}
             {% endfor %}
@@ -47,18 +45,15 @@
               <span>{{ subpage_title }}</span>
             </button>
             <ul id="help-header-nav-{{ subpage_slug }}" class="usa-nav__submenu">
-              {% for article in articles %} {% assign article_slug = article[0] %} {% assign
-              article_title = article[1] %} {% assign article_url = subpage_url | append:
-              article_slug | append: '/' %} {% assign path_split_article = page.path | split:
-              article_url %}
-              <li class="usa-nav__submenu-item">
-                <a
-                  href="{{ article_url }}"
-                  class="{% if page.url == article_url %}usa-current{% endif %}"
-                >
-                  {{ article_title }}
-                </a>
-              </li>
+              {% for article in articles %}
+                <li class="usa-nav__submenu-item">
+                  <a
+                    href="{{ article.url }}"
+                    class="{% if page.url == article.url %}usa-current{% endif %}"
+                  >
+                    {{ article.title }}
+                  </a>
+                </li>
               {% endfor %}
             </ul>
           </li>

--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -29,7 +29,7 @@
             {% assign subpage_url = '/help/' | append: subpage_slug | append: '/' | prepend: site.baseurl %}
             {% assign path_split_subpage = page.path | split: subpage_url %}
             {% assign subpage_has_current = 'false' %}
-            {% assign articles = site[page.lang] | where_exp: "item", "item.category == subpage_slug and item.lang == page.lang" | sort:'order' %}
+            {% assign articles = site[page.lang] | where_exp: "item", "item.category == subpage_slug and item.lang == page.lang" | sort: 'order' %}
             {% for article in articles %}
               {% if page.url == article.url %}
                 {% assign subpage_has_current = 'true' %}


### PR DESCRIPTION
**Why**: In transitioning to Netlify CMS, we no longer track articles in settings data. Instead, each is a content page with a category corresponding to the help category it is associated with. Just like we do with sidenav rendering, we should filter pages to construct the mobile primary navigation.

Before these changes, additional menu items aren't shown when a user taps on a mobile menu item in the help section.

See: https://github.com/18F/identity-site/pull/596/files#diff-f73e2a71b0a1bd48fbf42480e81c5a7f1b0f846eac2b83cad53644201db1c5aa

Before|After
---|---
![Screen Shot 2021-06-02 at 3 23 27 PM](https://user-images.githubusercontent.com/1779930/120540483-c1557700-c3b6-11eb-9eff-86a182bf1f07.png)|![Screen Shot 2021-06-02 at 3 29 24 PM](https://user-images.githubusercontent.com/1779930/120541069-66704f80-c3b7-11eb-93e0-8b7b98ecf26c.png)
