### PR TITLE
LG-6288 fix partners logo overlap in subfooter

### DIFF
--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -24,7 +24,7 @@
       justify-content: flex-end;
       padding-top: ($container-spacing-sm * 3);
 
-      @include at-media("desktop") {
+      @include at-media("tablet-lg") {
         display: flex;
         padding-top: 0;
       }

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -24,7 +24,7 @@
       justify-content: flex-end;
       padding-top: ($container-spacing-sm * 3);
 
-      @include at-media("tablet") {
+      @include at-media("desktop") {
         display: flex;
         padding-top: 0;
       }


### PR DESCRIPTION
Why? Fixes overlap of the login.gov partners logo in the subfooter.

Overlap was happening around 770px width.
<img width="420" alt="Screen Shot 2022-05-25 at 12 26 48 PM" src="https://user-images.githubusercontent.com/1034049/170313684-0b87d080-7904-45ee-a55f-2df35c28ef35.png">
