### PR TITLE
Hide /partners from crawlers (LG-6391)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -93,6 +93,10 @@ defaults:
       path: 'content/**/*/*._fr.md'
     values:
       lang: fr
+  - scope: # temporarily hide /partners content from sitemap.xml while under development
+      path: 'content/_partners/**/*'
+    values:
+      sitemap: false
 
 include:
   # dotfiles are excluded by default

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,6 @@
 User-agent: *
 Sitemap: /sitemap.xml
 Allow: /
+
+User-agent: *
+Disallow: /partners/


### PR DESCRIPTION
**Why**: So we can merge the /partners redesign long-lived branch
and keep iterating on it before linking to it and making it live