### PR TITLE
Remove valid internal pages spec

### DIFF
--- a/scripts/sitemap-check
+++ b/scripts/sitemap-check
@@ -62,7 +62,6 @@ end
 def check_urls(urls:, directory:, source:)
   missing_urls = []
   urls.each do |url|
-    next if url.end_with? '404.html'
     if !File.exist?(File.join(directory, to_relative_path(url)))
       missing_urls << [url, source]
     end

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe 'all pages' do
         expect(doc).to link_to_valid_headers
       end
 
-      xit 'links to valid internal pages' do
-        expect(doc).to link_to_valid_internal_pages
-      end
-
       locale = get_locale(path)
       context 'localization', if: locale do
         it 'maintains locale in links' do

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -53,30 +53,6 @@ RSpec::Matchers.define :link_to_locale_pages do |locale|
   end
 end
 
-RSpec::Matchers.define :link_to_valid_internal_pages do
-  missing_pages = []
-
-  match do |actual|
-    doc = actual
-
-    doc.css('a[href^="/"]').each do |a|
-      page = a[:href]
-
-      begin
-        file_at(page)
-      rescue StandardError
-        missing_pages << page
-      end
-    end
-
-    expect(missing_pages).to be_empty
-  end
-
-  failure_message do |actual|
-    "expected that #{actual.url} would link to valid pages:\n#{missing_pages.join("\n")}"
-  end
-end
-
 RSpec::Matchers.define :properly_escape_html do
   escaped_html_tags = nil
 


### PR DESCRIPTION
See: https://github.com/18F/identity-site/pull/657#discussion_r649484068

We use htmlproofer, which already checks for valid links, so this spec is redundant. It's also currently skipped.