### PR TITLE
Switch from "npm ci" to "npm install" for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - install-dependencies
       - run:
           name: check lockfile differences
-          command: make lint-assets
+          command: make validate-lockfiles
 
   check-javascript-syntax:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
           name: install dependencies
           command: |
             sudo npm install -g n && sudo n 12
-            npm ci
+            npm install
             bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:
@@ -100,6 +100,18 @@ jobs:
           name: check optimized images
           command: make lint-assets
 
+  check-lockfiles:
+    docker:
+      - image: cimg/ruby:2.7-node
+    environment:
+      SKIP_INSTALL: true
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: check lockfile differences
+          command: make lint-assets
+
   check-javascript-syntax:
     docker:
       - image: cimg/ruby:2.7-node
@@ -137,6 +149,7 @@ workflows:
       - build
       - eslint
       - check-optimized-assets
+      - check-lockfiles
       - test:
           requires:
             - build

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ validate-gemfile-lock: Gemfile Gemfile.lock
 
 validate-package-lock: package.json package-lock.json
 	@echo "Validating package-lock.json..."
-	@[[ -z SKIP_INSTALL ]] && npm install --ignore-scripts || exit 0
+	@[[ -z $$SKIP_INSTALL ]] && npm install --ignore-scripts || exit 0
 	@(! git diff --name-only | grep package-lock.json) || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
 
 validate-lockfiles: validate-gemfile-lock validate-package-lock

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint-assets:
 	npm run viewbox || (echo "Make sure all SVG images have a viewBox attribute"; exit 1)
 	git diff --quiet assets/img || (echo "Error: Optimize SVG images using 'npm run optimize-assets'"; exit 1)
 
-lint: lint-js lint-assets
+lint: lint-js lint-assets validate-lockfiles
 
 test: build
 	bundle exec rspec spec
@@ -30,3 +30,15 @@ htmlproofer:
 build:
 	npm run build-js
 	bundle exec jekyll build
+
+validate-gemfile-lock: Gemfile Gemfile.lock
+	@echo "Validating Gemfile.lock..."
+	@bundle check
+	@git diff-index --quiet HEAD Gemfile.lock || (echo "Error: There are uncommitted changes after running 'bundle install'"; exit 1)
+
+validate-package-lock: package.json package-lock.json
+	@echo "Validating package-lock.json..."
+	@[[ -z SKIP_INSTALL ]] && npm install --ignore-scripts || exit 0
+	@(! git diff --name-only | grep package-lock.json) || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
+
+validate-lockfiles: validate-gemfile-lock validate-package-lock


### PR DESCRIPTION
**Why**: Because "npm ci" ignores and destroys the cached node_modules and is otherwise difficult to cache. "npm install" should behave similar, respect package-lock.json, hydrate from cache. The other behavior of "npm ci" of validating package-lock.json [isn't always reliable](https://github.com/18F/identity-style-guide/pull/268), and is replicated here with check-lockfiles, largely copied from similar scripts in identity-style-guide and identity-idp.

Related: https://github.com/npm/cli/issues/564

From [example build](https://app.circleci.com/pipelines/github/18F/identity-site/2056/workflows/9c3753ae-9df4-4edb-993a-47b38fc08b7e/jobs/8691):

```
Found a cache from build 8619 at v2-dependencies-gGKVNxLRg3iHjN88fQag16qWfIEt44dSLDpRuOkhS2s=
Size: 170 MiB
Cached paths:
  * /home/circleci/project/node_modules

Downloading cache archive...
Validating cache...

Unarchiving cache...

# ...

npm WARN prepare removing existing node_modules/ before installation
```