### PR TITLE
add `redirect_from` on english help pages

### DIFF
--- a/content/_help/get-started/authentication-options._en.md
+++ b/content/_help/get-started/authentication-options._en.md
@@ -5,7 +5,6 @@ category: get-started
 permalink: /help/get-started/authentication-options/
 order: 2
 redirect_from:
-  - /en/help/get-started/authentication-options/
   - /help/security-keys/does-using-a-security-key-mean-im-completely-safe-from-phishing/
   - /help/security-keys/what-is-a-security-key/
   - /help/security-keys/what-is-phishing/
@@ -17,6 +16,7 @@ redirect_from:
   - /help/security-keys/
   - /help/authentication-methods/which-authentication-method-should-i-use/
   - /help/authentication-methods/
+  - /en/help/get-started/authentication-options/
 ---
 
 In addition to your password, Login.gov requires that you set up at least one secondary authentication method to keep your account secure. This is two-factor authentication (2FA). We use 2FA as an added layer of protection to secure your information.

--- a/content/_help/get-started/authentication-options._en.md
+++ b/content/_help/get-started/authentication-options._en.md
@@ -5,6 +5,7 @@ category: get-started
 permalink: /help/get-started/authentication-options/
 order: 2
 redirect_from:
+  - /en/help/get-started/authentication-options/
   - /help/security-keys/does-using-a-security-key-mean-im-completely-safe-from-phishing/
   - /help/security-keys/what-is-a-security-key/
   - /help/security-keys/what-is-phishing/

--- a/content/_help/get-started/create-your-account._en.md
+++ b/content/_help/get-started/create-your-account._en.md
@@ -4,6 +4,8 @@ category: get-started
 permalink: /help/get-started/create-your-account/
 order: 1
 title: Create your Login.gov account
+redirect_from:
+   - /en/help/get-started/create-your-account/
 ---
 
 Follow these steps to create your Login.gov account.

--- a/content/_help/get-started/overview._en.md
+++ b/content/_help/get-started/overview._en.md
@@ -6,7 +6,6 @@ permalink: /help/get-started/overview/
 meta_title: Overview
 order: 0
 redirect_from:
-  - /en/help/get-started/overview/
   - /help/creating-an-account/authentication-application/
   - /help/creating-an-account/creating-a-strong-password/
   - /help/creating-an-account/email-address-confirmation-link-is-invalid/
@@ -32,6 +31,8 @@ redirect_from:
   - /help/creating-an-account/why-do-i-need-to-use-logingov-to-access-government-services-online/
   - /help/creating-an-account/why-is-my-confirmation-link-invalid/
   - /help/get-started/
+  - /en/help/get-started/overview/
+  - /en/help/get-started/
 ---
 Login.gov is the public's one account and password for government. Login.gov is a shared service and trusted by government agencies. With one Login.gov account you can access applications from participating government partners.
 

--- a/content/_help/get-started/overview._en.md
+++ b/content/_help/get-started/overview._en.md
@@ -6,6 +6,7 @@ permalink: /help/get-started/overview/
 meta_title: Overview
 order: 0
 redirect_from:
+  - /en/help/get-started/overview/
   - /help/creating-an-account/authentication-application/
   - /help/creating-an-account/creating-a-strong-password/
   - /help/creating-an-account/email-address-confirmation-link-is-invalid/

--- a/content/_help/manage-your-account/add-or-change-your-authentication-method._en.md
+++ b/content/_help/manage-your-account/add-or-change-your-authentication-method._en.md
@@ -4,6 +4,8 @@ title: Add or change your authentication method
 category: manage-your-account
 permalink: /help/manage-your-account/add-or-change-your-authentication-method/
 order: 7
