### PR TITLE
Link to specific anchors on "our services" page (LG-6380)

### DIFF
--- a/content/_partners/index._en.md
+++ b/content/_partners/index._en.md
@@ -17,19 +17,19 @@ services:
   col1: >-
     Users create one account to access all your digital services with multi-factor authentication.
 
-    [Learn about authentication](/partners/our-services/){:class="partners-authentication caret"}
+    [Learn about authentication](/partners/our-services/#self-asserted-identity-and-authentication-ial1aal2){:class="partners-authentication caret"}
   subheading2: Identity verification
   col_class2: identity
   col2: >-
     Verify the right person has access to the right information with secure identity verification.
 
-    [Learn about identity verification](/partners/our-services/){:class="partners-identity caret"}
+    [Learn about identity verification](/partners/our-services/#verified-identity-and-authentication-aal2){:class="partners-identity caret"}
   subheading3: Multilingual user support
   col_class3: multilingual
   col3: >-
     Comprehensive, multilingual support for your end-users Monday-Friday, 8 a.m.-8 p.m. ET.
 
-    [Learn about user support](/partners/our-services/){:class="partners-multilingual caret"}
+    [Learn about user support](/partners/our-services/#multilingual-support-for-your-end-users){:class="partners-multilingual caret"}
 
 right_for_you:
   heading: Is Login.gov right for you?
@@ -59,12 +59,12 @@ nist_fedramp:
   heading: Security and compliance
   class: nist-fedramp
   items:
-    - 
+    -
       class: nist
       image: partners/nist.svg
       text:  Login.gov is working closely with [NIST](https://www.nist.gov/){:class="external-link"} to stay current on the latest guidelines, recommendations, and best practices. Our goal is to remove the agency burden of compliance with these standards, so you can focus on your specific mission and those you serve.
       alt: National Institute of Standards and Technology (NIST)
-    - 
+    -
       class: fedramp
       image: partners/fedramp.png
       text:  <span>Our FedRAMP Moderate Authority to Operate (ATO)</span> Login.gov has a [FedRAMP](https://www.fedramp.gov/){:class="external-link"} Moderate ATO issued by the U.S. General Services Administration. Our SSP/Control Implementation Survey/Customer Responsibility Matrix is available through the FedRAMP marketplace.


### PR DESCRIPTION
I confirmed that if the anchors are incorrect, `htmlproofer` will get cranky, so that will help us ensure these continue to work