### PR TITLE
Add sidenav to partners impact stories (LG-6534, LG-6535)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ collections:
   partners:
     output: true
     permalink: /:collection/:path/
+  partners_impact_stories:
+    output: true
+    permalink: /:collection/:path/
   policy:
     output: true
     permalink: /:collection/:path/

--- a/_includes/partners/impact-stories-navigation.html
+++ b/_includes/partners/impact-stories-navigation.html
@@ -1,0 +1,19 @@
+<nav class="position-sticky pin-top" aria-label="{{ site.data.[page.lang].settings.accessible_labels.secondary_navigation }}">
+  <ul class="usa-sidenav margin-left-1">
+    <li class="usa-sidenav__item">
+      <a href="{{ "/partners/impact-stories/" | locale_url }}" class="usa-current">
+        Impact Stories
+      </a>
+
+      <ul class="usa-sidenav__sublist">
+        {% for impact_story in site.partners_impact_stories %}
+          <li class="usa-sidenav__item">
+            <a href="{{ impact_story.url }}" class="{% if page.url == impact_story.url %}usa-current{% endif %}">
+              {{ impact_story.agency }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </li>
+  </ul>
+</nav>

--- a/_layouts/partners/rrb-impact-story.html
+++ b/_layouts/partners/rrb-impact-story.html
@@ -29,7 +29,7 @@ layout: base
         </div>
         <div class="container partners-container">
             <div class="grid-row">
-                <div class="tablet:grid-col-12">
+                <div class="tablet:grid-col-8">
                     <div>{{ page.subtitle | markdownify }}</div>
                     <div class="partners-body">{{ page.body | markdownify }}</div>
                     <div class="partners-body padding-top-2">{{ page.challenge | markdownify }}</div>
@@ -37,6 +37,9 @@ layout: base
                     <div class="partners-body padding-top-2">{{ page.impact | markdownify }}</div>
                     <div class="partners-body padding-top-2 padding-bottom-2">{{ page.key_shifts | markdownify }}</div>
                     <a href="{{ '/partners/impact-stories/' | locale_url }}" class="partners-body caret">Read more impact stories</a>
+                </div>
+                <div class="tablet:grid-col-4 padding-left-1">
+                    {% include partners/impact-stories-navigation.html %}
                 </div>
             </div>
         </div>

--- a/_layouts/partners/sba-impact-story.html
+++ b/_layouts/partners/sba-impact-story.html
@@ -10,7 +10,7 @@ layout: base
     <section>
         <div class="container partners-container">
             <div class="grid-row">
-                <div class="tablet:grid-col-12 partners-body">
+                <div class="tablet:grid-col-8 partners-body">
                     <h1 class="partners-title">{{ page.title }}</h1>
                     <div class="partners-border"></div>
                     <div>{{ page.subtitle | markdownify }}</div>
@@ -20,6 +20,9 @@ layout: base
                     <div class="partners-body padding-top-2">{{ page.impact | markdownify }}</div>
                     <div class="partners-body padding-top-2 padding-bottom-2">{{ page.key_shifts | markdownify }}</div>
                     <a href="{{ '/partners/impact-stories/' | locale_url }}" class="partners-body caret">Read more impact stories</a>
+                </div>
+                <div class="tablet:grid-col-4 padding-left-1">
+                    {% include partners/impact-stories-navigation.html %}
                 </div>
             </div>
         </div>

--- a/content/_partners_impact_stories/rrb._en.md
+++ b/content/_partners_impact_stories/rrb._en.md
@@ -1,6 +1,7 @@
 ---
 layout: partners/rrb-impact-story
 permalink: /partners/rrb-impact-story/
+agency: Railroad Retirement Board (RRB)
 title: >-
     Impact story: RRB
 quote: |-

--- a/content/_partners_impact_stories/sba._en.md
+++ b/content/_partners_impact_stories/sba._en.md
@@ -1,6 +1,7 @@
 ---
 layout: partners/sba-impact-story
 permalink: /partners/sba-impact-story/
+agency: Small Business Administration (SBA)
 title: >-
     Impact story: SBA
 subtitle: >-


### PR DESCRIPTION
- Creates a new collection, so that adding new impact stories is easier

There wasn't one JIRA for just this task, but it seemed to fall naturally out of LG-6534 and LG-6535

I know that @theabrad and @nickttng are also looking at some of the widths on impact stories, this was just a rough pass to add the sidenav, and not affect the rest. I chose to move the files to make new collections, so that may increase the chances of merge conflicts... apologies!

I think the nav here is too wide compared to [the Figma](https://www.figma.com/file/N4ivGLmr17PsrG1vEYcOxm/LG-5379-design-Iteration-partners.login.gov?node-id=1149%3A3957), but like I said, this is just the first pass

| before | after |
| --- | --- |
| <img width="1239" alt="Screen Shot 2022-06-08 at 3 48 01 PM" src="https://user-images.githubusercontent.com/458784/172730141-23369635-5ab1-4e34-b15f-c96c6537f6fa.png"> |  <img width="1239" alt="Screen Shot 2022-06-08 at 3 47 57 PM" src="https://user-images.githubusercontent.com/458784/172730151-359248f7-7d20-4798-9584-436d92c9f22f.png"> |

 