### PR TITLE
Remove invalid, unused page spec

### DIFF
--- a/spec/_pages/index.md_spec.rb
+++ b/spec/_pages/index.md_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-RSpec.describe 'index.md' do
-  let(:doc) { Nokogiri::HTML(file_at('/')) }
-
-  xit 'contains specific copy that NewRelic checks for' do
-    expect(doc.text).to include('secure access to government services')
-  end
-end


### PR DESCRIPTION
**Why**: The content doesn't exist, nor is it checked for in NewRelic.

Timeline:

- Spec added in #85
- Content changes, test skipped in #428

Per the test case message, while there is a monitor in NewRelic "prod login.gov static site monitor", it appears to currently be configured as a simple [ping monitor](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/types-synthetic-monitors/), not checking for specific content.