### PR TITLE
LG-4251 remove login gov text

### DIFF
--- a/content/_en/policy/messaging.md
+++ b/content/_en/policy/messaging.md
@@ -17,4 +17,4 @@ login.gov uses SMS text messaging to help verify your identity when you create a
 * To opt out of receiving text messages from login.gov reply with the message STOP to the unwanted text message.
 * See [Our privacy act statement](/policy/our-privacy-act-statement/) for privacy policy information.
 * Carriers are not liable for delayed or undelivered messages.
-* You may [contact customer care here](/contact/) if you have questions or concerns.
+* You may [contact customer care](/contact/) if you have questions or concerns.

--- a/content/_en/policy/messaging.md
+++ b/content/_en/policy/messaging.md
@@ -14,7 +14,7 @@ login.gov uses SMS text messaging to help verify your identity when you create a
 * login.gov provides an authentication service and will not use text or voice messaging for any other purpose.
 * Your carriers messaging and data rates may apply.
 * Messages will only be sent as part of setting up and signing into your login.gov account.
-* You may [contact customer care here](/contact/) or by email at [hello@login.gov](mailto:hello@login.gov).
+* You may [contact customer care here](/contact/).
 * To opt out of receiving text messages from login.gov reply with the message STOP to the unwanted text message.
 * See [Our privacy act statement](/policy/our-privacy-act-statement/) for privacy policy information.
 * Carriers are not liable for delayed or undelivered messages.

--- a/content/_en/policy/messaging.md
+++ b/content/_en/policy/messaging.md
@@ -14,7 +14,7 @@ login.gov uses SMS text messaging to help verify your identity when you create a
 * login.gov provides an authentication service and will not use text or voice messaging for any other purpose.
 * Your carriers messaging and data rates may apply.
 * Messages will only be sent as part of setting up and signing into your login.gov account.
-* You may [contact customer care here](/contact/).
 * To opt out of receiving text messages from login.gov reply with the message STOP to the unwanted text message.
 * See [Our privacy act statement](/policy/our-privacy-act-statement/) for privacy policy information.
 * Carriers are not liable for delayed or undelivered messages.
+* You may [contact customer care here](/contact/) if you have questions or concerns.

--- a/content/_es/policy/messaging.md
+++ b/content/_es/policy/messaging.md
@@ -13,7 +13,7 @@ login.gov utiliza mensajes de texto SMS para ayudar a verificar su identidad cua
 * login.gov proporciona un servicio de autenticación y no utilizará mensajes de texto o de voz para ningún otro propósito.
 * Es posible que se apliquen tarifas de mensajería y datos de su proveedor.
 * Los mensajes solo se enviarán como parte de la configuración y el inicio de sesión en su cuenta de login.gov.
-* Puede [contactar a atención al cliente aquí](/es/contact/).
 * Para optar por no recibir mensajes de texto de login.gov, responda con el mensaje DETENER al mensaje de texto no deseado.
 * Consulte [Nuestra declaración de la ley de privacidad](/es/policy/our-privacy-act-statement/) para obtener información sobre la política de privacidad.
 * Los transportistas no son responsables por mensajes retrasados ​​o no entregados.
+* Puede [contactar al servicio de atención al cliente](/es/contact/) si tiene alguna duda o pregunta

--- a/content/_es/policy/messaging.md
+++ b/content/_es/policy/messaging.md
@@ -13,7 +13,7 @@ login.gov utiliza mensajes de texto SMS para ayudar a verificar su identidad cua
 * login.gov proporciona un servicio de autenticación y no utilizará mensajes de texto o de voz para ningún otro propósito.
 * Es posible que se apliquen tarifas de mensajería y datos de su proveedor.
 * Los mensajes solo se enviarán como parte de la configuración y el inicio de sesión en su cuenta de login.gov.
-* Puede [contactar a atención al cliente aquí](/es/contact/) o por correo electrónico a [hello@login.gov](mailto:hello@login.gov).
+* Puede [contactar a atención al cliente aquí](/es/contact/).
 * Para optar por no recibir mensajes de texto de login.gov, responda con el mensaje DETENER al mensaje de texto no deseado.
 * Consulte [Nuestra declaración de la ley de privacidad](/es/policy/our-privacy-act-statement/) para obtener información sobre la política de privacidad.
 * Los transportistas no son responsables por mensajes retrasados ​​o no entregados.

--- a/content/_fr/policy/messaging.md
+++ b/content/_fr/policy/messaging.md
@@ -13,7 +13,7 @@ login.gov utilise la messagerie texte SMS pour vous aider à vérifier votre ide
 * login.gov fournit un service d'authentification et n'utilisera pas la messagerie texte ou vocale à d'autres fins.
 * Les tarifs de messagerie et de données de votre opérateur peuvent s'appliquer.
 * Les messages ne seront envoyés que dans le cadre de la configuration et de la connexion à votre compte login.gov.
-* Vous pouvez [contacter le service client ici](/fr/contact/).
 * Pour refuser de recevoir des messages texte de login.gov, répondez avec le message STOP au message texte indésirable.
 * Voir [Notre déclaration de confidentialité](/fr/policy/our-privacy-act-statement/) pour obtenir des informations sur la politique de confidentialité.
 * Les transporteurs ne sont pas responsables des messages retardés ou non livrés.
+* Vous pouvez [contacter le service clientèle](/fr/contact/) si vous avez des questions ou des préoccupations.

--- a/content/_fr/policy/messaging.md
+++ b/content/_fr/policy/messaging.md
@@ -13,7 +13,7 @@ login.gov utilise la messagerie texte SMS pour vous aider à vérifier votre ide
 * login.gov fournit un service d'authentification et n'utilisera pas la messagerie texte ou vocale à d'autres fins.
 * Les tarifs de messagerie et de données de votre opérateur peuvent s'appliquer.
 * Les messages ne seront envoyés que dans le cadre de la configuration et de la connexion à votre compte login.gov.
-* Vous pouvez [contacter le service client ici](/fr/contact/) ou par e-mail à [hello@login.gov](mailto:hello@login.gov).
+* Vous pouvez [contacter le service client ici](/fr/contact/).
 * Pour refuser de recevoir des messages texte de login.gov, répondez avec le message STOP au message texte indésirable.
 * Voir [Notre déclaration de confidentialité](/fr/policy/our-privacy-act-statement/) pour obtenir des informations sur la politique de confidentialité.
 * Les transporteurs ne sont pas responsables des messages retardés ou non livrés.


### PR DESCRIPTION
### Why

This will update the language to remove references to help@login.gov which was causing confusion to customers. This also updated the language around the rest of the sentence for all available internationalizations.  