### PR TITLE
Improve external link check URL normalization

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 # Site settings
 title: login.gov
 image: /assets/img/login-gov-288x288.png
-canonical_domain: www.login.gov
 
 # i18n
 languages:

--- a/_config.yml
+++ b/_config.yml
@@ -112,4 +112,4 @@ help_pages:
   - specific-agencies
   - verify-your-identity
 
-url: https://www.login.gov
+url: https://login.gov

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Site settings
 title: login.gov
 image: /assets/img/login-gov-288x288.png
+canonical_domain: www.login.gov
 
 # i18n
 languages:
@@ -111,4 +112,4 @@ help_pages:
   - specific-agencies
   - verify-your-identity
 
-url: https://login.gov
+url: https://www.login.gov

--- a/_includes/already_have_an_account_banner.html
+++ b/_includes/already_have_an_account_banner.html
@@ -5,7 +5,7 @@
             {{ site.data.[page.lang].settings.banner.already-have-an-account.one_account }}
         </h3>
         <p class="margin-bottom-0">
-            <a class="one-account-banner__link" href="{{ '/create-an-account' | locale_url }}">
+            <a class="one-account-banner__link" href="{{ '/create-an-account/' | locale_url }}">
                 {{ site.data.[page.lang].settings.banner.already-have-an-account.learn_more }}
             </a>
         </p>
@@ -18,7 +18,7 @@
             <a class="one-account-banner__link" href="https://secure.login.gov">
                 {{ site.data.[page.lang].settings.banner.already-have-an-account.sign_in }}
             </a>
-        </p>    
+        </p>
     </div>
   </div>
 </aside>

--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -67,7 +67,7 @@
 
       <a
         class="usa-link desktop:display-none padding-y-1 margin-y-3 text-no-underline text-bold"
-        href="{{ '/contact' | locale_url }}"
+        href="{{ '/contact/' | locale_url }}"
       >
         {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>
@@ -84,7 +84,7 @@
 
       <a
         class="usa-link display-none desktop:display-inline text-no-underline text-bold margin-left-1"
-        href="{{ '/contact' | locale_url }}"
+        href="{{ '/contact/' | locale_url }}"
       >
         {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,7 +34,7 @@
         <li class="usa-nav__primary-item">
           <a
             class="usa-nav__link {% if page.url contains '/what-is-login/' %}usa-current{% endif %}"
-            href="{{ '/what-is-login' | locale_url }}"
+            href="{{ '/what-is-login/' | locale_url }}"
           >
             <span>{{ site.data.[page.lang].settings.nav.what_is_login_gov }}</span>
           </a>
@@ -42,7 +42,7 @@
         <li class="usa-nav__primary-item">
           <a
             class="usa-nav__link {% if page.url contains '/who-uses-login/' %}usa-current{% endif %}"
-            href="{{ '/who-uses-login' | locale_url }}"
+            href="{{ '/who-uses-login/' | locale_url }}"
           >
             <span>{{ site.data.[page.lang].settings.nav.who_uses_login_gov }}</span>
           </a>
@@ -50,7 +50,7 @@
         <li class="usa-nav__primary-item">
           <a
             class="usa-nav__link {% if page.url contains '/create-an-account/' %}usa-current{% endif %}"
-            href="{{ '/create-an-account' | locale_url }}"
+            href="{{ '/create-an-account/' | locale_url }}"
           >
             <span>{{ site.data.[page.lang].settings.nav.create_an_account }}</span>
           </a>
@@ -58,7 +58,7 @@
         <li class="usa-nav__primary-item">
           <a
             class="usa-nav__link {% if page.url contains '/help/' %}usa-current{% endif %}"
-            href="{{ '/help' | locale_url }}"
+            href="{{ '/help/' | locale_url }}"
           >
             <span>{{ site.data.[page.lang].settings.nav.help_center }}</span>
           </a>
@@ -67,7 +67,7 @@
 
       <a
         class="usa-link desktop:display-none padding-y-1 margin-y-3 text-no-underline text-bold"
-        href="{{ '/contact' | locale_url }}"
+        href="{{ '/contact/' | locale_url }}"
       >
         {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>

--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -17,7 +17,7 @@
       {% else %}
         {% assign page_lang = '' %}
       {% endif %}
-        <a href="{{ subpage_slug | prepend: '/help/' | locale_url }}"
+        <a href="{{ subpage_slug | append: '/' | prepend: '/help/' | locale_url }}"
           class="{% if page.url contains subpage_slug %}usa-current{% endif %}">
           {{ site.data[page.lang]["settings"]["help_subpages"][subpage] }}
         </a>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -50,7 +50,7 @@
 <meta property="og:image" content="{{ image | absolute_url }}" />
 <meta name="twitter:image" content="{{ image | absolute_url }}" />
 
-<link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.canonical_domain | replace: '//', '/' | prepend: 'https://' }}" />
+<link rel="canonical" href="{{ page.url | replace: 'index.html', '' | absolute_url }}" />
 
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/apple-touch-icon.png' | relative_url }}" />
 <link rel="icon" type="image/png" href="{{ '/favicon-32x32.png' | relative_url }}" sizes="32x32" />

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -50,7 +50,7 @@
 <meta property="og:image" content="{{ image | absolute_url }}" />
 <meta name="twitter:image" content="{{ image | absolute_url }}" />
 
-<link rel="canonical" href="{{ page.url | replace: 'index.html', '' | absolute_url }}" />
+<link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.canonical_domain | replace: '//', '/' | prepend: 'https://' }}" />
 
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/apple-touch-icon.png' | relative_url }}" />
 <link rel="icon" type="image/png" href="{{ '/favicon-32x32.png' | relative_url }}" sizes="32x32" />

