### PR TITLE
Remove accessibility spec exception for partner contact page

### DIFF
--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -48,14 +48,6 @@ describe('accessibility', () => {
             .disableFrame('*')
             .exclude('.footer-nav'); // See: LG-4038 (TODO: Remove with implementation of LG-4038)
 
-          if (path === '/partners/contact/') {
-            // This specific page embeds its content using an iframe, which includes the top-level
-            // heading, but Axe is unable to inject its script into the frame since it's hosted on
-            // an external domain. A more durable solution would be to pull as much content out of
-            // the frame and into the page as possible.
-            runner.disableRules('page-has-heading-one');
-          }
-
           const results = await runner.analyze();
           expect(results).toHaveNoViolations();
 


### PR DESCRIPTION
It was originally added as a workaround to the embedded contact form, but we migrated away from the embedded form to a natively-rendered form in #923.