### PR TITLE
Fix links on partners homepage (LG-6320)

### DIFF
--- a/_includes/components/3-col.html
+++ b/_includes/components/3-col.html
@@ -3,15 +3,15 @@
     <div class="grid-row">
       <div class="tablet:grid-col">
         <h3 class="hdr {{ include.col_class1}}">{{ include.subheading1 }}</h3>
-        {{ include.col1 | replace: 'site.baseurl', site.baseurl | markdownify }}
+        {{ include.col1 | markdownify }}
       </div>
       <div class="tablet:grid-col">
         <h3 class="hdr {{ include.col_class2}}">{{ include.subheading2 }}</h3>
-        {{ include.col2 | replace: 'site.baseurl', site.baseurl | markdownify }}
+        {{ include.col2 | markdownify }}
       </div>
       <div class="tablet:grid-col">
         <h3 class="hdr {{ include.col_class3}}">{{ include.subheading3 }}</h3>
-        {{ include.col3 | replace: 'site.baseurl', site.baseurl | markdownify }}
+        {{ include.col3 | markdownify }}
       </div>
     </div>
   </article>

--- a/_includes/partners/x-col.html
+++ b/_includes/partners/x-col.html
@@ -20,6 +20,6 @@
     </div>
   </div>
   {% if include.link and include.link != '' %}
-    {{ include.link | replace: 'site.baseurl', site.baseurl | markdownify }}
+    {{ include.link | markdownify }}
   {% endif %}
 </article>

--- a/content/_partners/index._en.md
+++ b/content/_partners/index._en.md
@@ -17,19 +17,19 @@ services:
   col1: >-
     Users create one account to access all your digital services with multi-factor authentication.
 
-    [Learn about authentication](site.baseurl/partners/our-services/){:class="partners-authentication caret"}
+    [Learn about authentication](/partners/our-services/){:class="partners-authentication caret"}
   subheading2: Identity verification
   col_class2: identity
   col2: >-
     Verify the right person has access to the right information with secure identity verification.
 
-    [Learn about identity verification](site.baseurl/partners/our-services/){:class="partners-identity caret"}
+    [Learn about identity verification](/partners/our-services/){:class="partners-identity caret"}
   subheading3: Multilingual user support
   col_class3: multilingual
   col3: >-
     Comprehensive, multilingual support for your end-users Monday-Friday, 8 a.m.-8 p.m. ET.
 
-    [Learn about user support](site.baseurl/partners/our-services/){:class="partners-multilingual caret"}
+    [Learn about user support](/partners/our-services/){:class="partners-multilingual caret"}
 
 right_for_you:
   heading: Is Login.gov right for you?
@@ -53,7 +53,7 @@ who_we_work_with:
     - image: partners/logos/doi.png
     - image: partners/logos/va.png
   link: >
-    [Read our impact stories](site.baseurl/partners/impact-stories/){:class="usa-nav_link caret"}
+    [Read our impact stories](/partners/impact-stories/){:class="usa-nav_link caret"}
 
 nist_fedramp:
   heading: Security and compliance
@@ -68,5 +68,5 @@ nist_fedramp:
       image: partners/fedramp.png
       text:  <span>Our FedRAMP Moderate Authority to Operate (ATO)</span> Login.gov has a [FedRAMP](https://www.fedramp.gov/){:class="external-link"} Moderate ATO issued by the U.S. General Services Administration. Our SSP/Control Implementation Survey/Customer Responsibility Matrix is available through the FedRAMP marketplace.
   link: >
-    [Learn more about our security experience](site.baseurl/partners/security-experience/){:class="usa-nav_link caret"}
+    [Learn more about our security experience](/partners/security-experience/){:class="usa-nav_link caret"}
 ---


### PR DESCRIPTION
This reverts commit 7db61bc8bc6a2fe6127dd8cb8bd0e2ae3145c254.

Background: 7db61bc8bc6a2fe6127dd8cb8bd0e2ae3145c254 added ` | replace: 'site.baseurl', site.baseurl ` but we also have a (`base_url.rb` plugin https://github.com/18F/identity-site/blob/main/_plugins/base_url.rb) that prefixes the base url to all links starting with `/`... so there was some duplication


This is in draft because it's hard to test locally