--- a/content/_en/help/get-started/create-your-account.md
+++ b/content/_en/help/get-started/create-your-account.md
@@ -40,7 +40,7 @@ Follow these steps to create your login.gov account.
    - Phone call
    - Backup codes
 
-   [Learn more about each authentication option](/help/get-started/authentication-options) to choose the one that is right for you.
+   [Learn more about each authentication option](/help/get-started/authentication-options/) to choose the one that is right for you.
 
 1. Success! Once you have authenticated, you have created your login.gov account.
 {: .number-list}
@@ -49,5 +49,5 @@ You will be taken to your login.gov account page or the government agency you ar
 
 ## Related articles
 
-- [Authentication options](/help/get-started/authentication-options)
-- [Manage your account](/help/manage-your-account/overview)
+- [Authentication options](/help/get-started/authentication-options/)
+- [Manage your account](/help/manage-your-account/overview/)

--- a/content/_en/help/get-started/overview.md
+++ b/content/_en/help/get-started/overview.md
@@ -35,5 +35,5 @@ Login.gov is the public's one account and password for government. Login.gov is 
 
 * [Create your login.gov account](/help/get-started/create-your-account/)
 * [Learn about authentication options](/help/get-started/authentication-options/)
-* [Why you are being asked to use login.gov](/what-is-login)
+* [Why you are being asked to use login.gov](/what-is-login/)
 {: .help-question-list}

--- a/content/_en/help/trouble-signing-in/overview.md
+++ b/content/_en/help/trouble-signing-in/overview.md
@@ -51,6 +51,6 @@ Forgot your password? Locked out of your account? We'll help you resolve account
 
 ## Common troubleshooting topics
 
-* [How to sign in to login.gov](/help/trouble-signing-in/how-to-sign-in)
-* [Forgot your password](/help/trouble-signing-in/forgot-your-password)
+* [How to sign in to login.gov](/help/trouble-signing-in/how-to-sign-in/)
+* [Forgot your password](/help/trouble-signing-in/forgot-your-password/)
 {: .help-question-list}

--- a/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_en/help/verify-your-identity/how-to-verify-your-identity.md
@@ -19,7 +19,7 @@ You will need to verify your identity and secure your account.
 If you are missing any of this information, please contact the government agency you are trying to access.
 
 ## Our privacy and security standards
