### PR TITLE
Migrate Federalist to Cloud.gov Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ Feature branches should be merged to `main` when they are ready through the norm
 
 ## Publishing Workflow
 
-Branch off of `main` and make pull requests back to the `main` branch. Federalist will build a live preview for each branch so we suggest using those builds as staging environments to run your proposed changes by the rest of the team.
+Branch off of `main` and make pull requests back to the `main` branch. Cloud.gov Pages will build a live preview for each branch so we suggest using those builds as staging environments to run your proposed changes by the rest of the team.
 
-To view the preview URL for your branch click the federalist link in your pull request or modify the following URL to include your branch name:
-
-```
-https://federalist-proxy.app.cloud.gov/preview/18f/identity-site/{BRANCH}/
-```
+To view the preview URL for your branch, click the Cloud.gov Pages "Details" link in your pull request's checks.
 
 ## Development
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ languages:
 
 exclude_from_localizations: ['javascript', 'images', 'css']
 
-# Contact form production values (overridden in Federalist for preview branches)
+# Contact form production values (overridden in Cloud.gov Pages for preview branches)
 contact_form_captcha_enabled: true
 contact_form_action: 'https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8'
 contact_form_orgid: '00DU0000000Leux'

--- a/docs/0002-add-netlifycms.md
+++ b/docs/0002-add-netlifycms.md
@@ -18,4 +18,4 @@ We will add Netlify CMS (Content Management System) to the architecture of the L
 
 Content editing can now fall on a designated content editor, whether it may be a content writer, product manager, designer, or any other member of Team Katherine. With Netlify CMS added to the architecture, content editors will be able to add, edit, or delete content without relying on an engineer. Adding Netlify CMS will require content editors to have a GitHub account because an account with Federalist permissions is required in order to access the CMS.
 
-All published content changes will result in a GitHub pull request. Pull requests on the `identity-site` repository requires at least one approval in order for content to be added to the website. This will mean that an engineer may still be involved in the content editing process, although not required. 
+All published content changes will result in a GitHub pull request. Pull requests on the `identity-site` repository requires at least one approval in order for content to be added to the website. This will mean that an engineer may still be involved in the content editing process, although not required.


### PR DESCRIPTION
**Why**: [Federalist is becoming Cloud.gov Pages](https://cloud.gov/pages/federalist-migration/), and as such we'll need to update configurations accordingly.