### PR TITLE
Update home link from partners page to go through markdown

### DIFF
--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -1,12 +1,10 @@
 <section class="login-developers-links">
   <div class="container">
     <div class="grid-col display-flex flex-justify-end flex-align-center">
-      <a
-        class="usa-nav__link usa-link"
-        href="/"
-      >
-        Login.gov
-      </a>
+      {%- capture home_link -%}
+        [Login.gov](/){:class="usa-nav__link usa-link"}
+      {%- endcapture -%}
+      {{ home_link | markdownify }}
       <span class="links-separator">&#124;</span>
       <a
         class="usa-nav__link usa-link"


### PR DESCRIPTION
**Why**: markdown URLs get processed through base_url.rb but
plain HTML ones don't, so this helps us make sure that link
works in preview URLs