### PR TITLE
Run JavaScript immediately on load

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,31 +1,26 @@
 import $ from 'jquery';
 import { accordion, accordionCloseButton, banner, navigation } from 'identity-style-guide';
-import domready from 'domready';
-
-window.LoginGov = window.LoginGov || {};
 
 const components = [accordion, accordionCloseButton, banner, navigation];
-domready(() => components.forEach((component) => component.on()));
+components.forEach((component) => component.on());
 
-$(function () {
-  // Language picker
+// Language picker
 
-  function languagePicker(trigger, dropdown) {
-    trigger.on('click keypress', function (event) {
-      event.preventDefault();
-      var eventType = event.type;
-      if (eventType == 'click' || (eventType == 'keypress' && event.which == 13)) {
-        dropdown.toggle();
+function languagePicker(trigger, dropdown) {
+  trigger.on('click keypress', function (event) {
+    event.preventDefault();
+    var eventType = event.type;
+    if (eventType == 'click' || (eventType == 'keypress' && event.which == 13)) {
+      dropdown.toggle();
 
-        $(this).attr('aria-expanded', function (i, attr) {
-          return attr == 'true' ? 'false' : 'true';
-        });
-      }
-    });
-  }
+      $(this).attr('aria-expanded', function (i, attr) {
+        return attr == 'true' ? 'false' : 'true';
+      });
+    }
+  });
+}
 
-  languagePicker(
-    $('.language-picker__label--button'),
-    $('.language-picker__label--button + .dropdown'),
-  );
-});
+languagePicker(
+  $('.language-picker__label--button'),
+  $('.language-picker__label--button + .dropdown'),
+);


### PR DESCRIPTION
**Why**: Since the script is the last content of the page, all elements referenced in the scripts will already be present. It's unnecessary to wait for the DOMContentLoaded event, which may introduce a brief delay. Additionally, this removes the domready dependency and reduces dependency on jQuery, facilitating its removal in the future.

For review, it's easiest to select the GitHub option "Ignore whitespace changes".