### PR TITLE
LG-4051: Make "Don't have a state-issued ID?" a live link

### DIFF
--- a/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
@@ -10,7 +10,7 @@ Some government applications require identity verification. This additional laye
 You will need to verify your identity and secure your account.
 
 ## Requirements for identity verification
-1. Your State-Issued ID. You can upload a photo by phone or by computer. [Don’t have a state issued ID?](https://login.gov/help/verify-your-identity/accepted-state-issued-identification/)
+1. Your State-Issued ID. You can upload a photo by phone or by computer. [Don’t have a state issued ID?](/help/verify-your-identity/accepted-state-issued-identification)
 1. A phone or computer with a camera to take a photo of yourself (not always required)
 1. Social Security Number
 1. A phone number on a phone plan that is in your name.

--- a/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
@@ -10,7 +10,7 @@ Some government applications require identity verification. This additional laye
 You will need to verify your identity and secure your account.
 
 ## Requirements for identity verification
-1. Your State-Issued ID. You can upload a photo by phone or by computer. Don’t have a state issued ID?
+1. Your State-Issued ID. You can upload a photo by phone or by computer. [Don’t have a state issued ID?](https://login.gov/help/verify-your-identity/accepted-state-issued-identification/)
 1. A phone or computer with a camera to take a photo of yourself (not always required)
 1. Social Security Number
 1. A phone number on a phone plan that is in your name.

--- a/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
@@ -10,7 +10,7 @@ Some government applications require identity verification. This additional laye
 You will need to verify your identity and secure your account.
 
 ## Requirements for identity verification
-1. Your State-Issued ID. You can upload a photo by phone or by computer. [Don’t have a state issued ID?](/help/verify-your-identity/accepted-state-issued-identification)
+1. Your State-Issued ID. You can upload a photo by phone or by computer. [Don’t have a state issued ID?](/help/verify-your-identity/accepted-state-issued-identification/)
 1. A phone or computer with a camera to take a photo of yourself (not always required)
 1. Social Security Number
 1. A phone number on a phone plan that is in your name.

--- a/content/_es/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_es/help/verify-your-identity/how-to-verify-your-identity.md
@@ -10,7 +10,7 @@ Necesitarás verificar tu identidad y asegurar tu cuenta.
 
 ## Requisitos para la verificación de identidad
 
-1. Tu identificación emitida por el estado. Puedes subir una foto por teléfono o por computadora. ¿No cuentas con una identificación emitida por el estado?
+1. Tu identificación emitida por el estado. Puedes subir una foto por teléfono o por computadora. [¿No cuentas con una identificación emitida por el estado?](/es/help/verify-your-identity/accepted-state-issued-identification)
 1. Un teléfono o computadora con cámara para que te tomes una foto (no siempre se requiere)
 1. Número de seguridad social
 1. Un número telefónico o un plan telefónico que tengas a tu nombre
@@ -19,7 +19,7 @@ Necesitarás verificar tu identidad y asegurar tu cuenta.
 Si te falta alguna información de este tipo, por favor ponte en contacto con la agencia gubernamental a la que estás tratando de tener acceso.
 
 ## Nuestros estándares de privacidad y seguridad
-Login.gov es un sitio web gubernamental seguro que se apega a los estándares más altos en lo que se refiere a la protección de datos. La mayor parte de los datos que envías no se almacenan. Conoce cómo verificamos tu identidad y las [medidas de privacidad y seguridad](/es/policy/) que adoptamos para mantener tu información segura (https://login.gov/policy).
+Login.gov es un sitio web gubernamental seguro que se apega a los estándares más altos en lo que se refiere a la protección de datos. La mayor parte de los datos que envías no se almacenan. Conoce cómo verificamos tu identidad y las [medidas de privacidad y seguridad](/es/policy) que adoptamos para mantener tu información segura.
 
 ## Pasos para la verificación de identidad y para asegurar tu cuenta
 1. Lee los requisitos en la página que dice "Necesitamos verificar tu identidad", y si estás de acuerdo, marca el recuadro que se encuentra junto a la declaración de consentimiento informado de login.gov.

--- a/content/_es/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_es/help/verify-your-identity/how-to-verify-your-identity.md
@@ -10,7 +10,7 @@ Necesitarás verificar tu identidad y asegurar tu cuenta.
 
 ## Requisitos para la verificación de identidad
 
-1. Tu identificación emitida por el estado. Puedes subir una foto por teléfono o por computadora. [¿No cuentas con una identificación emitida por el estado?](/es/help/verify-your-identity/accepted-state-issued-identification)
+1. Tu identificación emitida por el estado. Puedes subir una foto por teléfono o por computadora. [¿No cuentas con una identificación emitida por el estado?](/es/help/verify-your-identity/accepted-state-issued-identification/)
 1. Un teléfono o computadora con cámara para que te tomes una foto (no siempre se requiere)
 1. Número de seguridad social
 1. Un número telefónico o un plan telefónico que tengas a tu nombre
@@ -19,7 +19,7 @@ Necesitarás verificar tu identidad y asegurar tu cuenta.
 Si te falta alguna información de este tipo, por favor ponte en contacto con la agencia gubernamental a la que estás tratando de tener acceso.
 
 ## Nuestros estándares de privacidad y seguridad
-Login.gov es un sitio web gubernamental seguro que se apega a los estándares más altos en lo que se refiere a la protección de datos. La mayor parte de los datos que envías no se almacenan. Conoce cómo verificamos tu identidad y las [medidas de privacidad y seguridad](/es/policy) que adoptamos para mantener tu información segura.
+Login.gov es un sitio web gubernamental seguro que se apega a los estándares más altos en lo que se refiere a la protección de datos. La mayor parte de los datos que envías no se almacenan. Conoce cómo verificamos tu identidad y las [medidas de privacidad y seguridad](/es/policy/) que adoptamos para mantener tu información segura.
 
 ## Pasos para la verificación de identidad y para asegurar tu cuenta
 1. Lee los requisitos en la página que dice "Necesitamos verificar tu identidad", y si estás de acuerdo, marca el recuadro que se encuentra junto a la declaración de consentimiento informado de login.gov.

--- a/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
@@ -9,7 +9,7 @@ Certaines applications gouvernementales nécessitent une vérification d'identit
 Vous devrez vérifier votre identité et sécuriser votre compte.
 
 ## Exigences relatives à la vérification de l'identité
-1. Votre carte d'identité délivrée par l'État. Vous pouvez charger une photo via un téléphone ou un ordinateur. Vous n'avez pas de carte d'identité délivrée par l'État?
+1. Votre carte d'identité délivrée par l'État. Vous pouvez charger une photo via un téléphone ou un ordinateur. [Vous n'avez pas de carte d'identité délivrée par l'État?](/fr/help/verify-your-identity/accepted-state-issued-identification)
 1. Vous pouvez à l'aide d'un téléphone ou d'un ordinateur équipé d'une caméra prendre une photo de vous (pas toujours nécessaire)
 1. Numéro de sécurité sociale
 1. Un numéro de téléphone sur un plan téléphonique qui est à votre nom.

--- a/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
@@ -9,7 +9,7 @@ Certaines applications gouvernementales nécessitent une vérification d'identit
 Vous devrez vérifier votre identité et sécuriser votre compte.
 
 ## Exigences relatives à la vérification de l'identité
-1. Votre carte d'identité délivrée par l'État. Vous pouvez charger une photo via un téléphone ou un ordinateur. [Vous n'avez pas de carte d'identité délivrée par l'État?](/fr/help/verify-your-identity/accepted-state-issued-identification)
+1. Votre carte d'identité délivrée par l'État. Vous pouvez charger une photo via un téléphone ou un ordinateur. [Vous n'avez pas de carte d'identité délivrée par l'État?](/fr/help/verify-your-identity/accepted-state-issued-identification/)
 1. Vous pouvez à l'aide d'un téléphone ou d'un ordinateur équipé d'une caméra prendre une photo de vous (pas toujours nécessaire)
 1. Numéro de sécurité sociale
 1. Un numéro de téléphone sur un plan téléphonique qui est à votre nom.


### PR DESCRIPTION
The purpose of this ticket is to add a hyperlink to the "Don't have a state issued ID?" copy on the "Verify your Identity" page. The text now links the user to the "Accepted State-Issued Identification" page.