### PR TITLE
LG-6557: /partners mobile logo and header issue

### DIFF
--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -25,7 +25,7 @@
         <a href="{{ '/partners/' | locale_url }}" aria-label="Home">
           <img
             src="{{ site.baseurl }}/assets/img/partners/partners_logo.svg"
-            class="usa-logo__img partners-logo__img"
+            class="usa-logo__img partners-logo__img padding-right-2"
             alt="login.gov partners"
           />
         </a>

--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -1,6 +1,6 @@
 <section class="login-developers-links">
   <div class="container">
-    <div class="grid-col display-flex flex-justify-end flex-align-center">
+    <div class="grid-col display-flex flex-justify-end flex-align-center padding-y-1">
       <a
         class="usa-nav__link usa-link"
         href="{{site.baseurl}}/"

--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -1,6 +1,6 @@
 <section class="login-developers-links">
   <div class="container">
-    <div class="grid-col display-flex flex-justify-end flex-align-center padding-y-1">
+    <div class="grid-col display-flex flex-justify-end flex-align-center">
       <a
         class="usa-nav__link usa-link"
         href="{{site.baseurl}}/"

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -4,6 +4,7 @@
   background-color: $blue-lightest;
   border-bottom: 1px solid $border-color;
   line-height: 1.5em;
+  padding: 0.5rem 0;
 
   @include at-media('desktop') {
     padding: 0.75rem 0;


### PR DESCRIPTION
**Issues on some mobile and tablet devices**

1. Lack of horizontal spacing between the logo and menu button
2. Lack of vertical spacing between `Login.gov | Developers.login.gov` links

👉🏼 [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-6557/partners/)

| Before | After |
|---|---|
|![before-spacing](https://user-images.githubusercontent.com/6327082/172668722-35fade59-f301-4a7b-bf42-bfe869fc565b.png)|![after-spacing](https://user-images.githubusercontent.com/6327082/172668760-05eed28b-8300-4256-9f37-52283c1dd42c.png)|