### PR TITLE
add integrity hash to touchpoints script tag

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,6 +9,6 @@
 <script src="{{ _src | relative_url }}"></script>
 {% endfor %}{% endfor %}
 {% if layout.includes_touchpoints %}
-  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" integrity="sha256-bJJrp2Fye5tHOooPte/au2FqGDZwmymjr4+r4UrbeaE="></script>
+  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" integrity="sha256-bJJrp2Fye5tHOooPte/au2FqGDZwmymjr4+r4UrbeaE="  crossorigin="anonymous"></script>
   <script src="{{'/assets/js/build/touchpoints_translations.js' | relative_url}}"></script>
 {% endif %}  

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,6 +9,6 @@
 <script src="{{ _src | relative_url }}"></script>
 {% endfor %}{% endfor %}
 {% if layout.includes_touchpoints %}
-  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js"></script>
+  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" integrity="sha256-bJJrp2Fye5tHOooPte/au2FqGDZwmymjr4+r4UrbeaE="></script>
   <script src="{{'/assets/js/build/touchpoints_translations.js' | relative_url}}"></script>
 {% endif %}  


### PR DESCRIPTION
This ticket adds the integrity attribute to the Touchpoints script tag. This was done in hopes of adding a security layer to responses on the Touchpoints survey.