### PR TITLE
Fix link to contact us 

### DIFF
--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -87,7 +87,7 @@
 
       <a
         class="usa-link desktop:display-none padding-y-1 margin-y-3 text-no-underline text-bold"
-        href="{{ '/contact/' | locale_url }}"
+        href="/partners/contact/"
       >
         {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>


### PR DESCRIPTION
Fixes link to contact-us on mobile menu:

https://cm-jira.usa.gov/browse/LG-6202