### PR TITLE
Fix PBGC dropdown option

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -30,7 +30,7 @@ contact_page:
       "DOT National Registry of Certified Medical Examiners": DOT National Registry of Certified Medical Examiners
       "DS Logon": DS Logon
       "GSA Sam.gov": GSA SAM.gov
-      "PBGC - MyPBA": "PBGC - MyPBA"
+      "PBGC-MyPBA": "PBGC - MyPBA"
       "Railroad Retirement Board": Railroad Retirement Board
       "SBA DLAP": SBA DLAP
       "Social Security Administration (SSA)": Social Security Administration (SSA)

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -30,7 +30,7 @@ contact_page:
       "DOT National Registry of Certified Medical Examiners": Registro Nacional de Examinadores Médicos Certificados del Departamento de Transporte
       "DS Logon": Conexión DS
       "GSA Sam.gov": GSA SAM.gov
-      "PBGC - MyPBA": "PBGC - MyPBA"
+      "PBGC-MyPBA": "PBGC - MyPBA"
       "Railroad Retirement Board": Junta de Jubilación del Ferrocarril
       "SBA DLAP": SBA DLAP
       "Social Security Administration (SSA)": Administración del Seguro Social (SSA, por su siglas en inglés)

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -30,7 +30,7 @@ contact_page:
       "DOT National Registry of Certified Medical Examiners": Registre national des médecins agréés du Département des transports
       "DS Logon": Connexion DS
       "GSA Sam.gov": GSA SAM.gov
-      "PBGC - MyPBA": "PBGC - MyPBA"
+      "PBGC-MyPBA": "PBGC - MyPBA"
       "Railroad Retirement Board": Conseil des retraites des chemins de fer
       "SBA DLAP": SBA DLAP
       "Social Security Administration (SSA)": Administration de la sécurité sociale (SSA)

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -3,7 +3,7 @@ layout: sidenav
 sidenav: contact_us
 common_applications:
  - USAJOBS
- - "PBGC - MyPBA"
+ - "PBGC-MyPBA"
  - SBA DLAP
  - Social Security Administration (SSA)
  - Trusted Traveler Programs (Global Entry/Nexus/Sentri)


### PR DESCRIPTION
**Why**: Backend was deployed without spaces around the dash

See debugging notes in Slack: https://gsa-tts.slack.com/archives/C20J64X6V/p1626798587009000?thread_ts=1626796218.008500&cid=C20J64X6V