### PR TITLE
Remove TIFF and BMP support copy.

### DIFF
--- a/content/_en/help/verify-your-identity/how-to-add-images-of-your-state-issued-id.md
+++ b/content/_en/help/verify-your-identity/how-to-add-images-of-your-state-issued-id.md
@@ -20,7 +20,7 @@ A clear picture of your state-issued ID is required to complete the identity ver
 ## Tips for uploading or scanning your ID:
 
 * Follow the same tips for taking photo\s of your ID with a camera
-* Save each file as a JPG, PNG, TIFF, or BMP. You cannot use a PDF file. Look at the name of your file and it should have an abbreviation after the title (ex: JohnDoeID_Front.jpg) 
+* Save each file as a JPG or PNG. You cannot use a PDF file. Look at the name of your file and it should have an abbreviation after the title (ex: JohnDoeID_Front.jpg) 
 * Make sure your ID takes up about 80% of the images
 * Make sure your images are high-resolution (around 2025 x 1275 pixels is ideal)
 * Images should be in color (24-bit RGB)

--- a/content/_es/help/verify-your-identity/how-to-add-images-of-your-state-issued-id.md
+++ b/content/_es/help/verify-your-identity/how-to-add-images-of-your-state-issued-id.md
@@ -19,7 +19,7 @@ Para completar el proceso de verificación de la identidad, se necesita una foto
 ## Consejos para subir o escanear tu documento de identidad:
 
 * Sigue los mismos consejos para hacer fotos de tu documento de identidad con una cámara 
-* Guarda cada archivo como JPG, PNG, TIFF o BMP. No puedes utilizar un archivo PDF. Fíjate en el nombre de tu archivo y debe tener una abreviatura después del título (por ejemplo: JohnDoeID_Front.jpg) 
+* Guarda cada archivo como JPG o PNG. No puedes utilizar un archivo PDF. Fíjate en el nombre de tu archivo y debe tener una abreviatura después del título (por ejemplo: JohnDoeID_Front.jpg) 
 * Asegúrate de que tu documento de identidad ocupa aproximadamente el 80% de las imágenes
 * Asegúrate de que tus imágenes son de alta resolución (lo ideal es en torno a 2025 x 1275 píxeles)
 * Las imágenes deben ser en color (RGB de 24 bits).

--- a/content/_fr/help/verify-your-identity/how-to-add-images-of-your-state-issued-id.md
+++ b/content/_fr/help/verify-your-identity/how-to-add-images-of-your-state-issued-id.md
@@ -19,7 +19,7 @@ Une photo claire de votre pièce d'identité délivrée par l'État est nécessa
 ## Conseils pour télécharger ou scanner votre pièce d'identité:
 
 * Suivez les mêmes conseils pour prendre des photos de votre pièce d'identité avec un appareil photo
-* Enregistrez chaque fichier au format JPG, PNG, TIFF ou BMP. Vous ne pouvez pas utiliser un fichier PDF. Regardez le nom de votre fichier et il devrait avoir une abréviation après le titre (ex : JohnDoeID_Front.jpg) 
+* Enregistrez chaque fichier au format JPG ou PNG. Vous ne pouvez pas utiliser un fichier PDF. Regardez le nom de votre fichier et il devrait avoir une abréviation après le titre (ex : JohnDoeID_Front.jpg) 
 * Veillez à ce que votre identification occupe environ 80 % des images
 * Veillez à ce que vos images soient en haute résolution (environ 2025 x 1275 pixels)
 * Les images doivent être en couleur (RVB 24 bit)


### PR DESCRIPTION
In [RC 160](https://github.com/18F/identity-idp/releases/tag/2021-10-05T131147) we removed support for TIFF and BMP support was dropped. Removing from our help documentation on our brochure site.