### PR TITLE
LG-5875 Bullets overlap fix

### DIFF
--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -27,7 +27,7 @@
 }
 
 .thumbs-up {
-    padding-left: 10%;
+    padding-left: 2.75rem;
     background: url(../img/partners/thumbs-up.svg) no-repeat top 12px left;
 }
 
@@ -48,7 +48,7 @@
         background-size: 35%;
     }
 }
-  
+
 .security-list {
     font-size: 1rem;
     line-height: 1.5em;
@@ -104,7 +104,7 @@
 }
 
 .accordion-list-headings {
-    font-size: $base-font-size; 
+    font-size: $base-font-size;
 }
 
 .usa-accordion__content h4 p {


### PR DESCRIPTION
Why: Fixing the overlap of the thumbs up icons on /partnerships/our-services when viewed on mobile.