+redirect_from:
+    - /en/help/manage-your-account/add-or-change-your-authentication-method/
 ---
 [An authentication method](https://login.gov/help/get-started/authentication-options/) is an additional layer of security for your account. We recommend having at least two authentication methods for your account in case you lose one method.
 

--- a/content/_help/manage-your-account/change-your-email-address._en.md
+++ b/content/_help/manage-your-account/change-your-email-address._en.md
@@ -5,9 +5,9 @@ category: manage-your-account
 permalink: /help/manage-your-account/change-your-email-address/
 order: 4
 redirect_from:
-  - /en/help/manage-your-account/change-your-email-address/
   - help/changing-settings/add-or-remove-email-address
   - help/changing-settings/change-my-email-address/
+  - /en/help/manage-your-account/change-your-email-address/
 ---
 
 Follow these steps to change the email address associated with your account.

--- a/content/_help/manage-your-account/change-your-email-address._en.md
+++ b/content/_help/manage-your-account/change-your-email-address._en.md
@@ -5,6 +5,7 @@ category: manage-your-account
 permalink: /help/manage-your-account/change-your-email-address/
 order: 4
 redirect_from:
+  - /en/help/manage-your-account/change-your-email-address/
   - help/changing-settings/add-or-remove-email-address
   - help/changing-settings/change-my-email-address/
 ---

--- a/content/_help/manage-your-account/change-your-password._en.md
+++ b/content/_help/manage-your-account/change-your-password._en.md
@@ -5,6 +5,7 @@ category: manage-your-account
 order: 1
 permalink: /help/manage-your-account/change-your-password/
 redirect_from:
+  - /en/help/manage-your-account/change-your-password/
   - /help/changing-settings/change-my-password/
   - /help/changing-settings/how-do-i-change-my-password/
 ---

--- a/content/_help/manage-your-account/change-your-password._en.md
+++ b/content/_help/manage-your-account/change-your-password._en.md
@@ -5,9 +5,9 @@ category: manage-your-account
 order: 1
 permalink: /help/manage-your-account/change-your-password/
 redirect_from:
-  - /en/help/manage-your-account/change-your-password/
   - /help/changing-settings/change-my-password/
   - /help/changing-settings/how-do-i-change-my-password/
+  - /en/help/manage-your-account/change-your-password/
 ---
 
 Follow these steps to change your Login.gov password.

--- a/content/_help/manage-your-account/change-your-phone-number._en.md
+++ b/content/_help/manage-your-account/change-your-phone-number._en.md
@@ -4,6 +4,8 @@ title: Change the phone number associated with your account
 category: manage-your-account
 permalink: /help/manage-your-account/change-your-phone-number/
 order: 3
+redirect_from:
+    - /en/help/manage-your-account/change-your-phone-number/
 ---
 
 Follow these steps to change the phone number associated with your account.

--- a/content/_help/manage-your-account/delete-your-account._en.md
+++ b/content/_help/manage-your-account/delete-your-account._en.md
@@ -5,9 +5,9 @@ category: manage-your-account
 permalink: /help/manage-your-account/delete-your-account/
 order: 1
 redirect_from:
-  - /en/help/manage-your-account/delete-your-account/
   - /help/changing-settings/delete-my-account/
   - /help/changing-settings/how-do-i-delete-my-account/
+  - /en/help/manage-your-account/delete-your-account/
 ---
 
  __There might be different reasons why you need to delete an account:__

--- a/content/_help/manage-your-account/delete-your-account._en.md
+++ b/content/_help/manage-your-account/delete-your-account._en.md
@@ -5,6 +5,7 @@ category: manage-your-account
 permalink: /help/manage-your-account/delete-your-account/
 order: 1
 redirect_from:
+  - /en/help/manage-your-account/delete-your-account/
   - /help/changing-settings/delete-my-account/
   - /help/changing-settings/how-do-i-delete-my-account/
 ---

--- a/content/_help/manage-your-account/international-phone-support._en.md
+++ b/content/_help/manage-your-account/international-phone-support._en.md
@@ -6,6 +6,8 @@ permalink: /help/manage-your-account/international-phone-support/
 order: 5
 scripts:
   - /assets/js/build/country_support.js
+redirect_from:
+  - /en/help/manage-your-account/international-phone-support/
 ---
 
 <noscript>

--- a/content/_help/manage-your-account/overview._en.md
+++ b/content/_help/manage-your-account/overview._en.md
@@ -6,7 +6,6 @@ meta_title: Overview
 permalink: /help/manage-your-account/overview/
 order: 0
 redirect_from:
-  - /en/help/manage-your-account/overview/
   - /help/changing-settings/add-or-remove-email-address/
   - /help/changing-settings/change-my-email-address/
   - /help/changing-settings/email-address-is-already-in-use/
@@ -24,6 +23,8 @@ redirect_from:
   - /help/changing-settings/change-my-phone-number/
   - /help/changing-settings/how-do-i-change-the-phone-number-i-am-using-with-my-account/
   - /help/changing-settings/how-do-i-change-the-phone-number-i-use-to-sign-in/
+  - /en/help/manage-your-account/
+  - /en/help/manage-your-account/overview/
 ---
 
 Manage your account settings including your password, phone number, email, and more.

--- a/content/_help/manage-your-account/overview._en.md
+++ b/content/_help/manage-your-account/overview._en.md
@@ -6,6 +6,7 @@ meta_title: Overview
 permalink: /help/manage-your-account/overview/
 order: 0
 redirect_from:
+  - /en/help/manage-your-account/overview/
   - /help/changing-settings/add-or-remove-email-address/
   - /help/changing-settings/change-my-email-address/
   - /help/changing-settings/email-address-is-already-in-use/

--- a/content/_help/manage-your-account/relink-your-accounts._en.md
+++ b/content/_help/manage-your-account/relink-your-accounts._en.md
@@ -4,6 +4,8 @@ title: "Relink your accounts "
 category: manage-your-account
 permalink: /help/manage-your-account/relink-your-accounts/
 order: 6
+redirect_from:
+    - /en/help/manage-your-account/relink-your-accounts/
 ---
 If you have problems signing in to a Login.gov partner website after changing your email address, then it is possible the partner linked your account to a different email address. You may want to relink your account to access your information or profile on the partner website. 
 

--- a/content/_help/specific-agencies/overview._en.md
+++ b/content/_help/specific-agencies/overview._en.md
@@ -6,6 +6,7 @@ meta_title: Overview
 permalink: /help/specific-agencies/overview/
 order: 0
 redirect_from:
+  - /en/help/specific-agencies/overview/
   - /help/specific-agencies/
   - /help/specific-agencies/usajobs/
   - /help/usajobs/gov-mil-edu-email-address/

--- a/content/_help/specific-agencies/overview._en.md
+++ b/content/_help/specific-agencies/overview._en.md
@@ -6,7 +6,6 @@ meta_title: Overview
 permalink: /help/specific-agencies/overview/
 order: 0
 redirect_from:
-  - /en/help/specific-agencies/overview/
   - /help/specific-agencies/
   - /help/specific-agencies/usajobs/
   - /help/usajobs/gov-mil-edu-email-address/
@@ -24,6 +23,8 @@ redirect_from:
   - /help/usajobs/try-not-to-use-a-gov-mil-or-edu-email-address/
   - /help/usajobs/what-email-address-should-i-use/
   - /help/usajobs/what-will-happen-to-my-usajobs-profile/
+  - /en/help/specific-agencies/overview/
+  - /en/help/specific-agencies/
 ---
 
 Login.gov is for account access and sign in only. This account does not affect or have any information related to the specific agency you are trying to access.

--- a/content/_help/specific-agencies/sam._en.md
+++ b/content/_help/specific-agencies/sam._en.md
@@ -5,6 +5,7 @@ category: specific-agencies
 permalink: /help/specific-agencies/sam/
 order: 2
 redirect_from:
+  - /en/help/specific-agencies/sam/
   - /help/sam/have-account-different-email/
   - /help/sam/no-longer-have-email/
   - /help/sam/relink-my-profile/

--- a/content/_help/specific-agencies/sam._en.md
+++ b/content/_help/specific-agencies/sam._en.md
@@ -5,7 +5,6 @@ category: specific-agencies
 permalink: /help/specific-agencies/sam/
 order: 2
 redirect_from:
-  - /en/help/specific-agencies/sam/
   - /help/sam/have-account-different-email/
   - /help/sam/no-longer-have-email/
   - /help/sam/relink-my-profile/
@@ -25,6 +24,7 @@ redirect_from:
   - /help/sam/my-logingov-account-uses-a-different-email-address/
   - /help/sam/my-sam-information-is-not-there/
   - /help/sam/reset-or-relink-my-logingov-account-for-sam/
+  - /en/help/specific-agencies/sam/
 ---
 
 Login.gov is for secure sign in only. Your Login.gov account does not affect or have any information about your System for Award Management (SAM) account, application, status, membership, or eligibility.

--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -5,6 +5,7 @@ category: specific-agencies
 permalink: /help/specific-agencies/trusted-traveler-programs/
 order: 1
 redirect_from:
+  - /en/help/specific-agencies/trusted-traveler-programs/
   - /help/trusted-traveler-programs/another-question/
   - /help/trusted-traveler-programs/aol-verizon/
   - /help/trusted-traveler-programs/application-status/

--- a/content/_help/specific-agencies/trusted-traveler-programs._en.md
+++ b/content/_help/specific-agencies/trusted-traveler-programs._en.md
@@ -5,7 +5,6 @@ category: specific-agencies
 permalink: /help/specific-agencies/trusted-traveler-programs/
 order: 1
 redirect_from:
-  - /en/help/specific-agencies/trusted-traveler-programs/
   - /help/trusted-traveler-programs/another-question/
   - /help/trusted-traveler-programs/aol-verizon/
   - /help/trusted-traveler-programs/application-status/
@@ -29,6 +28,7 @@ redirect_from:
   - /help/trusted-traveler-programs/whats-my-passid/
   - /help/trusted-traveler-programs/will-my-ktn-known-traveler-number-change/
   - /help/trusted-traveler-programs/
+  - /en/help/specific-agencies/trusted-traveler-programs/
 ---
 
 Login.gov is for secure sign in only. Your Login.gov account does not affect or have any information about your [Trusted Traveler Programs](https://ttp.dhs.gov/) (TTP) application, membership, or eligibility. Please do not send Login.gov sensitive data about yourself or identifying membership numbers.

--- a/content/_help/trouble-signing-in/forgot-your-password._en.md
+++ b/content/_help/trouble-signing-in/forgot-your-password._en.md
@@ -5,6 +5,7 @@ category: trouble-signing-in
 permalink: /help/trouble-signing-in/forgot-your-password/
 order: 2
 redirect_from:
+  - /en/help/trouble-signing-in/forgot-your-password/
   - /help/signing-in/what-do-i-do-if-my-password-doesnt-work-or-i-forget-it/
   - /help/signing-in/how-do-i-reset-my-password/
   - /help/signing-in/forgot-my-password/

--- a/content/_help/trouble-signing-in/forgot-your-password._en.md
+++ b/content/_help/trouble-signing-in/forgot-your-password._en.md
@@ -5,11 +5,11 @@ category: trouble-signing-in
 permalink: /help/trouble-signing-in/forgot-your-password/
 order: 2
 redirect_from:
-  - /en/help/trouble-signing-in/forgot-your-password/
   - /help/signing-in/what-do-i-do-if-my-password-doesnt-work-or-i-forget-it/
   - /help/signing-in/how-do-i-reset-my-password/
   - /help/signing-in/forgot-my-password/
   - /help/signing-in/my-reset-password-link-is-invalid/
+  - /en/help/trouble-signing-in/forgot-your-password/
 ---
 
 Follow these steps to reset your password.

--- a/content/_help/trouble-signing-in/how-to-sign-in._en.md
+++ b/content/_help/trouble-signing-in/how-to-sign-in._en.md
@@ -5,9 +5,9 @@ category: trouble-signing-in
 permalink: /help/trouble-signing-in/how-to-sign-in/
 order: 1
 redirect_from:
-  - /en/help/trouble-signing-in/how-to-sign-in/
   - /help/signing-in/
   - /help/signing-in/how-to-sign-in/
+  - /en/help/trouble-signing-in/how-to-sign-in/
 ---
 
 Every time you sign in to your Login.gov account, you will need your email address, your password, and access to one of the two-factor authentication methods you set up.

--- a/content/_help/trouble-signing-in/how-to-sign-in._en.md
+++ b/content/_help/trouble-signing-in/how-to-sign-in._en.md
@@ -5,6 +5,7 @@ category: trouble-signing-in
 permalink: /help/trouble-signing-in/how-to-sign-in/
 order: 1
 redirect_from:
+  - /en/help/trouble-signing-in/how-to-sign-in/
   - /help/signing-in/
   - /help/signing-in/how-to-sign-in/
 ---

--- a/content/_help/trouble-signing-in/overview._en.md
+++ b/content/_help/trouble-signing-in/overview._en.md
@@ -6,6 +6,7 @@ category: trouble-signing-in
 meta_title: Overview
 order: 0
 redirect_from:
+  - /en/help/trouble-signing-in/overview/
   - /help/signing-in/
   - /help/signing-in/i-forgot-which-email-address-i-used-to-create-an-account/
   - /help/signing-in/forgot-my-email-address/

--- a/content/_help/trouble-signing-in/overview._en.md
+++ b/content/_help/trouble-signing-in/overview._en.md
@@ -7,6 +7,7 @@ meta_title: Overview
 order: 0
 redirect_from:
   - /en/help/trouble-signing-in/overview/
+  - /en/help/trouble-signing-in/
   - /help/signing-in/
   - /help/signing-in/i-forgot-which-email-address-i-used-to-create-an-account/
   - /help/signing-in/forgot-my-email-address/

--- a/content/_help/verify-your-identity/accepted-state-issued-identification._en.md
+++ b/content/_help/verify-your-identity/accepted-state-issued-identification._en.md
@@ -4,6 +4,8 @@ title: "Accepted State-Issued Identification "
 category: verify-your-identity
 permalink: /help/verify-your-identity/accepted-state-issued-identification/
 order: 3
+redirect_from:
+  - /en/help/verify-your-identity/accepted-state-issued-identification/
 ---
 At this time, only the following state-issued identification is accepted: 
 

--- a/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._en.md
+++ b/content/_help/verify-your-identity/how-to-add-images-of-your-state-issued-id._en.md
@@ -4,6 +4,8 @@ title: How to add images of your state-issued ID
 category: verify-your-identity
 permalink: /help/verify-your-identity/how-to-add-images-of-your-state-issued-id/
 order: 5
+redirect_from:
+    - /en/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/
 ---
 A clear picture of your state-issued ID is required to complete the identity verification process. For best results, we recommend using a phone to automatically take a photo of the front and back of your ID. If you are verifying your identity on a computer, you will be able to switch to a phone for this part of the process.
 

--- a/content/_help/verify-your-identity/how-to-verify-your-identity._en.md
+++ b/content/_help/verify-your-identity/how-to-verify-your-identity._en.md
@@ -4,6 +4,8 @@ title: How to verify your identity
 category: verify-your-identity
 permalink: /help/verify-your-identity/how-to-verify-your-identity/
 order: 2
+redirect_from:
+    - /en/help/verify-your-identity/how-to-verify-your-identity/
 ---
 
 Some government applications require identity verification. This additional layer of security requires you to prove you are you - and not someone pretending to be you.

--- a/content/_help/verify-your-identity/overview._en.md
+++ b/content/_help/verify-your-identity/overview._en.md
@@ -6,6 +6,7 @@ permalink: /help/verify-your-identity/overview/
 meta_title: Overview
 order: 0
 redirect_from:
+  - /en/help/verify-your-identity/
   - /en/help/verify-your-identity/overview/
   - /help/verify-your-identity/
   - /help/verifying-your-identity/dont-have-a-state-issued-id/

--- a/content/_help/verify-your-identity/overview._en.md
+++ b/content/_help/verify-your-identity/overview._en.md
@@ -6,6 +6,7 @@ permalink: /help/verify-your-identity/overview/
 meta_title: Overview
 order: 0
 redirect_from:
+  - /en/help/verify-your-identity/overview/
   - /help/verify-your-identity/
   - /help/verifying-your-identity/dont-have-a-state-issued-id/
   - /help/verifying-your-identity/how-to-verify-my-identity/

--- a/content/_help/verify-your-identity/phone-number-and-phone-plan-in-your-name._en.md
+++ b/content/_help/verify-your-identity/phone-number-and-phone-plan-in-your-name._en.md
@@ -4,6 +4,8 @@ title: "Phone number and phone plan in your name "
 category: verify-your-identity
 permalink: /help/verify-your-identity/phone-number-and-phone-plan-in-your-name/
 order: 4
+redirect_from:
+    - /en/help/verify-your-identity/phone-number-and-phone-plan-in-your-name/
 ---
 You need to provide a U.S. based phone number with your name on the phone plan to successfully complete identity verification. 
 

--- a/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._en.md
+++ b/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._en.md
@@ -4,6 +4,8 @@ title: Troubleshoot uploading your state-issued ID
 category: verify-your-identity
 permalink: /help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/
 order: 6
+redirect_from:
+    - /en/help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/
 ---
 A [clear photo of your state-issued ID](https://login.gov/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/) is required for identity verification. If you’ve taken a photo that meets the requirements, try the steps below if you’re still getting an error while uploading your state-issued identification.
 

--- a/content/_help/verify-your-identity/verify-your-address-by-mail._en.md
+++ b/content/_help/verify-your-identity/verify-your-address-by-mail._en.md
@@ -4,6 +4,8 @@ title: Verify your address by mail
 category: verify-your-identity
 permalink: /help/verify-your-identity/verify-your-address-by-mail/
 order: 1
+redirect_from:
+    - /en/help/verify-your-identity/verify-your-address-by-mail/
 ---
 
 Identity verification is the process where you prove you are you - and not someone pretending to be you. One step in this process requires you to have a phone number with your name on the phone plan to automatically verify your address. 

--- a/content/_landing/create_an_account._en.md
+++ b/content/_landing/create_an_account._en.md
@@ -37,4 +37,6 @@ steps:
 one_account_banner: true
 twitter_card: large
 image: /assets/img/create-an-account/header/create-account-illo-header.png
+redirect_from:
+  - /en/create-an-account/
 ---

--- a/content/_landing/help._en.md
+++ b/content/_landing/help._en.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /help/
 hero: true
 redirect_from:
-  - /en/help
+  - /en/help/
 ---
 <article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">

--- a/content/_landing/index._en.md
+++ b/content/_landing/index._en.md
@@ -2,6 +2,7 @@
 layout: landing
 permalink: /
 redirect_from:
+  - /en/
   - /playbook/
   - /playbook/implementation/
   - /playbook/principles/
@@ -36,6 +37,4 @@ three_col:
     [See developer guide](https://developers.login.gov/){:class="why-more-info"}
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
-redirect_from:
-  - /en/
 ---

--- a/content/_landing/index._en.md
+++ b/content/_landing/index._en.md
@@ -36,4 +36,6 @@ three_col:
     [See developer guide](https://developers.login.gov/){:class="why-more-info"}
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
+redirect_from:
+  - /en/
 ---

--- a/content/_landing/what_is_login._en.md
+++ b/content/_landing/what_is_login._en.md
@@ -59,4 +59,6 @@ component:
     Login.gov verifies your identity for the agency. By submitting personal identifiable information (PII), such as your photo ID, you can verify that you are you and not someone pretending to be you. We only confirm that you are you and do not make any determination on eligibility for agency services.
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
+redirect_from:
+  - /en/what-is-login/
 ---

--- a/content/_landing/who_uses_login._en.md
+++ b/content/_landing/who_uses_login._en.md
@@ -29,4 +29,6 @@ component:
     Agencies choose Login.gov because we provide a secure — and simple — solution. [Read more about our partner program](https://partners.login.gov).
 twitter_card: large
 image: /assets/img/login-gov-600x314.png
+redirect_from:
+  - /en/who-uses-login/
 ---

--- a/content/_partners/index._en.md
+++ b/content/_partners/index._en.md
@@ -1,6 +1,7 @@
 ---
 permalink: /partners/
 redirect_from:
+- /en/partners/
 - /partners/learn/
 - /partners/our-agency-partners/
 - /partners/why-login-gov/

--- a/content/_policy/about-us._en.md
+++ b/content/_policy/about-us._en.md
@@ -3,6 +3,8 @@ layout: sidenav
 sidenav: about_us
 title: About us
 permalink: /about-us/
+redirect_from:
+    - /en/about-us/
 ---
 ## Our mission
 

--- a/content/_policy/accessibility._en.md
+++ b/content/_policy/accessibility._en.md
@@ -4,6 +4,8 @@ title: Accessibility
 description: Read our accessibility statement
 permalink: /accessibility/
 sidenav: accessibility
+redirect_from:
+    - /en/accessibility/
 ---
 
 ## Our commitment

--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -46,4 +46,6 @@ footer_content: >-
 scripts:
   - /assets/js/build/contact.js
 permalink: /contact/
+redirect_from:
+  - /en/contact/
 ---

--- a/content/_policy/how_does_it_work._en.md
+++ b/content/_policy/how_does_it_work._en.md
@@ -4,6 +4,8 @@ title: "Privacy & security: How it works"
 description: Learn how we protect and secure your personal information.
 permalink: /policy/how-does-it-work/
 sidenav: policies
+redirect_from:
+    - /en/policy/how-does-it-work/
 ---
 ## How does it work ## {#how-does-it-work}
 

--- a/content/_policy/index._en.md
+++ b/content/_policy/index._en.md
@@ -5,6 +5,7 @@ description: Learn more about our security and privacy practices
 permalink: /policy/
 sidenav: policies
 redirect_from:
+  - /en/policy/
   - /docs/Logingov_PIA_August2019.pdf/
   - /docs/Privacy-Impact-Assessment 9-18.pdf/
   - /docs/privacy-impact-assessment.pdf/

--- a/content/_policy/messaging._en.md
+++ b/content/_policy/messaging._en.md
@@ -4,6 +4,8 @@ title: "Privacy & security: Messaging terms and conditions"
 description: Learn how we use text messaging for authentication.
 permalink: /policy/messaging-terms-and-conditions/
 sidenav: policies
+redirect_from:
+    - /en/policy/messaging-terms-and-conditions/
 ---
 ## Messaging terms and conditions ## {#messaging-terms-and-conditions}
  Login.gov uses SMS text messaging to help verify your identity when you create a new account. SMS text messages, or automated voice calls, may also be used if you choose your telephone number as one of your authentication methods.

--- a/content/_policy/privacy._en.md
+++ b/content/_policy/privacy._en.md
@@ -6,6 +6,7 @@ description: Learn how we ask for, use, retain, and protect your personal
   information, as well as your obligation to disclose it.
 permalink: /policy/our-privacy-act-statement/
 redirect_from:
+  - /en/policy/our-privacy-act-statement/
   - /policy/our-privacy-practices/
 ---
 ## Our privacy act statement ## {#our-privacy-act-statement}

--- a/content/_policy/rules-of-use._en.md
+++ b/content/_policy/rules-of-use._en.md
@@ -4,6 +4,8 @@ title: Rules of Use
 description: Rules of use.
 permalink: /policy/rules-of-use/
 sidenav: policies
+redirect_from:
+    - /en/policy/rules-of-use/
 ---
 ## Rules of Use
 

--- a/content/_policy/security._en.md
+++ b/content/_policy/security._en.md
@@ -5,6 +5,7 @@ description: 'Learn the various methods we use to protect this U.S. government s
 permalink: /policy/our-security-practices/
 sidenav: policies
 redirect_from:
+- /en/policy/our-security-practices/
 - /help/privacy-and-security/how-do-i-make-my-password-strong/
 - /help/privacy-and-security/how-does-logingov-protect-my-data/
 - /help/privacy-and-security/will-logingov-share-my-information/


### PR DESCRIPTION
This PR fixes Nokogiri tests for internal links.

Fix: Add the `/en/` prefix on all English pages