### PR TITLE
LG-6500: Update links to open in the same window/tab

### DIFF
--- a/content/_partners/security-experience._en.md
+++ b/content/_partners/security-experience._en.md
@@ -41,7 +41,7 @@ considerations2: >-
 
     * Are users aware of what data they are sharing, who they are sharing it with and how it is used?
 
-    * Is language around consent for sharing their data written in <a class="external-link" target="blank" href="https://www.plainlanguage.gov/">plain language</a> and <a class="external-link" target="blank" href="https://login.gov/accessibility/">accessible</a>?
+    * Is language around consent for sharing their data written in <a class="external-link" href="https://www.plainlanguage.gov/">plain language</a> and <a class="external-link" href="https://login.gov/accessibility/">accessible</a>?
 
     * Does the public understand that they have the right to revoke consent of the sharing of their data?
 simple: >-

--- a/content/_partners/security-experience._en.md
+++ b/content/_partners/security-experience._en.md
@@ -41,7 +41,7 @@ considerations2: >-
 
     * Are users aware of what data they are sharing, who they are sharing it with and how it is used?
 
-    * Is language around consent for sharing their data written in <a class="external-link" href="https://www.plainlanguage.gov/">plain language</a> and <a class="external-link" href="https://login.gov/accessibility/">accessible</a>?
+    * Is language around consent for sharing their data written in <a class="external-link" href="https://www.plainlanguage.gov/">plain language</a> and [accessible](/accessibility/){:class="external-link"}?
 
     * Does the public understand that they have the right to revoke consent of the sharing of their data?
 simple: >-


### PR DESCRIPTION
**Issue:** A few links are opening in a new window/tab, which isn't consistent with other link experiences.

**How:** Remove the target blank from these links on the `/security-experience/` page

> Is language around consent for sharing their data written in [plain language](https://www.plainlanguage.gov/) and [accessible](http://localhost:4000/accessibility/)?

🔗 [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-remove-target-blank/partners/security-experience/)

Notes: There are three links to update on the `/contact/` form, but we don't have access to the embedded markup. Proposing this task to be bundled into another ticket ([Slack context](https://gsa-tts.slack.com/archives/C0184P9SCJ0/p1654537687035049))