### PR TITLE
Partners site: Resolve width issues to improve reading experience

### DIFF
--- a/_layouts/partners/impact-stories.html
+++ b/_layouts/partners/impact-stories.html
@@ -12,7 +12,7 @@ layout: base
             <div class="grid-row">
                 <h1 class="partners-title">{{ page.title }}</h1>
                 <div class="tablet:grid-col-12 partners-border"></div>
-                <div class="partners-body tablet:grid-col-12">
+                <div class="tablet:grid-col-12">
                     <div>{{ page.subtitle | markdownify}}</div>
                     <div class="partners-subtitle">{{ page.body | markdownify}}</div>
                 </div>

--- a/_layouts/partners/our-services.html
+++ b/_layouts/partners/our-services.html
@@ -12,7 +12,7 @@ layout: base
             <div class="grid-row">
                 <h1 class="partners-title">{{ page.title }}</h1>
                 <div class="tablet:grid-col-12 partners-border"></div>
-                <div class="partners-body tablet:grid-col-12">
+                <div class="tablet:grid-col-12">
                     <div>{{ page.subtitle | markdownify}}</div>
                     <div class="partners-subtitle">{{ page.subsection | markdownify}}</div>
                 </div>

--- a/_layouts/partners/rrb-impact-story.html
+++ b/_layouts/partners/rrb-impact-story.html
@@ -21,7 +21,7 @@ layout: base
                     <div class="tablet:grid-col-2 padding-top-2">
                         <img src="{{ site.baseurl }}/assets/img/partners/rrb_logo.svg" alt='Railroad Retirement Board'>
                     </div>
-                    <div class="tablet:grid-col-9">
+                    <div class="tablet:grid-col-9 partners-body">
                         {{ page.quote | markdownify }}
                     </div>
                 </div>

--- a/_layouts/partners/security-experience.html
+++ b/_layouts/partners/security-experience.html
@@ -11,7 +11,7 @@ layout: base
         <div class="container partners-container" id="security-experience-container">
             <div class="grid-row">
                 <h1 class="partners-title">{{ page.title }}</h1>
-                <div class="partners-body tablet:grid-col-12 partners-border"></div>
+                <div class="tablet:grid-col-12 partners-border"></div>
                 <div class="partners-body tablet:grid-col-8">
                     <div>{{ page.subtitle | markdownify}}</div>
                     <div class="partners-subtitle">{{ page.subsection | markdownify }}</div>

--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -14,7 +14,7 @@
 }
 
 .partners-body {
-    max-width: 640px; // USWDS tablet width
+    max-width: 640px;
     line-height: 1.5em;
     h4 {
         font-size: 1.125em;
@@ -33,6 +33,7 @@
 }
 
 .partners-subtitle {
+    max-width: 880px;
     line-height: 1.5em;
     font-size: 1.25em;
 }

--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -14,6 +14,7 @@
 }
 
 .partners-body {
+    max-width: 640px; // USWDS tablet width
     line-height: 1.5em;
     h4 {
         font-size: 1.125em;

--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -45,7 +45,7 @@
 }
 
 #security-experience-container {
-    @include at-media("desktop") {
+    @include at-media("tablet") {
         background: url(../img/partners/security-experience.svg) no-repeat top 14% right 7%;
         background-size: 35%;
     }


### PR DESCRIPTION
**Issue:** There are instances when the content exceeds the line length of the optimal reading experience (~80 characters). 

**How:** This PR proposes various fixes until we have a better solution(s) in place, e.g., revamped layouts, the addition of side navigation, etc. Please feel free to propose a better way as well.

**Note:** This PR covers `/partners`-wide content brought up by these tickets.

- LG-6533
- LG-6534
- LG-6535
- LG-6556

Also, @theabrad, @zachmargolis, and I think that the PR should resolve all line length issues.

---
👉🏼 [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-6556/partners/)

| Example | Before | After |
|---|---|---|
| SBA Impact story | ![sba-story-before](https://user-images.githubusercontent.com/6327082/172729224-d0e005c2-1d66-4af3-b3c4-3f08e0b81f38.png) | ![sba-story-after](https://user-images.githubusercontent.com/6327082/172729256-68c9cdaa-14ff-4441-a626-f6f0fd60c707.png) |
| Security experience content | ![security-experience-before](https://user-images.githubusercontent.com/6327082/172729278-e60975e5-fb0f-48e6-a687-28dd390641b8.png) | ![security-experience-after](https://user-images.githubusercontent.com/6327082/172729300-a9c31c85-7872-4633-841d-22d962da4799.png) |
| Process list | ![process-list-before](https://user-images.githubusercontent.com/6327082/172729321-3813d754-240c-4b89-ae99-0d3095f79fb5.png) | ![process-list-after](https://user-images.githubusercontent.com/6327082/172729338-5eb3adfe-fefd-40ae-910b-f969abbc5b44.png) |
