### PR TITLE
Fix contact form empty error message visual appearance

### DIFF
--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -494,7 +494,7 @@ include:
   />
   <div
     id="captcha-error-message"
-    class="usa-error-message margin-bottom-4"
+    class="usa-error-message display-none margin-bottom-4"
     role="alert"
     data-error="{{ site.data.[page.lang].settings.contact_page.support_request_form.errors.captcha_required }}"
   ></div>

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -12,7 +12,7 @@ function bindCaptchaValidation() {
     if (!captcha || !captcha.value) {
       event.preventDefault();
       error.textContent = error.dataset.error;
-      error.className = error.className.replace(/(\s*)display-none(\s*)/, '$1$2');
+      error.classList.remove('display-none');
     }
   });
 }
@@ -22,6 +22,6 @@ window.clearCaptchaError = () => {
   const error = document.getElementById('captcha-error-message');
   if (error.textContent) {
     error.textContent = '';
-    error.className += ' display-none';
+    error.classList.add('display-none');
   }
 };

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -12,6 +12,7 @@ function bindCaptchaValidation() {
     if (!captcha || !captcha.value) {
       event.preventDefault();
       error.textContent = error.dataset.error;
+      error.className = error.className.replace(/(\s*)display-none(\s*)/, '$1$2');
     }
   });
 }
@@ -21,5 +22,6 @@ window.clearCaptchaError = () => {
   const error = document.getElementById('captcha-error-message');
   if (error.textContent) {
     error.textContent = '';
+    error.className += ' display-none';
   }
 };


### PR DESCRIPTION
**Why**: Due to the upgrade in #777, new styling for error messages now causes part of an error icon to appear when there is no error.

This is related to updated error styling introduced as part of https://github.com/18F/identity-style-guide/pull/265 .

Contact form: https://login.gov/contact/

Note that the issue can't be seen in Federalist previews, since we don't render the ReCaptcha elements there. You will need to confirm locally, where ReCaptcha is shown (with default configuration, at least).

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/147978158-3879b79e-8fb4-4618-b36c-56bc17a8c063.png)|![image](https://user-images.githubusercontent.com/1779930/147978133-5e9c8338-8763-4f57-8b8d-b383bc57b853.png)

**Implementation notes:**

- ~Using the [`classList` API](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) would be simpler, but it is not supported in Internet Explorer, and we don't have a (reliable) polyfill.~ **Edit:** As discussed in https://github.com/18F/identity-site/pull/782#discussion_r777704893, there is partial support available in Internet Explorer for the features we need.
- Another alternative could be to style the element if it has no content (i.e. `.usa-error-message:empty`), but this isn't super reliable since [`:empty`](https://developer.mozilla.org/en-US/docs/Web/CSS/:empty) doesn't account for whitespace, so it's easy to accidentally create a meaningfully-empty-but-not-`:empty` element.