### PR TITLE
Use sentence case for items in partners heading (LG-6100)

### DIFF
--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -46,7 +46,7 @@
             class="usa-nav__link {% if page.url contains '/our-services' %}usa-current{% endif %}"
             href="{{ '/partners/our-services/' | locale_url }}"
           >
-            <span>Our Services</span>
+            Our services
           </a>
         </li>
         <li class="usa-nav__primary-item">
@@ -54,7 +54,7 @@
             class="usa-nav__link {% if page.url contains '/impact-stories' %}usa-current{% endif %}"
             href="{{ '/partners/impact-stories/' | locale_url }}"
           >
-            <span>Impact Stories</span>
+            Impact stories
           </a>
         </li>
         <li class="usa-nav__primary-item">
@@ -62,7 +62,7 @@
             class="usa-nav__link {% if page.url contains '/security-experience' %}usa-current{% endif %}"
             href="{{ '/partners/security-experience/' | locale_url }}"
           >
-            <span>Security Experience</span>
+            Security experience
           </a>
         </li>
         <li class="usa-nav__primary-item">
@@ -70,7 +70,7 @@
             class="usa-nav__link {% if page.url contains '/faq' %}usa-current{% endif %}"
             href="{{ '/partners/faq/' | locale_url }}"
           >
-            <span>FAQ</span>
+            FAQ
           </a>
         </li>
       </ul>
@@ -79,11 +79,11 @@
         <a
           class="{{include.mobile}} usa-button usa-button--outline {% if page.url contains '/state-and-local' %}partners-usa-button--active{% endif %}"
           href="{{ site.baseurl }}/partners/state-and-local/"
-        >State and Local</a>
+        >State and local</a>
         <a
           class="{{include.mobile}} usa-button {% if page.url contains '/get-started' %}usa-button--active{% endif %}"
           href="{{ site.baseurl }}/partners/get-started/"
-        >Get Started</a>
+        >Get started</a>
       </div>
 
       <a


### PR DESCRIPTION
- Also remove some empty span tags

- I also sentence-cased the buttons? The ticket was unclear, so I went for it.

| state | screenshot |
| --- | --- |
| before | <img width="1128" alt="Screen Shot 2022-04-06 at 3 49 27 PM" src="https://user-images.githubusercontent.com/458784/162085578-62a44edc-f9e1-40b3-8496-50292ec1d36e.png"> |
| after | <img width="1128" alt="Screen Shot 2022-04-06 at 3 49 30 PM" src="https://user-images.githubusercontent.com/458784/162085590-5093d65e-7d0b-41cb-bdf8-c5759f1c8516.png"> |


 