### PR TITLE
Clicking side navigation parent link reloads current page

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -208,6 +208,7 @@ nav:
   playbook: Playbook
   policies:
     title: Privacy & security
+    url: /policy/
     sections:
       - name: Our commitment to your privacy and security
         url: /policy/

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -213,6 +213,7 @@ nav:
   playbook: Manual
   policies:
     title: Privacidad y seguridad
+    url: /es/policy/
     sections:
       - name: Nuestro compromiso con su privacidad y seguridad
         url: /es/policy/

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -211,6 +211,7 @@ nav:
   playbook: Guide de mise en œuvre
   policies:
     title: Confidentialité et sécurité
+    url: /fr/policy/
     sections:
       - name: Notre engagement envers votre confidentialité et votre sécurité
         url: /fr/policy/

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -22,7 +22,7 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
         <ul class="usa-sidenav__sublist">
           {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
           <li class="usa-sidenav__item">
-            <a href="{{ item.url }}"
+            <a href="{{ item.url | prepend: side.baseurl }}"
                class="{% if item.url == page.permalink %}usa-current{% endif %}"
             >
               {{ item.name }}

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -34,6 +34,29 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
     </ul>
   </nav>
   {% endif %}
+  {% if page.sidenav == "policy" %}
+  <nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
+    <ul class="usa-sidenav">
+      <li class="usa-sidenav__item">
+        <!-- TODO: Parent item should not be clickable -->
+        <a href="{{ page.url | prepend: site.baseurl }}" class="usa-current"
+          >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
+        >
+        <ul class="usa-sidenav__sublist">
+          {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
+          <li class="usa-sidenav__item">
+            <a href="{{ item.url }}"
+               class="{% if item.url == page.permalink %}usa-current{% endif %}"
+            >
+              {{ item.name }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
 {% endcapture %}
 
 {% capture heading %}

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -11,30 +11,31 @@ sections: - name: Our commitment to your privacy and security url: /policy/ - na
 url: /policy/#another-policy-link The page.sidenav value will be passed to the sidenav for loop
 below. Note: This does not apply to Help pages, which is far more complex. {% endcomment %}
 {% capture sidenav %}
+{% if page.sidenav == "policies" %}
+<nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
+  <ul class="usa-sidenav">
+    <li class="usa-sidenav__item">
+      <!-- Policy page sidenav -->
+      <a href="{{ '/policy' || locale_url }}" class="usa-current"
+        >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"].url }}</a
+      >
+      <ul class="usa-sidenav__sublist">
+        {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
+        <li class="usa-sidenav__item">
+          <a href="{{ item.url }}"
+             class="{% if item.url == page.permalink %}usa-current{% endif %}"
+          >
+            {{ item.name }}
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </li>
+  </ul>
+</nav>
+{% endif %}
+
   {% if page.sidenav != "none" %}
-  <nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
-    <ul class="usa-sidenav">
-      <li class="usa-sidenav__item">
-        <!-- TODO: Parent item should not be clickable -->
-        <a href="{{ page.url | prepend: site.baseurl }}" class="usa-current"
-          >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
-        >
-        <ul class="usa-sidenav__sublist">
-          {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
-          <li class="usa-sidenav__item">
-            <a href="{{ item.url }}"
-               class="{% if item.url == page.permalink %}usa-current{% endif %}"
-            >
-              {{ item.name }}
-            </a>
-          </li>
-          {% endfor %}
-        </ul>
-      </li>
-    </ul>
-  </nav>
-  {% endif %}
-  {% if page.sidenav == "policy" %}
   <nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
     <ul class="usa-sidenav">
       <li class="usa-sidenav__item">

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -11,38 +11,21 @@ sections: - name: Our commitment to your privacy and security url: /policy/ - na
 url: /policy/#another-policy-link The page.sidenav value will be passed to the sidenav for loop
 below. Note: This does not apply to Help pages, which is far more complex. {% endcomment %}
 {% capture sidenav %}
-{% if page.sidenav == "policies" %}
-<nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
-  <ul class="usa-sidenav">
-    <li class="usa-sidenav__item">
-      <!-- Policy page sidenav -->
-      <a href="{{ '/policy' || locale_url }}" class="usa-current"
-        >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"].url }}</a
-      >
-      <ul class="usa-sidenav__sublist">
-        {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
-        <li class="usa-sidenav__item">
-          <a href="{{ item.url }}"
-             class="{% if item.url == page.permalink %}usa-current{% endif %}"
-          >
-            {{ item.name }}
-          </a>
-        </li>
-        {% endfor %}
-      </ul>
-    </li>
-  </ul>
-</nav>
-{% endif %}
-
   {% if page.sidenav != "none" %}
   <nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
     <ul class="usa-sidenav">
       <li class="usa-sidenav__item">
         <!-- TODO: Parent item should not be clickable -->
-        <a href="{{ page.url | prepend: site.baseurl }}" class="usa-current"
-          >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
-        >
+        <!-- If the user is on the policy page, make the parent item fixed -->
+        {% if page.sidenav == "policies" %}
+          <a href="{{ '/policy/' | locale_url }}" class="usa-current"
+            >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
+          >
+        {% else %}
+          <a href="{{ page.url | prepend: site.baseurl }}" class="usa-current"
+            >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
+          >
+        {% endif%}
         <ul class="usa-sidenav__sublist">
           {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
           <li class="usa-sidenav__item">

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -15,17 +15,10 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
   <nav aria-label="{{ site.data[page.lang].settings.accessible_labels.secondary_navigation }}" class="position-sticky pin-top">
     <ul class="usa-sidenav">
       <li class="usa-sidenav__item">
-        <!-- TODO: Parent item should not be clickable -->
-        <!-- If the user is on the policy page, make the parent item fixed -->
-        {% if page.sidenav == "policies" %}
-          <a href="{{ '/policy/' | locale_url }}" class="usa-current"
-            >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
-          >
-        {% else %}
-          <a href="{{ page.url | prepend: site.baseurl }}" class="usa-current"
-            >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
-          >
-        {% endif%}
+        {% assign section_url = site.data[page.lang].settings.nav[page.sidenav].url | default: page.url %}
+        <a href="{{ section_url | prepend: site.baseurl }}" class="usa-current"
+          >{{ site.data[page.lang].settings["nav"][page.sidenav]["title"] }}</a
+        >
         <ul class="usa-sidenav__sublist">
           {% for item in site.data[page.lang].settings["nav"][page.sidenav]["sections"]%}
           <li class="usa-sidenav__item">


### PR DESCRIPTION
The PR fixes a bug--if a user went to the Privacy and Security act statement page, the user would see the original page. If they clicked away from that page to another (ex: How does it work), the Privacy and Security link would then get the attribute of the current page they were on.

This PR makes it so that the Privacy and Security Act statement link *always* redirects to [Login.gov/policy](http://login.gov/policy)