### PR TITLE
Drop browser tools from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,6 @@ jobs:
   accessibility:
     docker:
       - image: cimg/ruby:2.7-browsers
-        environment:
-          NODE_ENV: development
     environment:
       SKIP_BUILD: true
     steps:


### PR DESCRIPTION
Related: #704

**Why**: It's quite time-consuming, because it installs multiple browsers and browser drivers. Our end-to-end tests use Puppeteer, which is capable of installing its own copy of Chromium. We also don't need browsers outside the end-to-end (accessibility) test build.

![image](https://user-images.githubusercontent.com/1779930/138885477-8d3f9542-9209-47f5-b936-7a73be7474f6.png)
