### PR TITLE
Flip default rendering of partners site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ collections:
     output: true
     permalink: /:collection/:path/
   partners:
-    output: false # overridden for preview branch
+    output: true
     permalink: /:collection/:path/
   policy:
     output: true


### PR DESCRIPTION
**Why**: Defaulting to rendering makes testing these new pages easier

I updated the configs already in federalist, this should be safe