### PR TITLE
Stop using incremental Jekyll build

### DIFF
--- a/Makefile.server
+++ b/Makefile.server
@@ -4,7 +4,7 @@ _config.dev.yml:
 	touch _config.dev.yml
 
 jekyll: _config.dev.yml
-	bundle exec jekyll serve --watch --incremental --config _config.yml,_config.dev.yml
+	bundle exec jekyll serve --watch --config _config.yml,_config.dev.yml
 
 npm-watch-js:
 	NODE_ENV=development npm run watch-js


### PR DESCRIPTION
**Why**: So that I can trust that when I save while running `make run`, the site contents will be rebuilt.

Incremental flag seems very flakey, and seems to depend heavily on the type of content being saved whether it actually works (e.g. markdown vs. partials, etc).