### PR TITLE
Test small and large viewports for accessibility tests

### DIFF
--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -19,22 +19,44 @@ describe('accessibility', () => {
     .map((url) => new URL(url).pathname)
     .filter((path) => !EXCLUDE_PATTERNS.some((pattern) => pattern.test(path)));
 
-  test.each(paths)(
-    '%s',
-    async (path) => {
-      await goto(path);
-      const results = await new AxePuppeteer(page)
-        .disableRules('frame-tested')
-        .exclude('iframe')
-        .exclude('.footer-nav') // See: LG-4038 (TODO: Remove with implementation of LG-4038)
-        .analyze();
-      expect(results).toHaveNoViolations();
+  /** @type {Record<string, Partial<import('puppeteer').Viewport>>} */
+  const viewports = {
+    small: { width: 800, height: 600 },
+    large: { width: 1280, height: 800 },
+  };
 
-      const links = await getLinks(page);
-      links.forEach((a) => {
-        expect(a).toNotHaveTargetBlank();
+  for (const [label, viewport] of Object.entries(viewports)) {
+    describe(`${label} viewport`, () => {
+      /** @type {import('puppeteer').Viewport} */
+      let originalViewport;
+
+      beforeAll(async () => {
+        originalViewport = page.viewport();
+        await page.setViewport(viewport);
       });
-    },
-    TEST_TIMEOUT_MS,
-  );
+
+      afterAll(async () => {
+        await page.setViewport(originalViewport);
+      });
+
+      test.each(paths)(
+        '%s',
+        async (path) => {
+          await goto(path);
+          const results = await new AxePuppeteer(page)
+            .disableRules('frame-tested')
+            .exclude('iframe')
+            .exclude('.footer-nav') // See: LG-4038 (TODO: Remove with implementation of LG-4038)
+            .analyze();
+          expect(results).toHaveNoViolations();
+
+          const links = await getLinks(page);
+          links.forEach((a) => {
+            expect(a).toNotHaveTargetBlank();
+          });
+        },
+        TEST_TIMEOUT_MS,
+      );
+    });
+  }
 });


### PR DESCRIPTION
Context: https://github.com/18F/identity-site/pull/674#issuecomment-877332750

**Why**: Due to media query styling, some issues are only present at one or the other viewport. Previously, the viewport was quite small so desktop-specific issues were not surfaced.

Review ignoring whitespace changes: https://github.com/18F/identity-site/pull/677/files?w=1

~Note: It's expected this will fail pending the changes at #674.~