### PR TITLE
LG-6579: Fix missing partners hero image on a tablet

### DIFF
--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -39,19 +39,40 @@
   height: 14rem;
 }
 
-@include at-media("desktop") {
-  .hero {
+.hero {
+  padding: 0;
+  @include at-media("tablet") {
+    height: 16rem;
+  }
+  @include at-media("desktop") {
     height: 20rem;
-    padding: 0;
-
-    > .container {
-      height: 100%;
+  }
+  
+  > .container {
+    height: 100%;
+    background-repeat: no-repeat;
+    @include at-media("desktop") {
       background-image: url(../img/header@2x.png);
       background-position: 100% 50%;
-      background-repeat: no-repeat;
       background-size: 650px;
     }
+  }
+  
+  &.partners {
+    @include at-media("tablet") {
+    background: no-repeat url(../img/partners/heroes/partners-hero.svg) 80% / 100% ;
+    background-size: 30%;
+      > .container {
+        background: none;
+      }
+    }
+    
+    @include at-media("desktop") {
+    height: 28rem;
+    }
+  }
 
+  @include at-media("desktop") {
     &.what-is-login {
       > .container {
         line-height: 1.375em;
@@ -60,7 +81,7 @@
         background-size: 45%;
       }
     }
-
+    
     &.who-uses-login {
       background-image: url(../img/who-uses-login/who-uses-illo-header/who-uses-illo-header@2x.png);
       background-position: right center;
@@ -81,15 +102,6 @@
       }
     }
 
-    &.partners {
-      height: 28rem;
-      background: no-repeat url(../img/partners/heroes/partners-hero.svg) 80% / 100% ;
-      background-size: 30%;
-      > .container {
-        background: none;
-      }
-    }
-
     &.bg-none {
       height: 11.125rem;
 
@@ -98,12 +110,12 @@
       }
     }
   }
+}
 
-  .hero--search {
-    height: 17.625rem;
+.hero--search {
+  height: 17.625rem;
 
-    > .container {
-      background-image: none;
-    }
+  > .container {
+    background-image: none;
   }
 }


### PR DESCRIPTION
**Issue:** The `/partners` hero image is not displayed on a tablet.

**How:** Reconfigured media queries so that the partners hero image appears on a tablet. 

**Team Katherine** / @mdiarra3 / @jmdembe The PR addresses the Partners site but also touches the hero images of the brochure site; however, the impact should be minimal or none. Please feel free to review with this [preview link](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-6579/).

👉🏼 [Federalist preview](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.app.cloud.gov/preview/18f/identity-site/nng-lg-6579/partners/)

| Before | After |
|---|---|
| ![federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5 app cloud gov_preview_18f_identity-site_partners-redesign_partners_](https://user-images.githubusercontent.com/6327082/173457368-e80e4f4d-5be9-4bf1-8eb1-ce6a64ba5707.png) | ![localhost_4000_partners_ (1)](https://user-images.githubusercontent.com/6327082/173457455-0921144c-d9dc-427e-9450-c7d60d029b9b.png) | 
