### PR TITLE
Add toggle for contact phone number location on the webpage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,9 +16,10 @@ contact_form_captcha_enabled: true
 contact_form_action: 'https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8'
 contact_form_orgid: '00DU0000000Leux'
 
-# Contact page phone number enabled
+# Contact page phone number enabled (overridden in Cloud.gov Pages)
 contact_phone_number_enabled: false
 contact_phone_number: ''
+contact_phone_number_location: 'bottom' # acceptable values are 'top' and 'bottom'
 
 # Used to load country code support
 idp_base_url: https://secure.login.gov

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -15,11 +15,17 @@ common_applications:
   
   {{ page.intro_content | markdownify }} 
   
+  {% if site.contact_phone_number_enabled and site.contact_phone_number and 
+     site.contact_phone_number_location == 'top' %} 
+    {% include contact_phone.html common_applications=layout.common_applications %} 
+  {% endif %}
+
   <div class="desktop:grid-col-9">
     {% include contact_form.html common_applications=layout.common_applications %}
   </div>
 
-  {% if site.contact_phone_number_enabled and site.contact_phone_number %} 
+  {% if site.contact_phone_number_enabled and site.contact_phone_number and
+     site.contact_phone_number_location == 'bottom' %} 
     {% include contact_phone.html common_applications=layout.common_applications %} 
   {% endif %}
 </div>

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -17,7 +17,7 @@ common_applications:
   
   {% if site.contact_phone_number_enabled and site.contact_phone_number and 
      site.contact_phone_number_location == 'top' %} 
-    {% include contact_phone.html common_applications=layout.common_applications %} 
+    {% include contact_phone.html %} 
   {% endif %}
 
   <div class="desktop:grid-col-9">
@@ -26,7 +26,7 @@ common_applications:
 
   {% if site.contact_phone_number_enabled and site.contact_phone_number and
      site.contact_phone_number_location == 'bottom' %} 
-    {% include contact_phone.html common_applications=layout.common_applications %} 
+    {% include contact_phone.html %} 
   {% endif %}
 </div>
 


### PR DESCRIPTION
During phone number testing, the contact center noticed an increase in phone calls without a substantial decrease in the number of emails received. The centers hypothesis is that because the phone number is below the contact form, folks are submitting the contact form then calling (the center does not collect enough information on callers to confirm there are actually duplicates).

The contact center would like to run an experiment to move the phone number above the contact form to see if that has an impact on duplicates, and to see if it changes email vs phone call rates.

This PR adds a toggle (top, bottom) allowing us to easily change the location of the contact phone number on the page by overriding the value in Cloud.gov pages. Any value other than top or bottom results in the number not being displayed.

Once the phone number is live, this toggle should be removed and the contact number placed in its permanent position on the page.