### PR TITLE
Fix partners hero text/background color at smaller break (LG-6099)

### DIFF
--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -30,8 +30,8 @@
   }
 
   &.partners {
-    background-color: $white;
-    color: $base-font-color;
+    background-color: color('white');
+    color: color('ink');
   }
 }
 

--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -28,6 +28,11 @@
       font-size: 1.25rem; // 20px
     }
   }
+
+  &.partners {
+    background-color: $white;
+    color: $base-font-color;
+  }
 }
 
 .hero--search {
@@ -78,10 +83,8 @@
 
     &.partners {
       height: 28rem;
-      background-color: $white;
       background: no-repeat url(../img/partners/heroes/partners-hero.svg) 80% / 100% ;
       background-size: 30%;
-      color: $base-font-color;
       > .container {
         background: none;
       }


### PR DESCRIPTION


| | desktop | mobile |
|-|---|---|
| before | <img width="1037" alt="Screen Shot 2022-04-06 at 4 10 58 PM" src="https://user-images.githubusercontent.com/458784/162088310-b1574801-1019-4af2-9667-4c37d6dceb67.png"> | <img width="805" alt="Screen Shot 2022-04-06 at 4 11 12 PM" src="https://user-images.githubusercontent.com/458784/162088345-48052e76-9716-419a-90df-2d3101be8c0e.png"> |
| after | <img width="1037" alt="Screen Shot 2022-04-06 at 4 10 55 PM" src="https://user-images.githubusercontent.com/458784/162088332-8e632ad5-4084-49d4-8b46-bb49bd734fa0.png"> | <img width="805" alt="Screen Shot 2022-04-06 at 4 11 16 PM" src="https://user-images.githubusercontent.com/458784/162088365-76823996-3b16-432b-aaec-e092b4318dc5.png"> |
 