### PR TITLE
Update Partners Logo in Header

### DIFF
--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -24,11 +24,10 @@
       <div class="usa-logo partners-logo" id="extended-logo">
         <a href="{{ '/partners/' | locale_url }}" aria-label="Home">
           <img
-            src="{{ site.baseurl }}/assets/img/logo.svg"
-            class="usa-logo__img"
-            alt="login.gov"
+            src="{{ site.baseurl }}/assets/img/partners/partners_logo.svg"
+            class="usa-logo__img partners-logo__img"
+            alt="login.gov partners"
           />
-          <span>Partners</span>
         </a>
       </div>
 

--- a/_sass/pages/_partners.scss
+++ b/_sass/pages/_partners.scss
@@ -8,22 +8,8 @@
   }
 }
 
-.partners-logo a {
-  align-items: center;
-  display: flex;
-  & span {
-    color: $red;
-    font-weight: 600;
-    letter-spacing: 2px;
-    margin-left: 3px;
-    text-transform: uppercase;
-    @include at-media("card") {
-      font-size: 1.15rem;
-    }
-    @include at-media("desktop") {
-      font-size: 1.67rem;
-    }
-  }
+.partners-logo__img {
+  height: 1.7rem;
 }
 
 .partners-footer-logo {


### PR DESCRIPTION
Why? Updated the Partners logo in the header to use an image rather than image + span.

Old Logo:
<img width="404" alt="Screen Shot 2022-04-21 at 3 31 57 PM" src="https://user-images.githubusercontent.com/1034049/164538847-33a91f41-6258-4e42-8643-cdad05360aa7.png">

New Logo:
<img width="368" alt="Screen Shot 2022-04-21 at 3 32 06 PM" src="https://user-images.githubusercontent.com/1034049/164538872-3f8594c8-e981-4f96-86ac-945d58971fcb.png">
