### PR TITLE
LG-4684: Add spec to verify localized pages maintain locale in links

### DIFF
--- a/_includes/language_picker.html
+++ b/_includes/language_picker.html
@@ -41,8 +41,11 @@
         {% assign locale_url = page.url | replace_first: page.lang, locale %}
       {% endif %}
     {% endif %}
-
-      <a href="{{ locale_url | prepend: site.baseurl }}" class="text-no-underline">
+      <a
+        href="{{ locale_url | prepend: site.baseurl }}"
+        class="text-no-underline"
+        lang="{{ locale }}"
+      >
         {{ site.data.[locale].settings.global.locales[locale] }}
       </a>
     </li>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ end
 
 REPO_ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 SITE_ROOT = Pathname.new(File.expand_path('../../_site', __FILE__))
+SITE_URL = YAML.load_file(File.join(REPO_ROOT, '_config.yml'))['url']
 
 def file_at(path)
   escaped_path = CGI.unescape(path)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -40,7 +40,9 @@ RSpec::Matchers.define :link_to_locale_pages do |locale|
       next if a[:lang]
       page = a[:href]
       link_path = URI::parse(page).path
-      broken_links << a.to_html if !link_path.start_with? "/#{locale}/"
+      if !link_path.start_with?("/#{locale}/") && !File.exist?(File.join(REPO_ROOT, link_path))
+        broken_links << a.to_html
+      end
     end
 
     expect(broken_links).to be_empty

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -30,6 +30,27 @@ RSpec::Matchers.define :link_to_valid_headers do
   end
 end
 
+RSpec::Matchers.define :link_to_locale_pages do |locale|
+  pages_with_broken_links = []
+
+  match do |actual|
+    doc = actual
+
+    doc.css("a[href^='/'],a[href^='#{SITE_URL}']").each do |a|
+      next if a[:lang]
+      page = a[:href]
+      link_path = URI::parse(page).path
+      pages_with_broken_links << a.to_html if !link_path.start_with? "/#{locale}/"
+    end
+
+    expect(pages_with_broken_links).to be_empty
+  end
+
+  failure_message do |actual|
+    "expected that #{actual.url} would link to locale #{locale}:\n\n#{pages_with_broken_links.join("\n\n")}"
+  end
+end
+
 RSpec::Matchers.define :link_to_valid_internal_pages do
   missing_pages = []
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -31,7 +31,7 @@ RSpec::Matchers.define :link_to_valid_headers do
 end
 
 RSpec::Matchers.define :link_to_locale_pages do |locale|
-  pages_with_broken_links = []
+  broken_links = []
 
   match do |actual|
     doc = actual
@@ -40,14 +40,14 @@ RSpec::Matchers.define :link_to_locale_pages do |locale|
       next if a[:lang]
       page = a[:href]
       link_path = URI::parse(page).path
-      pages_with_broken_links << a.to_html if !link_path.start_with? "/#{locale}/"
+      broken_links << a.to_html if !link_path.start_with? "/#{locale}/"
     end
 
-    expect(pages_with_broken_links).to be_empty
+    expect(broken_links).to be_empty
   end
 
   failure_message do |actual|
-    "expected that #{actual.url} would link to locale #{locale}:\n\n#{pages_with_broken_links.join("\n\n")}"
+    "expected that #{actual.url} would link to locale #{locale}:\n\n#{broken_links.join("\n\n")}"
   end
 end
 


### PR DESCRIPTION
**Why**: As a user, I expect that when I'm reading the French or Spanish version of the site, links within content maintain the locale, so that I can follow navigation in my preferred language.

Also incorporates LG-4388: "Brochure Site: Add "lang" attribute to language dropdown items", as an indicator of exception for language picker links.

This is expected to fail build currently, since there are a number of existing issues.