### PR TITLE
Update i18n spec to assert no missing translations

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -154,59 +154,6 @@ help_subpages:
   manage-your-account: Manage your account
   specific-agencies: Help with specific agencies
   verify-your-identity: Verify your identity
-meta:
-  accessibility:
-    description: Read our accessibility statement
-    title: Accessibility
-  contact:
-    title: Contact
-  contact_us:
-    description: Have a question or a problem with login.gov?
-    title: Contact us
-  developers:
-    title: Partners
-  help:
-    description: Get answers to common questions about login.gov.
-    title: Help
-  home:
-    description: Use one account for secure, private access to Federal benefits and services.
-    title: Home
-  implementation:
-    description: Determine whether your agency or organization needs a consumer identity
-      management system.
-    title: Implementation
-  not_found:
-    title: '404'
-  our-agency-partners:
-    description: Join the dozens of U.S. government agencies using login.gov. Learn more about how login.gov can benefit your agency.
-    title: Our agency partners
-  partners:
-    description: We help government agencies manage, secure and optimize the login experience for their websites, services and applications.
-    title: Partner with login.gov
-  playbook:
-    description: Helping developers and technologists in government agencies build
-      usable, secure, and privacy-protecting consumer identity management systems.
-    title: Identity Playbook
-  principles:
-    description: Explore the principles that have helped us make the best system possible.
-    title: Principles
-  privacy_and_security:
-    description: Learn more about our security and privacy practices.
-    title: Privacy & security
-  privacy_policy:
-    title: Privacy policy
-  what-is-login:
-    title: What is login.gov?
-    description: A summary of what login.gov is and the service it provides.
-  who-uses-login:
-    title: Who uses login.gov?
-    description: A list of customers currently benefitting from login.gov's services
-  why-login-gov:
-    title: Why login.gov
-    description: U.S. government agencies can take advantage of login.gov’s authentication and identity proofing platform. Find out more about login.gov’s offerings and opportunities.
-  create-an-account:
-    title: Create an account
-    description: Join the millions of people who trust login.gov for safe, secure access to government agencies.
 nav:
   accessibility:
     title: Accessibility statement
@@ -245,8 +192,6 @@ nav:
   implementation: Implementation
   menu: Menu
   overview: Overview
-  our-agency-partners: Our agency partners
-  partners: Partners
   playbook: Playbook
   policies:
     title: Privacy & security

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -157,49 +157,6 @@ help_subpages:
   manage-your-account: Administrar su cuenta
   specific-agencies: Ayuda con agencias específicas
   verify-your-identity: Verificación de identidad
-meta:
-  contact:
-    title: Contacto
-  contact_us:
-    description: '¿Tiene alguna pregunta o problema con login.gov?'
-    title: Contáctenos
-  developers:
-    title: Desarrolladores
-  help:
-    description: Obtenga respuestas a preguntas comunes sobre login.gov.
-    title: Ayuda
-  home:
-    description: Use una cuenta para tener acceso privado y seguro a los beneficios y servicios federales.
-    title: Inicio
-  implementation:
-    description: Determine si su agencia u organización necesita un sistema de gestión
-      de la identidad del consumidor.
-    title: Implementación
-  not_found:
-    title: '404'
-  playbook:
-    description: Ayudar a los desarrolladores y tecnólogos de los organismos gubernamentales
-      a crear sistemas de administración de la identidad de los consumidores que sean
-      útiles, seguros y que garanticen la protección de la privacidad.
-    title: Manual de identidad
-  principles:
-    description: Explore los principios que nos han ayudado a hacer el mejor sistema
-      posible.
-    title: Principios
-  privacy_and_security:
-    description: Obtenga más información sobre nuestras prácticas de seguridad y privacidad.
-    title: Privacidad y seguridad
-  privacy_policy:
-    title: Política de privacidad
-  what-is-login:
-    description: Un resumen de lo que es login.gov y el servicio que brinda.
-    title: ¿Qué es login.gov
-  who-uses-login:
-    description: Una lista de clientes que se benefician actualmente de los servicios de login.gov
-    title: ¿Quién usa login.gov?
-  why-login-gov:
-    description: Las agencias gubernamentales de EE. UU. Pueden aprovechar la plataforma de autenticación y verificación de identidad de login.gov. Obtenga más información sobre las ofertas y oportunidades de login.gov.
-    title: Por qué login.gov
 nav:
   accessibility:
     title: Accesibilidad

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -156,52 +156,6 @@ help_subpages:
   manage-your-account: Gérez votre compte
   specific-agencies: Aide aux agences spécifiques
   verify-your-identity: Vérifiez votre identité
