### PR TITLE
Remove unused replace_locale_base_url filter

### DIFF
--- a/_plugins/locale_url_filter.rb
+++ b/_plugins/locale_url_filter.rb
@@ -1,7 +1,5 @@
 module Jekyll
   module LocaleUrlFilter
-    LOCALE_STRING_CONSTANT = '__LOCALE_BASE_URL__'.freeze
-
     def locale_url(path = '', locale = nil)
       site_base_url = @context.registers[:site].baseurl
       locale ||= @context.registers[:page]['lang']
@@ -15,10 +13,6 @@ module Jekyll
     def delocalize_url(path, locale = nil)
       locale ||= @context.registers[:page]['lang']
       path.gsub(%r{^/#{locale}/}, '/')
-    end
-
-    def replace_locale_base_url(input)
-      input.gsub(LOCALE_STRING_CONSTANT, locale_url.chomp('/'))
     end
   end
 end

--- a/spec/_plugins/locale_url_filter_spec.rb
+++ b/spec/_plugins/locale_url_filter_spec.rb
@@ -249,30 +249,4 @@ RSpec.describe Jekyll::LocaleUrlFilter do
       end
     end
   end
-
-  describe '#replace_locale_base_url' do
-    let(:input) { "#{Jekyll::LocaleUrlFilter::LOCALE_STRING_CONSTANT}/help/" }
-    subject(:locale_url) { instance.replace_locale_base_url(input) }
-
-    context 'without site base url' do
-      let(:config) { { 'collections' => { 'en' => { 'permalink' => '/:path/' } } } }
-
-      it 'replaces using page data' do
-        expect(locale_url).to eq('/help/')
-      end
-    end
-
-    context 'with site base url' do
-      let(:config) do
-        {
-          'baseurl' => 'https://example.com',
-          'collections' => { 'en' => { 'permalink' => '/:path/' } },
-        }
-      end
-
-      it 'replaces using page data' do
-        expect(locale_url).to eq('https://example.com/help/')
-      end
-    end
-  end
 end


### PR DESCRIPTION
**Why**: It was only necessary so long as we had translated Markdown data which used the "\_\_LOCALE_BASE_URL\_\_" magic string, which is no longer the case after #691.