### PR TITLE
Disable HTML output for /partners site by default

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ collections:
     output: true
     permalink: /:collection/:path/
   partners:
-    output: true
+    output: false # overridden for preview branch
     permalink: /:collection/:path/
   policy:
     output: true


### PR DESCRIPTION
I added the following override for preview branches, so this branch *should* still render:

```yaml
collections:
  partners:
    output: true
```