### PR TITLE
LG-5497 - fix leftnav to highlight active page

### DIFF
--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -22,8 +22,11 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
         <ul class="usa-sidenav__sublist">
           {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
           <li class="usa-sidenav__item">
-            <!-- TODO: Add active item -->
-            <a href="{{ item.url }}">{{ item.name }}</a>
+            <a href="{{ item.url }}"
+               class="{% if item.url == page.permalink %}usa-current{% endif %}"
+            >
+              {{ item.name }}
+            </a>
           </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
This pull request updates the policy left nav to highlight the active page.
![Screen Shot 2022-01-19 at 6 19 06 PM](https://user-images.githubusercontent.com/7727136/150233915-1b8e7681-abaf-4ba5-a1ac-43d7c0cb08be.png)
 