### PR TITLE
Clean up partners impact stories pages

### DIFF
--- a/_includes/partners/impact-stories-navigation.html
+++ b/_includes/partners/impact-stories-navigation.html
@@ -1,14 +1,14 @@
 <nav class="position-sticky pin-top" aria-label="{{ site.data.[page.lang].settings.accessible_labels.secondary_navigation }}">
   <ul class="usa-sidenav margin-left-1">
     <li class="usa-sidenav__item">
-      <a href="{{ "/partners/impact-stories/" | locale_url }}" class="usa-current">
-        Impact Stories
+      <a href="{{ "/partners/impact-stories/" | locale_url | prepend: site.baseurl }}" class="usa-current">
+        Impact stories
       </a>
 
       <ul class="usa-sidenav__sublist">
         {% for impact_story in site.partners_impact_stories %}
           <li class="usa-sidenav__item">
-            <a href="{{ impact_story.url }}" class="{% if page.url == impact_story.url %}usa-current{% endif %}">
+            <a href="{{ impact_story.url | prepend: site.baseurl }}" class="{% if page.url == impact_story.url %}usa-current{% endif %}">
               {{ impact_story.agency }}
             </a>
           </li>

--- a/_includes/partners/impact-stories-navigation.html
+++ b/_includes/partners/impact-stories-navigation.html
@@ -8,7 +8,7 @@
       <ul class="usa-sidenav__sublist">
         {% for impact_story in site.partners_impact_stories %}
           <li class="usa-sidenav__item">
-            <a href="{{ impact_story.url | prepend: site.baseurl }}" class="{% if page.url == impact_story.url %}usa-current{% endif %}">
+            <a href="{{ impact_story.url | locale_url }}" class="{% if page.url == impact_story.url %}usa-current{% endif %}">
               {{ impact_story.agency }}
             </a>
           </li>

--- a/_layouts/partners/impact-stories.html
+++ b/_layouts/partners/impact-stories.html
@@ -23,7 +23,7 @@ layout: base
                         <img src="{{ site.baseurl }}/{{ impact_story.logo }}" alt='{{ impact_story.agency }}'>
                     </div>
                     <div class="tablet:grid-col-9 margin-top-3">
-                        <a href="{{ impact_story.url | locale_url | prepend: site.baseurl }}" class="text-middle partners-subtitle caret">
+                        <a href="{{ impact_story.url | locale_url }}" class="text-middle partners-subtitle caret">
                             <b>{{ impact_story.agency }}</b>
                         </a>
                         <div class="partners-body text-middle padding-top-2">{{ impact_story.summary }}</div>

--- a/_layouts/partners/impact-stories.html
+++ b/_layouts/partners/impact-stories.html
@@ -17,24 +17,19 @@ layout: base
                     <div class="partners-subtitle">{{ page.body | markdownify}}</div>
                 </div>
             </div>
-            <div class="grid-row grid-gap-6 padding-top-4">
-                <div class="tablet:grid-col-2">
-                    <img src="{{ site.baseurl }}/assets/img/partners/sba_logo.svg" alt='Small Business Administration'>
+            {% for impact_story in site.partners_impact_stories %}
+                <div class="grid-row grid-gap-6 padding-top-4">
+                    <div class="tablet:grid-col-2">
+                        <img src="{{ site.baseurl }}/{{ impact_story.logo }}" alt='{{ impact_story.agency }}'>
+                    </div>
+                    <div class="tablet:grid-col-9 margin-top-3">
+                        <a href="{{ impact_story.url | locale_url | prepend: site.baseurl }}" class="text-middle partners-subtitle caret">
+                            <b>{{ impact_story.agency }}</b>
+                        </a>
+                        <div class="partners-body text-middle padding-top-2">{{ impact_story.summary }}</div>
+                    </div>
                 </div>
-                <div class="tablet:grid-col-9 margin-top-3">
-                    <a href="{{ '/partners/sba-impact-story/' | locale_url }}" class="text-middle partners-subtitle caret"><b>Small Business Administration (SBA)</b></a>
-                    <div class="partners-body text-middle padding-top-2">{{ page.sba_body }}</div>
-                </div>
-            </div>
-            <div class="grid-row grid-gap-6 padding-top-4">
-                <div class="tablet:grid-col-2">
-                    <img src="{{ site.baseurl }}/assets/img/partners/rrb_logo.svg" alt='Railroad Retirement Board'>
-                </div>
-                <div class="tablet:grid-col-9 margin-top-3">
-                    <a href="{{ '/partners/rrb-impact-story/' | locale_url }}" class="text-middle partners-subtitle caret" ><b>Railroad Retirement Board (RRB)</b></a>
-                    <div class="partners-body text-middle padding-top-2">{{ page.rrb_body }}</div>
-                </div>
-            </div>
+            {% endfor %}
         </div>
     </section>
 </main>

