### PR TITLE
Remove unused reference to js-mobile-nav-toggle element

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,14 +8,6 @@ const components = [accordion, accordionCloseButton, banner, navigation];
 domready(() => components.forEach((component) => component.on()));
 
 $(function () {
-  // Mobile main nav toggle
-
-  $('#js-mobile-nav-toggle').click(function () {
-    $(this).find('span').toggle();
-    $(this).find('img').toggleClass('display-none');
-    $('header nav').toggleClass('flex');
-  });
-
   // Language picker
 
   function languagePicker(trigger, dropdown) {

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -12,8 +12,6 @@ RSpec::Matchers.define :link_to_valid_headers do
     doc.css('a[href^="#"]').each do |a|
       target = a[:href]
 
-      next if a[:id] == 'js-mobile-nav-toggle'
-
       if target == '#'
         missing_headers << a.to_s
       else


### PR DESCRIPTION
**Why**: Smaller bundle size, fewer lingering dependencies on jQuery toward eventual removal.

Last reference removed as of 155cfc87afff9eaf50b3bb9d2d65191ada1951c8