-Login.gov is a secure, government website that adheres to the highest standards in data protection. Most of the data you submit is not stored. Learn how we verify your identity and the [privacy and security measures](/policy) we take to keep your information safe.
+Login.gov is a secure, government website that adheres to the highest standards in data protection. Most of the data you submit is not stored. Learn how we verify your identity and the [privacy and security measures](/policy/) we take to keep your information safe.
 
 ## Steps for identity verification and securing your account
 1. On the “We need to verify your identity” page, read the requirements and, if you agree, check the box next to the login.gov consent statement.

--- a/content/_en/landing/who_uses_login.md
+++ b/content/_en/landing/who_uses_login.md
@@ -17,7 +17,7 @@ component:
     * Paycheck Protection Program (Small Business Administration)
     * Disaster Loan Applications Program (Small Business Administration)
   col2: >-
-    Login.gov adheres to the latest [security standards](https://login.gov/security)
+    Login.gov adheres to the latest [security standards](https://login.gov/security/)
     established by top security organizations such as the [National Institute of
     Standards and Technology](https://www.nist.gov/), the [Cybersecurity
     National Action

--- a/content/_en/policy/contact.md
+++ b/content/_en/policy/contact.md
@@ -14,10 +14,10 @@ intro_content: |-
 
   If you need assistance with your login.gov account, check out our help center articles for help with common issues.
 
-  * [I can’t sign in to my account](/help/trouble-signing-in/overview)
-  * [I need help verifying my identity](/help/verify-your-identity/overview)
-  * [I need to change my information or manage my account](/help/manage-your-account/overview)
-  * [Browse more help articles](/help)
+  * [I can’t sign in to my account](/help/trouble-signing-in/overview/)
+  * [I need help verifying my identity](/help/verify-your-identity/overview/)
+  * [I need to change my information or manage my account](/help/manage-your-account/overview/)
+  * [Browse more help articles](/help/)
   {: .help-question-list}
 
   ## Do you have a question about your agency account?

--- a/content/_es/help/get-started/create-your-account.md
+++ b/content/_es/help/get-started/create-your-account.md
@@ -39,7 +39,7 @@ Siga estos pasos para crear su cuenta de login.gov.
    - Llamada telefónica
    - Códigos de respaldo
 
-   [Conozca más sobre cada opción de autenticación](/es/help/get-started/authentication-options) para elegir la que sea apropiada para usted.
+   [Conozca más sobre cada opción de autenticación](/es/help/get-started/authentication-options/) para elegir la que sea apropiada para usted.
 
 1. ¡El proceso fue exitoso! Una vez que haya autenticado, habrá creado su cuenta de login.gov.
 {: .number-list}
@@ -48,5 +48,5 @@ Será dirigido a la página de su cuenta de login.gov o a la agencia gubernament
 
 ## Artículos relacionados
 
-- [Opciones de autenticación](/es/help/get-started/authentication-options)
-- [Gestione su cuenta](/es/help/manage-your-account/overview)
+- [Opciones de autenticación](/es/help/get-started/authentication-options/)
+- [Gestione su cuenta](/es/help/manage-your-account/overview/)

--- a/content/_es/help/get-started/overview.md
+++ b/content/_es/help/get-started/overview.md
@@ -34,5 +34,5 @@ Login.gov es la única cuenta y contraseña pública para el gobierno. Login.gov
 
 * [Cree su cuenta de login.gov](/es/help/get-started/create-your-account/)
 * [Conozca las opciones de autenticación](/es/help/get-started/authentication-options/)
-* [Por qué se le solicita que use login.gov](/es/what-is-login)
+* [Por qué se le solicita que use login.gov](/es/what-is-login/)
 {: .help-question-list}

--- a/content/_es/help/trouble-signing-in/overview.md
+++ b/content/_es/help/trouble-signing-in/overview.md
@@ -50,6 +50,6 @@ redirect_from:
 
 ## Temas más comunes de solución de problemas
 
-* [Cómo acceder a login.gov](/es/help/trouble-signing-in/how-to-sign-in)
-* [Olvidó su contraseña](/es/help/trouble-signing-in/forgot-your-password)
+* [Cómo acceder a login.gov](/es/help/trouble-signing-in/how-to-sign-in/)
+* [Olvidó su contraseña](/es/help/trouble-signing-in/forgot-your-password/)
 {: .help-question-list}

--- a/content/_es/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_es/help/verify-your-identity/how-to-verify-your-identity.md
@@ -19,7 +19,7 @@ Necesitarás verificar tu identidad y asegurar tu cuenta.
 Si te falta alguna información de este tipo, por favor ponte en contacto con la agencia gubernamental a la que estás tratando de tener acceso.
 
 ## Nuestros estándares de privacidad y seguridad
-Login.gov es un sitio web gubernamental seguro que se apega a los estándares más altos en lo que se refiere a la protección de datos. La mayor parte de los datos que envías no se almacenan. Conoce cómo verificamos tu identidad y las [medidas de privacidad y seguridad](/es/policy) que adoptamos para mantener tu información segura (https://login.gov/policy).
+Login.gov es un sitio web gubernamental seguro que se apega a los estándares más altos en lo que se refiere a la protección de datos. La mayor parte de los datos que envías no se almacenan. Conoce cómo verificamos tu identidad y las [medidas de privacidad y seguridad](/es/policy/) que adoptamos para mantener tu información segura (https://login.gov/policy).
 
 ## Pasos para la verificación de identidad y para asegurar tu cuenta
 1. Lee los requisitos en la página que dice "Necesitamos verificar tu identidad", y si estás de acuerdo, marca el recuadro que se encuentra junto a la declaración de consentimiento informado de login.gov.

--- a/content/_es/landing/who_uses_login.md
+++ b/content/_es/landing/who_uses_login.md
@@ -20,7 +20,7 @@ component:
     * Programa de solicitudes de préstamos por desastre (Administración de pequeñas empresas)
   col2: >-
     Login.gov se adhiere a los últimos [estándares de
-    seguridad](https://login.gov/es/security) establecidos por las principales
+    seguridad](https://login.gov/es/security/) establecidos por las principales
     organizaciones de seguridad como el [Instituto Nacional de Estándares y
     Tecnología](https://www.nist.gov/), el [Plan de Acción Nacional de
     Ciberseguridad](https://www.hsdl.org/c/cybersecurity-national-action-plan/)

--- a/content/_es/policy/contact.md
+++ b/content/_es/policy/contact.md
@@ -14,10 +14,10 @@ intro_content: |-
 
   Si necesita ayuda con su cuenta de login.gov, consulte los artículos de nuestro centro de ayuda para obtener asistencia sobre problemas comunes.
 
-  * [No puedo iniciar sesión en mi cuenta](/es/help/trouble-signing-in/overview)
-  * [Necesito ayuda para verificar mi identidad](/es/help/verify-your-identity/overview)
-  * [Necesito cambiar mi información o administrar mi cuenta](/es/help/manage-your-account/overview)
-  * [Explorar más artículos de ayuda](/es/help)
+  * [No puedo iniciar sesión en mi cuenta](/es/help/trouble-signing-in/overview/)
+  * [Necesito ayuda para verificar mi identidad](/es/help/verify-your-identity/overview/)
+  * [Necesito cambiar mi información o administrar mi cuenta](/es/help/manage-your-account/overview/)
+  * [Explorar más artículos de ayuda](/es/help/)
   {: .help-question-list}
 
   ## ¿Tiene alguna pregunta sobre la cuenta de su agencia?

--- a/content/_fr/help/get-started/create-your-account.md
+++ b/content/_fr/help/get-started/create-your-account.md
@@ -39,7 +39,7 @@ Suivez les étapes suivantes pour créer votre compte login.gov.
    - Appel téléphonique
    - Codes de sauvegarde
 
-   [Renseignez-vous davantage sur chaque option d'authentification](/fr/help/get-started/authentication-options) pour choisir celle qui vous convient le mieux.
+   [Renseignez-vous davantage sur chaque option d'authentification](/fr/help/get-started/authentication-options/) pour choisir celle qui vous convient le mieux.
 
 1. Succès! Une fois que vous vous êtes authentifié, vous avez créé votre compte login.gov.
 {: .number-list}
@@ -48,5 +48,5 @@ Vous serez dirigé vers la page de votre compte login.gov ou vers l'agence gouve
 
 ## Articles connexes
 
-- [Options d'authentification](/fr/help/get-started/authentication-options)
-- [Gérer votre compte](/fr/help/manage-your-account/overview)
+- [Options d'authentification](/fr/help/get-started/authentication-options/)
+- [Gérer votre compte](/fr/help/manage-your-account/overview/)

--- a/content/_fr/help/get-started/overview.md
+++ b/content/_fr/help/get-started/overview.md
@@ -34,5 +34,5 @@ Login.gov est le seul compte et mot de passe du public pour le gouvernement. Log
 
 * [Créez votre compte login.gov](/fr/help/get-started/create-your-account/)
 * [En savoir plus sur les options d'authentification](/fr/help/get-started/authentication-options/)
-* [Pourquoi on vous demande d'utiliser login.gov](/fr/what-is-login)
+* [Pourquoi on vous demande d'utiliser login.gov](/fr/what-is-login/)
   {: .help-question-list}

--- a/content/_fr/help/trouble-signing-in/overview.md
+++ b/content/_fr/help/trouble-signing-in/overview.md
@@ -50,6 +50,6 @@ Vous avez oublié votre mot de passe? Verrouillé votre compte? Nous vous aidero
 
 ## Sujets de dépannage courants
 
-* [Comment se connecter à login.gov](/fr/help/trouble-signing-in/how-to-sign-in)
-* [Mot de passe oublié](/fr/help/trouble-signing-in/forgot-your-password)
+* [Comment se connecter à login.gov](/fr/help/trouble-signing-in/how-to-sign-in/)
+* [Mot de passe oublié](/fr/help/trouble-signing-in/forgot-your-password/)
 {: .help-question-list}

--- a/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
@@ -18,7 +18,7 @@ Vous devrez vérifier votre identité et sécuriser votre compte.
 S'il vous manque une de ces informations, veuillez contacter l'agence gouvernementale à laquelle vous essayez d'accéder.
 
 ## Nos normes de sécurité et de protection de la vie privée
-Login.gov est un site web gouvernemental sécurisé qui respecte les normes les plus strictes en matière de protection des données. La plupart des données que vous soumettez ne sont pas stockées. Découvrez comment nous vérifions votre identité et [les mesures de sécurité et de protection](https://login.gov/policy) de la vie privée que nous prenons pour assurer la sécurité de vos informations.
+Login.gov est un site web gouvernemental sécurisé qui respecte les normes les plus strictes en matière de protection des données. La plupart des données que vous soumettez ne sont pas stockées. Découvrez comment nous vérifions votre identité et [les mesures de sécurité et de protection](https://login.gov/policy/) de la vie privée que nous prenons pour assurer la sécurité de vos informations.
 
 ## Étapes de la vérification de l'identité et de la sécurisation de votre compte
 1. Sur la page « Nous devons vérifier votre identité », lisez les conditions et, si vous êtes d'accord, cochez la case située à côté de la déclaration de consentement de login.gov.

--- a/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
+++ b/content/_fr/help/verify-your-identity/how-to-verify-your-identity.md
@@ -18,7 +18,7 @@ Vous devrez vérifier votre identité et sécuriser votre compte.
 S'il vous manque une de ces informations, veuillez contacter l'agence gouvernementale à laquelle vous essayez d'accéder.
 
 ## Nos normes de sécurité et de protection de la vie privée
-Login.gov est un site web gouvernemental sécurisé qui respecte les normes les plus strictes en matière de protection des données. La plupart des données que vous soumettez ne sont pas stockées. Découvrez comment nous vérifions votre identité et [les mesures de sécurité et de protection](https://login.gov/policy/) de la vie privée que nous prenons pour assurer la sécurité de vos informations.
+Login.gov est un site web gouvernemental sécurisé qui respecte les normes les plus strictes en matière de protection des données. La plupart des données que vous soumettez ne sont pas stockées. Découvrez comment nous vérifions votre identité et [les mesures de sécurité et de protection](/fr/policy/) de la vie privée que nous prenons pour assurer la sécurité de vos informations.
 
 ## Étapes de la vérification de l'identité et de la sécurisation de votre compte
 1. Sur la page « Nous devons vérifier votre identité », lisez les conditions et, si vous êtes d'accord, cochez la case située à côté de la déclaration de consentement de login.gov.

--- a/content/_fr/landing/who_uses_login.md
+++ b/content/_fr/landing/who_uses_login.md
@@ -19,7 +19,7 @@ component:
 
     * Programme de demandes de prêts en cas de catastrophe (Small Business Administration)
   col2: >-
-    Login.gov adhère aux dernières [normes de sécurité](https://login.gov/fr/security)
+    Login.gov adhère aux dernières [normes de sécurité](https://login.gov/fr/security/)
     établies par des organisations de sécurité de premier plan telles que le
     [National Institute of Standards and Technology](https://www.nist.gov/), le
     [Cybersecurity National Action

--- a/content/_fr/policy/contact.md
+++ b/content/_fr/policy/contact.md
@@ -14,10 +14,10 @@ intro_content: |-
 
   Si vous avez besoin d’aide pour votre compte login.gov, consultez les articles de notre centre d’aide pour obtenir de l’aide sur des questions courantes.
 
-  * [Je ne peux pas me connecter à mon compte](/fr/help/trouble-signing-in/overview)
-  * [J’ai besoin d’aide pour vérifier mon identité](/fr/help/verify-your-identity/overview)
-  * [Je dois modifier mes informations ou gérer mon compte](/fr/help/manage-your-account/overview)
-  * [Parcourir d’autres articles d’aide](/fr/help)
+  * [Je ne peux pas me connecter à mon compte](/fr/help/trouble-signing-in/overview/)
+  * [J’ai besoin d’aide pour vérifier mon identité](/fr/help/verify-your-identity/overview/)
+  * [Je dois modifier mes informations ou gérer mon compte](/fr/help/manage-your-account/overview/)
+  * [Parcourir d’autres articles d’aide](/fr/help/)
   {: .help-question-list}
 
   ## Avez-vous une question concernant votre compte d’agence?

--- a/scripts/htmlproofer-external
+++ b/scripts/htmlproofer-external
@@ -18,5 +18,5 @@ HTMLProofer.check_directory(directory, {
   },
   # treat absolute URLs to our domain as if they were local
   # helps for rel="canonical" tags that exist locally but are not deployed yet
-  url_swap: { %r|https://www.login.gov/| => '/' },
+  url_swap: { %r|https?://(www\.)?login\.gov/?| => '/' },
 }).run

--- a/scripts/htmlproofer-external
+++ b/scripts/htmlproofer-external
@@ -3,6 +3,8 @@
 # ignore bad peer certificates which turn up in external links
 require 'html-proofer'
 
+SITE_URL = YAML.load_file(File.expand_path('../../_config.yml', __FILE__))['url']
+
 directory = ARGV.first
 if directory.nil?
   abort <<~STR
@@ -19,7 +21,7 @@ HTMLProofer.check_directory(directory, {
   # treat absolute URLs to our domain as if they were local
   # helps for rel="canonical" tags that exist locally but are not deployed yet
   url_swap: {
-    %r|https?://(www\.)?login\.gov/?| => '/',
+    %r|#{SITE_URL}/?| => '/',
     %r|/$| => '',
   },
 }).run

--- a/scripts/htmlproofer-external
+++ b/scripts/htmlproofer-external
@@ -18,5 +18,8 @@ HTMLProofer.check_directory(directory, {
   },
   # treat absolute URLs to our domain as if they were local
   # helps for rel="canonical" tags that exist locally but are not deployed yet
-  url_swap: { %r|https?://(www\.)?login\.gov/?| => '/' },
+  url_swap: {
+    %r|https?://(www\.)?login\.gov/?| => '/',
+    %r|./$| => '',
+  },
 }).run

--- a/scripts/htmlproofer-external
+++ b/scripts/htmlproofer-external
@@ -20,6 +20,6 @@ HTMLProofer.check_directory(directory, {
   # helps for rel="canonical" tags that exist locally but are not deployed yet
   url_swap: {
     %r|https?://(www\.)?login\.gov/?| => '/',
-    %r|./$| => '',
+    %r|/$| => '',
   },
 }).run

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -8,6 +8,10 @@ def redirect_page?(path)
   File.read(file_at(path)).include?('<meta http-equiv="refresh"')
 end
 
+def external_link?(uri)
+  uri.scheme && !/^(www\.)?#{URI(SITE_URL).host}$/.match(uri.host)
+end
+
 def get_locale(path)
   match = %r{^(fr|es)/}.match(path)
   match[1] if match
@@ -37,7 +41,7 @@ RSpec.describe 'all pages' do
         doc.css('a').each do |a|
           next if a[:href].start_with?('#')
           uri = URI(a[:href])
-          next if uri.scheme && !/^(www\.)?#{URI(SITE_URL).host}$/.match(uri.host)
+          next if external_link?(uri)
           expect(uri).to be_https_scheme, "expected https, got:\n\n#{a.to_html}"
           expect(uri).to be_plain_host, "expected plain host, got:\n\n#{a.to_html}"
           expect(uri).to have_trailing_slash, "expected trailing slash, got:\n\n#{a.to_html}"

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -34,7 +34,14 @@ RSpec.describe 'all pages' do
       end
 
       it 'links consistently' do
-        expect(doc).to link_consistently
+        doc.css('a').each do |a|
+          next if a[:href].start_with?('#')
+          uri = URI(a[:href])
+          next if uri.scheme && !/^(www\.)?#{URI(SITE_URL).host}$/.match(uri.host)
+          expect(uri).to be_https_scheme, "expected https, got:\n\n#{a.to_html}"
+          expect(uri).to be_plain_host, "expected plain host, got:\n\n#{a.to_html}"
+          expect(uri).to have_trailing_slash, "expected trailing slash, got:\n\n#{a.to_html}"
+        end
       end
 
       xit 'links to valid headings' do

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -9,7 +9,7 @@ def redirect_page?(path)
 end
 
 def external_link?(uri)
-  uri.scheme && !/^(www\.)?#{URI(SITE_URL).host}$/.match(uri.host)
+  uri.scheme && !/^(www\.)?#{SITE_URI.host}$/.match(uri.host)
 end
 
 def get_locale(path)

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -38,13 +38,15 @@ RSpec.describe 'all pages' do
       end
 
       it 'links consistently' do
-        doc.css('a').each do |a|
-          next if a[:href].start_with?('#')
-          uri = URI(a[:href])
-          next if external_link?(uri)
-          expect(uri).to be_https_scheme, "expected https, got:\n\n#{a.to_html}"
-          expect(uri).to be_plain_host, "expected plain host, got:\n\n#{a.to_html}"
-          expect(uri).to have_trailing_slash, "expected trailing slash, got:\n\n#{a.to_html}"
+        aggregate_failures do
+          doc.css('a').each do |a|
+            next if a[:href].start_with?('#')
+            uri = URI(a[:href])
+            next if external_link?(uri)
+            expect(uri).to be_https_scheme, "expected https, got:\n\n#{a.to_html}"
+            expect(uri).to be_plain_host, "expected plain host, got:\n\n#{a.to_html}"
+            expect(uri).to have_trailing_slash, "expected trailing slash, got:\n\n#{a.to_html}"
+          end
         end
       end
 

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe 'all pages' do
         expect(doc).to properly_escape_html
       end
 
+      it 'links consistently' do
+        expect(doc).to link_consistently
+      end
+
       xit 'links to valid headings' do
         expect(doc).to link_to_valid_headers
       end

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe 'all pages' do
             uri = URI(a[:href])
             next if external_link?(uri)
             expect(uri).to be_https_scheme, "expected https, got:\n\n#{a.to_html}"
-            expect(uri).to be_plain_host, "expected plain host, got:\n\n#{a.to_html}"
             expect(uri).to have_trailing_slash, "expected trailing slash, got:\n\n#{a.to_html}"
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 REPO_ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 SITE_ROOT = Pathname.new(File.expand_path('../../_site', __FILE__))
 SITE_URL = YAML.load_file(File.join(REPO_ROOT, '_config.yml'))['url']
+SITE_URI = URI(SITE_URL)
 
 def file_at(path)
   escaped_path = CGI.unescape(path)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -43,8 +43,8 @@ RSpec::Matchers.define :link_consistently do
       "a[href^='#{http_uri}']",
       "a[href^='#{www_uri}']",
       "a[href^='#{http_www_uri}']",
-      "a[href^='#{good_uri}']:not([href$='/'])",
-      "a[href^='/']:not([href$='/'])",
+      "a[href^='#{good_uri}']:not([href$='/']):not([href$='.pdf'])",
+      "a[href^='/']:not([href$='/']):not([href$='.pdf'])",
     ].join(',')).map { |node| node.to_html }.to_a
 
     expect(invalid_links).to be_empty

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -28,30 +28,18 @@ RSpec::Matchers.define :link_to_valid_headers do
   end
 end
 
-RSpec::Matchers.define :link_consistently do
-  invalid_links = []
+RSpec::Matchers.define :be_https_scheme do
+  match { |uri| expect(uri.scheme).to be_nil.or eq 'https' }
+end
 
-  match do |actual|
-    doc = actual
+RSpec::Matchers.define :be_plain_host do
+  match { |uri| expect(uri.host).to_not start_with 'www.' }
+end
 
-    good_uri = URI.parse(SITE_URL)
-    http_uri = good_uri.clone.tap { |u| u.scheme = 'http' }
-    www_uri = good_uri.clone.tap { |u| u.host = "www.#{u.host}" }
-    http_www_uri = http_uri.clone.tap { |u| u.host = "www.#{u.host}" }
-
-    invalid_links = doc.css([
-      "a[href^='#{http_uri}']",
-      "a[href^='#{www_uri}']",
-      "a[href^='#{http_www_uri}']",
-      "a[href^='#{good_uri}']:not([href$='/']):not([href$='.pdf'])",
-      "a[href^='/']:not([href$='/']):not([href$='.pdf'])",
-    ].join(',')).map { |node| node.to_html }.to_a
-
-    expect(invalid_links).to be_empty
-  end
-
-  failure_message do
-    "expected all internal links are rendered consistently (https protocol, no-www, trailing slash):\n\n#{invalid_links.join("\n")}"
+RSpec::Matchers.define :have_trailing_slash do
+  match do |uri|
+    expect(uri.path).to end_with('/').
+      or satisfy('have file extension') { |path| !File.extname(path).empty? }
   end
 end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -32,10 +32,6 @@ RSpec::Matchers.define :be_https_scheme do
   match { |uri| expect(uri.scheme).to be_nil.or eq 'https' }
 end
 
-RSpec::Matchers.define :be_plain_host do
-  match { |uri| expect(uri.host).to_not start_with 'www.' }
-end
-
 RSpec::Matchers.define :have_trailing_slash do
   match do |uri|
     expect(uri.path).to end_with('/').


### PR DESCRIPTION
**Why**: So that we ping fewer URLs and avoid pinging same-origin URLs, improving performance, reducing flakiness, and eliminating unnecessary requests to external sites.

Before:

>Checking 74 external links...

After:

>Checking 53 external links...