--- a/content/_partners/impact-stories._en.md
+++ b/content/_partners/impact-stories._en.md
@@ -7,8 +7,4 @@ subtitle: >-
     ## For government, by government
 body: >-
     Login.gov is a federal program within GSA’s Technology Transformation Services (TTS). We design and deliver a digital government with and for the American public by partnering with agencies. Learn more about our partnership in the impact stories below.
-sba_body: >-
-    U.S. Small Business Administration (SBA) partnered with GSA’s Federal Acquisition Service Technology Transformation Services (TTS) to centralize their identity management platform.
-rrb_body: >-
-    The U.S. Railroad Retirement Board (RRB) partnered with GSA’s Federal Acquisition Strategy’s Technology Transformation Services (TTS) to leverage the latest innovations in digital security to protect their customers.
 ---

--- a/content/_partners_impact_stories/rrb._en.md
+++ b/content/_partners_impact_stories/rrb._en.md
@@ -1,6 +1,6 @@
 ---
 layout: partners/rrb-impact-story
-permalink: /partners/impact-stories/rrb
+permalink: /partners/impact-stories/rrb/
 agency: Railroad Retirement Board (RRB)
 summary: >-
     The U.S. Railroad Retirement Board (RRB) partnered with GSA’s Federal Acquisition Strategy’s Technology Transformation Services (TTS) to leverage the latest innovations in digital security to protect their customers.

--- a/content/_partners_impact_stories/rrb._en.md
+++ b/content/_partners_impact_stories/rrb._en.md
@@ -1,7 +1,10 @@
 ---
 layout: partners/rrb-impact-story
-permalink: /partners/rrb-impact-story/
+permalink: /partners/impact-stories/rrb
 agency: Railroad Retirement Board (RRB)
+summary: >-
+    The U.S. Railroad Retirement Board (RRB) partnered with GSA’s Federal Acquisition Strategy’s Technology Transformation Services (TTS) to leverage the latest innovations in digital security to protect their customers.
+logo: assets/img/partners/rrb_logo.svg
 title: >-
     Impact story: RRB
 quote: |-

--- a/content/_partners_impact_stories/sba._en.md
+++ b/content/_partners_impact_stories/sba._en.md
@@ -1,6 +1,6 @@
 ---
 layout: partners/sba-impact-story
-permalink: /partners/impact-stories/sba
+permalink: /partners/impact-stories/sba/
 agency: Small Business Administration (SBA)
 summary: >-
     U.S. Small Business Administration (SBA) partnered with GSA’s Federal Acquisition Service Technology Transformation Services (TTS) to centralize their identity management platform.

--- a/content/_partners_impact_stories/sba._en.md
+++ b/content/_partners_impact_stories/sba._en.md
@@ -1,7 +1,10 @@
 ---
 layout: partners/sba-impact-story
-permalink: /partners/sba-impact-story/
+permalink: /partners/impact-stories/sba
 agency: Small Business Administration (SBA)
+summary: >-
+    U.S. Small Business Administration (SBA) partnered with GSA’s Federal Acquisition Service Technology Transformation Services (TTS) to centralize their identity management platform.
+logo: assets/img/partners/sba_logo.svg
 title: >-
     Impact story: SBA
 subtitle: >-


### PR DESCRIPTION
- Update URLs to be more directory-like /partners/impact-stories/:agency
- Sentence-case sidenav title
- Update landing page to use the same order as sidenav
- Fix URLs to work in preview pages

Lotta small changes, here are screenshots of the visible ones: (note, there are separate width changes in the visual diff not related to this specific PR)

| change | before | after |
| -- | --- | --- |
| landing page order: alphabetized | <img width="1166" alt="Screen Shot 2022-06-09 at 12 54 07 PM" src="https://user-images.githubusercontent.com/458784/172933196-f81e0301-97ca-4033-8cac-e58bc79bbcda.png">  |  <img width="1166" alt="Screen Shot 2022-06-09 at 12 53 59 PM" src="https://user-images.githubusercontent.com/458784/172933300-79e40e08-cb2a-46e2-aade-30812df19a67.png"> |
| sidenav: sentence case | <img width="437" alt="Screen Shot 2022-06-09 at 12 54 22 PM" src="https://user-images.githubusercontent.com/458784/172933385-22ae2972-d4c6-4f16-9026-aa6bd529cf78.png"> | <img width="437" alt="Screen Shot 2022-06-09 at 12 54 37 PM" src="https://user-images.githubusercontent.com/458784/172933382-2a9f95ab-c130-4460-a392-3d055480ae30.png">  |




 