### PR TITLE
remove integrity hash from touchpoints survey

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,6 +9,6 @@
 <script src="{{ _src | relative_url }}"></script>
 {% endfor %}{% endfor %}
 {% if layout.includes_touchpoints %}
-  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" async></script>
+  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js"></script>
   <script src="{{'/assets/js/build/touchpoints_translations.js' | relative_url}}"></script>
 {% endif %}  

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,6 +9,6 @@
 <script src="{{ _src | relative_url }}"></script>
 {% endfor %}{% endfor %}
 {% if layout.includes_touchpoints %}
-  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" integrity="sha256-bJJrp2Fye5tHOooPte/au2FqGDZwmymjr4+r4UrbeaE="  crossorigin="anonymous"></script>
+  <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js" async></script>
   <script src="{{'/assets/js/build/touchpoints_translations.js' | relative_url}}"></script>
 {% endif %}  


### PR DESCRIPTION
This PR removes the integrity hash from the Touchpoints script

Why: When the script had the integrity hash, the script would not load. The below error is what we saw after it was added

![image (3)](https://user-images.githubusercontent.com/17969963/146830706-3f906fda-8029-4512-bd52-e117f1abbc11.png)

The Touchpoints team informed us that the integrity has was not needed and not the recommended practice to add the survey, therefore, we are removing the hash. 
