### PR TITLE
Exclude form links from new tab accessibility testing

### DIFF
--- a/_includes/partners/contact.html
+++ b/_includes/partners/contact.html
@@ -344,7 +344,7 @@
         />
 
     <label class="usa-label" for="proofing">Identity verification (optional)</label>
-    <div id="proofing-hint" class="usa-hint">Does your application(s) require <a href="https://developers.login.gov/attributes" target="_blank">verified attributes</a> of its users?</div>
+    <div id="proofing-hint" class="usa-hint">Does your application(s) require <a href="https://developers.login.gov/attributes">verified attributes</a> of its users?</div>
     <select id="proofing" name="proofing" class="usa-select">
       <option value>-</option>
       <option value="authencation_only">Authentication only</option>
@@ -407,7 +407,7 @@
     <input type="submit" class="usa-button usa-button--big usa-button--wide" value="Submit" />
     <button type="reset" class="usa-button usa-button--big usa-button--wide usa-button--outline">Clear form</button>
     <div id="form-error-message" class="usa-error-message display-none margin-top-4" role="alert">
-      We were unable to submit your request at this time. Please visit our <a href="https://zendesk.login.gov/hc" target="_blank">Partner Support Portal</a> and submit a request for a "New Login.gov Partnership".
+      We were unable to submit your request at this time. Please visit our <a href="https://zendesk.login.gov/hc">Partner Support Portal</a> and submit a request for a "New Login.gov Partnership".
     </div>
 </form>
 <div class="partners-subtitle display-none margin-top-4" id="form-success-message">

--- a/_includes/partners/contact.html
+++ b/_includes/partners/contact.html
@@ -344,7 +344,7 @@
         />
 
     <label class="usa-label" for="proofing">Identity verification (optional)</label>
-    <div id="proofing-hint" class="usa-hint">Does your application(s) require <a href="https://developers.login.gov/attributes">verified attributes</a> of its users?</div>
+    <div id="proofing-hint" class="usa-hint">Does your application(s) require <a href="https://developers.login.gov/attributes" target="_blank">verified attributes</a> of its users?</div>
     <select id="proofing" name="proofing" class="usa-select">
       <option value>-</option>
       <option value="authencation_only">Authentication only</option>
@@ -407,7 +407,7 @@
     <input type="submit" class="usa-button usa-button--big usa-button--wide" value="Submit" />
     <button type="reset" class="usa-button usa-button--big usa-button--wide usa-button--outline">Clear form</button>
     <div id="form-error-message" class="usa-error-message display-none margin-top-4" role="alert">
-      We were unable to submit your request at this time. Please visit our <a href="https://zendesk.login.gov/hc">Partner Support Portal</a> and submit a request for a "New Login.gov Partnership".
+      We were unable to submit your request at this time. Please visit our <a href="https://zendesk.login.gov/hc" target="_blank">Partner Support Portal</a> and submit a request for a "New Login.gov Partnership".
     </div>
 </form>
 <div class="partners-subtitle display-none margin-top-4" id="form-success-message">

--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -14,6 +14,29 @@ const EXCLUDE_PATTERNS = [
   /admin/,
 ];
 
