### PR TITLE
LG-4054: Translate and implement password guidelines text

### DIFF
--- a/content/_en/landing/create_an_account.md
+++ b/content/_en/landing/create_an_account.md
@@ -3,7 +3,7 @@ layout: landing
 title: Create an account
 description: Join the millions of people who trust Login.gov for safe, secure
   access to government agencies.
-class: create-an-account  
+class: create-an-account
 steps:
   intro: "When you’re ready to create your secure Login.gov account, you’ll need
     to provide a few pieces of information:"

--- a/content/_fr/landing/create_an_account.md
+++ b/content/_fr/landing/create_an_account.md
@@ -16,7 +16,7 @@ steps:
   step2: >-
     ## 2. Mot de passe sécurisé
 
-    * Les mots de passe doivent comporter au moins 12 caractères et ne doivent pas inclure de mots ou d'expressions couramment utilisés.
+    * Les mots de passe doivent être composés d'au moins 12 caractères et ne doivent pas inclure des mots ou des phrases couramment utilisés.
   step3: >
     ## 3. Une ou plusieurs [méthodes
     d'authentification](/fr/help/authentication-methods/which-authentication-method-should-i-use/)


### PR DESCRIPTION
The purpose of this ticket is to translate and implement password guideline text as suggested by a translation service.

Why: So that the text can be as accurate as possible in translated languages.

Note-the Spanish copy was **not** modified because the original text and the translated text were the same.