### PR TITLE
Exclude iframes from accessibility end-to-end tests

### DIFF
--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -45,7 +45,7 @@ describe('accessibility', () => {
           await goto(path);
           const results = await new AxePuppeteer(page)
             .disableRules('frame-tested')
-            .exclude('iframe')
+            .disableFrame('*')
             .exclude('.footer-nav') // See: LG-4038 (TODO: Remove with implementation of LG-4038)
             .analyze();
           expect(results).toHaveNoViolations();


### PR DESCRIPTION
**Why**: Suspected cause of intermittent build failures attributable to nested ReCaptcha iframes.

We could be more specific with the selector here, but (a) the frame is added dynamically by Google's own JavaScript and could change over time and (b) we don't expect to have any content shown in an iframe.