+/**
+ * Returns true if the element is inside a form, or false otherwise.
+ *
+ * @param {Element} element
+ *
+ * @return {boolean}
+ */
+const isInForm = (element) => !!element.closest('form');
+
+/**
+ * Returns true if the given link should be considered an exception to enforcement of links opening
+ * in the same tab.
+ *
+ * Refer to WCAG guidance on qualifying situations.
+ *
+ * @see https://www.w3.org/TR/WCAG20-TECHS/G200.html
+ *
+ * @param {HTMLAnchorElement} link
+ *
+ * @return {boolean}
+ */
+const isNewTabLinkException = (link) => isInForm(link);
+
 describe('accessibility', () => {
   const paths = JSON.parse(process.env.ALL_URLS)
     .map((url) => new URL(url).pathname)
@@ -52,9 +75,9 @@ describe('accessibility', () => {
           expect(results).toHaveNoViolations();
 
           const links = await getLinks(page);
-          links.forEach((a) => {
-            expect(a).toNotHaveTargetBlank();
-          });
+          links
+            .filter((link) => !isNewTabLinkException(link))
+            .forEach((a) => expect(a).toNotHaveTargetBlank());
         },
         TEST_TIMEOUT_MS,
       );

--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -1,7 +1,7 @@
 import { AxePuppeteer } from '@axe-core/puppeteer';
 import { toHaveNoViolations } from 'jest-axe';
 import { page, goto } from './support/browser';
-import { getLinks, toNotHaveTargetBlank } from './support/target-blank';
+import { getCandidateLinks, toNotHaveTargetBlank } from './support/target-blank';
 
 expect.extend(toHaveNoViolations);
 expect.extend({ toNotHaveTargetBlank });
@@ -13,29 +13,6 @@ const EXCLUDE_PATTERNS = [
   /\.pdf$/, // Puppeteer Chromium cannot preview PDF files
   /admin/,
 ];
-
-/**
- * Returns true if the element is inside a form, or false otherwise.
- *
- * @param {Element} element
- *
- * @return {boolean}
- */
-const isInForm = (element) => !!element.closest('form');
-
-/**
- * Returns true if the given link should be considered an exception to enforcement of links opening
- * in the same tab.
- *
- * Refer to WCAG guidance on qualifying situations.
- *
- * @see https://www.w3.org/TR/WCAG20-TECHS/G200.html
- *
- * @param {HTMLAnchorElement} link
- *
- * @return {boolean}
- */
-const isNewTabLinkException = (link) => isInForm(link);
 
 describe('accessibility', () => {
   const paths = JSON.parse(process.env.ALL_URLS)
@@ -74,10 +51,8 @@ describe('accessibility', () => {
           const results = await runner.analyze();
           expect(results).toHaveNoViolations();
 
-          const links = await getLinks(page);
-          links
-            .filter((link) => !isNewTabLinkException(link))
-            .forEach((a) => expect(a).toNotHaveTargetBlank());
+          const links = await getCandidateLinks(page);
+          links.forEach((a) => expect(a).toNotHaveTargetBlank());
         },
         TEST_TIMEOUT_MS,
       );

--- a/spec/e2e/support/target-blank.js
+++ b/spec/e2e/support/target-blank.js
@@ -3,36 +3,15 @@
  */
 
 /**
- * Returns true if the element is inside a form, or false otherwise.
- *
- * @param {Element} element
- *
- * @return {boolean}
- */
-const isInForm = (element) => !!element.closest('form');
-
-/**
- * Returns true if the given link should be considered an exception to enforcement of links opening
- * in the same tab.
- *
- * Refer to WCAG guidance on qualifying situations.
- *
- * @see https://www.w3.org/TR/WCAG20-TECHS/G200.html
- *
- * @param {HTMLAnchorElement} link
- *
- * @return {boolean}
- */
-const isNewTabLinkException = (link) => isInForm(link);
-
-/**
  * @param {import('puppeteer').Page} page
  * @return {Promise<SimplifiedLink[]>}
  */
 function getCandidateLinks(page) {
   return page.$$eval('a', (aTags) =>
     aTags
-      .filter((a) => !isNewTabLinkException(a))
+      // Exclude form links from new tab enforcement.
+      // See: https://www.w3.org/TR/WCAG20-TECHS/G200.html
+      .filter((a) => !a.closest('form'))
       .map((a) =>
         // Get the info we want across the Chrome DevTools Protocol
         ({

--- a/spec/e2e/support/target-blank.js
+++ b/spec/e2e/support/target-blank.js
@@ -3,19 +3,44 @@
  */
 
 /**
+ * Returns true if the element is inside a form, or false otherwise.
+ *
+ * @param {Element} element
+ *
+ * @return {boolean}
+ */
+const isInForm = (element) => !!element.closest('form');
+
+/**
+ * Returns true if the given link should be considered an exception to enforcement of links opening
+ * in the same tab.
+ *
+ * Refer to WCAG guidance on qualifying situations.
+ *
+ * @see https://www.w3.org/TR/WCAG20-TECHS/G200.html
+ *
+ * @param {HTMLAnchorElement} link
+ *
+ * @return {boolean}
+ */
+const isNewTabLinkException = (link) => isInForm(link);
+
+/**
  * @param {import('puppeteer').Page} page
  * @return {Promise<SimplifiedLink[]>}
  */
-function getLinks(page) {
+function getCandidateLinks(page) {
   return page.$$eval('a', (aTags) =>
-    aTags.map((a) =>
-      // Get the info we want across the Chrome DevTools Protocol
-      ({
-        innerText: a.innerText.trim(),
-        href: a.href,
-        target: a.target,
-      }),
-    ),
+    aTags
+      .filter((a) => !isNewTabLinkException(a))
+      .map((a) =>
+        // Get the info we want across the Chrome DevTools Protocol
+        ({
+          innerText: a.innerText.trim(),
+          href: a.href,
+          target: a.target,
+        }),
+      ),
   );
 }
 
@@ -29,4 +54,4 @@ function toNotHaveTargetBlank(a) {
   };
 }
 
-export { getLinks, toNotHaveTargetBlank };
+export { getCandidateLinks, toNotHaveTargetBlank };


### PR DESCRIPTION
**Why**: Per our automated accessibility checks, we do not expect any links to open in a new tab. This is due to [accessibility recommendations](https://www.w3.org/TR/WCAG20-TECHS/G200.html). However, for certain scenarios like these (multi-step form), a new tab may be advisable to prevent loss of progress.

This resolves build failures currently occurring on the `main` branch. Unsure why this suddenly started failing (possibly a side-effect of #943), and why it did not fail in previous pull requests.

Related:

- #525
- https://www.w3.org/TR/WCAG20-TECHS/G200.html