### PR TITLE
Reduce external link test flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' '/^.*\.(pdf|PDF)$ / gm' 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '\.gov$' --url-ignore '\.pdf$' 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore '^.*\.(pdf|PDF)$' 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore '/^.*\.(pdf|PDF)$' 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore '/^.*\.(pdf|PDF)$' 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore '/^.*\.(pdf|PDF)$ / gm' 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '\.gov$' --url-ignore '\.pdf$' --http-status-ignore 503
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '\.gov$' --http-status-ignore 503
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '\.gov$' --url-ignore '\.pdf$' 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '\.gov$' --url-ignore '\.pdf$' --http-status-ignore 503
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore lastpass.com --url-ignore '^.*\.(pdf|PDF)$' 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore '^.*\.(pdf|PDF)$' 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore congress.gov --url-ignore lastpass.com 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore lastpass.com 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore '/^.*\.(pdf|PDF)$ / gm' 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' '/^.*\.(pdf|PDF)$ / gm' 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: "."
       - run:
           name: Run htmlproofer (external links only)
-          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore lastpass.com 
+          command: bundle exec scripts/htmlproofer --external --retry-external 3 --retry-external-delay 8 --url-ignore '/.*gov$ / gm' --url-ignore lastpass.com --url-ignore '^.*\.(pdf|PDF)$' 
       - slack/status:
           fail_only: true
           failure_message: ":login-gov::red_circle: external link check failed"

--- a/scripts/htmlproofer
+++ b/scripts/htmlproofer
@@ -12,7 +12,7 @@ proofer_options = { url_ignore: [] }
 OptionParser.new do |opt|
   opt.on('--internal') { proofer_options[:disable_external] = true }
   opt.on('--external') { proofer_options[:external_only] = true }
-  opt.on('--url-ignore PATTERN') { |pattern| proofer_options[:url_ignore] << /#{Regexp.quote(pattern)}/ }
+  opt.on('--url-ignore PATTERN') { |pattern| proofer_options[:url_ignore] << Regexp.quote(pattern) }
   opt.on('--retry-external RETRIES', Integer) { |retries_arg| retries = retries_arg }
   opt.on('--retry-external-delay DELAY', Integer) { |retry_delay_arg| retry_delay = retry_delay_arg }
 end.parse!

--- a/scripts/htmlproofer
+++ b/scripts/htmlproofer
@@ -13,6 +13,7 @@ OptionParser.new do |opt|
   opt.on('--internal') { proofer_options[:disable_external] = true }
   opt.on('--external') { proofer_options[:external_only] = true }
   opt.on('--url-ignore PATTERN') { |pattern| proofer_options[:url_ignore] << /#{Regexp.quote(pattern)}/ }
+  opt.on('--file-ignore PATTERN') { |pattern| proofer_options[:file_ignore] << /#{Regexp.quote(pattern)}/ }
   opt.on('--retry-external RETRIES', Integer) { |retries_arg| retries = retries_arg }
   opt.on('--retry-external-delay DELAY', Integer) { |retry_delay_arg| retry_delay = retry_delay_arg }
 end.parse!

--- a/scripts/htmlproofer
+++ b/scripts/htmlproofer
@@ -15,6 +15,7 @@ OptionParser.new do |opt|
   opt.on('--url-ignore PATTERN') { |pattern| proofer_options[:url_ignore] << Regexp.quote(pattern) }
   opt.on('--retry-external RETRIES', Integer) { |retries_arg| retries = retries_arg }
   opt.on('--retry-external-delay DELAY', Integer) { |retry_delay_arg| retry_delay = retry_delay_arg }
+  opt.on('--http-status-ignore', Integer) { |status_code_arg| status_code = status_code_arg }
 end.parse!
 
 site_config = Jekyll::Configuration.from(YAML.load_file('_config.yml'))

--- a/scripts/htmlproofer
+++ b/scripts/htmlproofer
@@ -13,7 +13,6 @@ OptionParser.new do |opt|
   opt.on('--internal') { proofer_options[:disable_external] = true }
   opt.on('--external') { proofer_options[:external_only] = true }
   opt.on('--url-ignore PATTERN') { |pattern| proofer_options[:url_ignore] << /#{Regexp.quote(pattern)}/ }
-  opt.on('--file-ignore PATTERN') { |pattern| proofer_options[:file_ignore] << /#{Regexp.quote(pattern)}/ }
   opt.on('--retry-external RETRIES', Integer) { |retries_arg| retries = retries_arg }
   opt.on('--retry-external-delay DELAY', Integer) { |retry_delay_arg| retry_delay = retry_delay_arg }
 end.parse!


### PR DESCRIPTION
This PR makes it so that there are fewer instances of the external link tests failing

Things that may help:
- Ignoring base .gov sites (example: www.cbp.gov will be ignored, but not www.cbp.gov/helloworld. Sites like the latter should be checked because there may be instances where a page can be taken down)
- Ignoring PDF files from congress.gov? Those kind of documents are public law, so I would think that the url will always be valid


