### PR TITLE
Add permalink field to help articles editor

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -70,6 +70,7 @@ collections:
           default: 'get-started',
           i18n: duplicate,
         }
+      - { label: 'Permalink', name: 'permalink', widget: 'string', i18n: true }
       - { label: 'Body', name: 'body', widget: 'markdown', i18n: true }
       - { label: 'Meta Title', name: 'meta_title', widget: 'string', required: false, i18n: true }
       - { label: 'Order', name: 'order', widget: 'number', default: 10, min: 0, i18n: duplicate }


### PR DESCRIPTION
This PR adds a Permalink field to the help pages so that pages can maintain their locale.

Problem: When running tests to make sure that localization maintains locale in links, they would fail because a permalink is not set. To get rid of this problem, we are creating a permalink field that will be required. Once implemented, the content team will be notified of the change and what to add.