-meta:
-  about:
-    description: Plus d'informations sur login.gov
-    title: Plus d'informations
-  contact:
-    title: Contact
-  contact_us:
-    description: Vous avez une question ou un problème concernant login.gov?
-    title: Nous joindre
-  developers:
-    title: Développeurs
-  help:
-    description: Trouvez des réponses aux questions fréquentes concernant login.gov.
-    title: Aide
-  home:
-    description: Utilisez un seul compte pour un accès sécurisé et privé aux prestations et services fédéraux.
-    title: Accueil
-  implementation:
-    description: Déterminez si votre agence ou votre organisme a besoin d'un système
-      de gestion de l'identité des utilisateurs.
-    title: Mise en œuvre
-  not_found:
-    title: '404'
-  playbook:
-    description: Aider les développeurs et les technologues des agences gouvernementales
-      à mettre en place des systèmes de gestion de l'identité des utilisateurs pratiques,
-      sécuritaires et respectueux de la vie privée.
-    title: Guide de mise en œuvre relatif à l'identité
-  principles:
-    description: Explorez les principes qui nous ont permis de concevoir le meilleur
-      système possible.
-    title: Principes
-  privacy_and_security:
-    description: Découvrez nos pratiques de sécurité et de confidentialité.
-    title: Confidentialité et sécurité
-  privacy_policy:
-    title: Politique de confidentialité
-  what-is-login:
-    description: Un résumé de ce qu'est login.gov et du service qu'il fournit.
-    title: Qu'est-ce que login.gov?
-  who-uses-login:
-    description: Une liste de clients bénéficiant actuellement des services login.gov
-    title: Qui utilise login.gov?
-  why-login-gov:
-    description: Les agences gouvernementales américaines peuvent tirer parti de la plate-forme d'authentification et de vérification d'identité de login.gov. En savoir plus sur les offres et les opportunités de login.gov.
-    title: Pourquoi login.gov
 nav:
   accessibility:
     title: Accessibilité

--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -69,7 +69,7 @@
         class="usa-link desktop:display-none padding-y-1 margin-y-3 text-no-underline text-bold"
         href="{{ '/contact' | locale_url }}"
       >
-        {{ site.data.[page.lang].settings.meta.contact_us.title }}
+        {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>
 
       <div class="display-none desktop:display-block">
@@ -86,7 +86,7 @@
         class="usa-link display-none desktop:display-inline text-no-underline text-bold margin-left-1"
         href="{{ '/contact' | locale_url }}"
       >
-        {{ site.data.[page.lang].settings.meta.contact_us.title }}
+        {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>
     </nav>
   </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -69,7 +69,7 @@
         class="usa-link desktop:display-none padding-y-1 margin-y-3 text-no-underline text-bold"
         href="{{ '/contact' | locale_url }}"
       >
-        {{ site.data.[page.lang].settings.meta.contact_us.title }}
+        {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>
 
       {% include search.html size="small" id="header-nav" %}

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe 'i18n' do
   it 'does not have missing translations' do
     missing_translations = MissingTranslationFinder.new.call
 
-    expect(missing_translations).to_not be_empty
+    expect(missing_translations).to be_empty
   end
 end


### PR DESCRIPTION
**Why**: Per test case description, there should be no missing translations, so the missing translation set should be empty.

It's expected that this will fail, and was only passing previously because there currently are missing translations. Some of these are being fixed in #665.