### PR TITLE
Remove DS Logon from contact us form.

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -28,7 +28,6 @@ contact_page:
       "DOD Moves.mil (Homes or Office)": DOD Move.mil (Homes or Office)
       "DOT FMCSA (Motor Carrier Safety)": DOT FMCSA (Motor Carrier Safety)
       "DOT National Registry of Certified Medical Examiners": DOT National Registry of Certified Medical Examiners
-      "DS Logon": DS Logon
       "GSA Sam.gov": GSA SAM.gov
       "PBGC-MyPBA": "PBGC - MyPBA"
       "Railroad Retirement Board": Railroad Retirement Board

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -28,7 +28,6 @@ contact_page:
       "DOD Moves.mil (Homes or Office)": DOD Move.mil (Hogares u oficinas)
       "DOT FMCSA (Motor Carrier Safety)": FMCSA del Departamento de Transporte (Seguridad de Autotransportes)
       "DOT National Registry of Certified Medical Examiners": Registro Nacional de Examinadores Médicos Certificados del Departamento de Transporte
-      "DS Logon": Conexión DS
       "GSA Sam.gov": GSA SAM.gov
       "PBGC-MyPBA": "PBGC - MyPBA"
       "Railroad Retirement Board": Junta de Jubilación del Ferrocarril

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -28,7 +28,6 @@ contact_page:
       "DOD Moves.mil (Homes or Office)": Move.mil de DOD (Résidences ou bureaux)
       "DOT FMCSA (Motor Carrier Safety)": FMCSA du Département des transports (Sécurité des transporteurs routiers)
       "DOT National Registry of Certified Medical Examiners": Registre national des médecins agréés du Département des transports
-      "DS Logon": Connexion DS
       "GSA Sam.gov": GSA SAM.gov
       "PBGC-MyPBA": "PBGC - MyPBA"
       "Railroad Retirement Board": Conseil des retraites des chemins de fer


### PR DESCRIPTION
This pull request removes DS Logon from our contact form. Spoke with @amoose @orenyk @TiffanyAndrews and we no longer need this as a drop down option.