### PR TITLE
Document destination of 2nd Google Analytics instance

### DIFF
--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,3 +1,4 @@
+<!-- Initialize analytics for the TTS Google Analytics account -->
 <script>
   (function (i, s, o, g, r, a, m) {
     i["GoogleAnalyticsObject"] = r;


### PR DESCRIPTION
When writing code to capture a Google Analytics event, I came across this file initializing a Google Analytics instance that _wasn't_ the same as the destination for DAP analytics. There was nothing in the code indicating where this instance was or who it belonged to. It took me a while – and some help – to figure it out.

According to several slack posts, this isn't the first time this has happened. So the purpose of this PR is to add a comment indicating what instance we're hooking ourselves up to, so the next person that comes across this file doesn't have to go through the same process as those who came before.