### PR TITLE
Remove account link from contact form

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -103,7 +103,6 @@ contact_page:
       verify_identity_error: I got a failure trying to verify my identity
       wrong_account_update: Wrong account update
     topics:
-      account_linking: Linking your Login.gov account to your profile
       changing_settings: Changing your Login.gov information
       creating_account: Create a Login.gov account
       feedback: Feedback for Login.gov

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -103,7 +103,6 @@ contact_page:
       verify_identity_error: He recibido un fallo al intentar verificar mi identidad
       wrong_account_update: Actualización de la cuenta errónea
     topics:
-      account_linking: Vincular su cuenta de Login.gov a su perfil
       changing_settings: Cambiar su información de Login.gov
       creating_account: Crear una cuenta de Login.gov
       feedback: Comentarios para Login.gov

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -103,7 +103,6 @@ contact_page:
       verify_identity_error: J'ai reçu un message d'erreur en essayant de vérifier mon identité
       wrong_account_update: Mise à jour de compte erronée
     topics:
-      account_linking: Lier votre compte Login.gov à votre profil
       changing_settings: Changer vos informations de Login.gov
       creating_account: Créer un compte Login.gov
       feedback: Commentaires pour Login.gov

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -206,10 +206,6 @@ include:
       ],
     ),
     new TopicEntry(
-      'Account Linking',
-      "{{ site.data.[page.lang].settings.contact_page.support_request_form.topics.account_linking }}",
-    ),
-    new TopicEntry(
       'Verifying your identity',
       "{{ site.data.[page.lang].settings.contact_page.support_request_form.topics.verifying_identity }}",
       [


### PR DESCRIPTION
This pull request removes "account linking" as an option from out customer support form. As most (if not all) of these request are related to the service provider, they are now a sub-category on non Login.gov related tickets.