### PR TITLE
Update international country support table

### DIFF
--- a/assets/js/country_support.js
+++ b/assets/js/country_support.js
@@ -3,7 +3,9 @@
  * @property {string} name
  * @property {string} country_code The international dialing code (ex "1" for the US)
  * @property {boolean} supports_sms
+ * @property {boolean?} supports_sms_unconfirmed
  * @property {boolean} supports_voice
+ * @property {boolean?} supports_voice_unconfirmed
  */
 
 /**
@@ -77,7 +79,9 @@ function loadCountrySupportTable(elem, fetch) {
               name,
               country_code: countryCode,
               supports_sms: supportsSms,
+              supports_sms_unconfirmed: supportsSmsUnconfirmed,
               supports_voice: supportsVoice,
+              supports_voice_unconfirmed: supportsVoiceUnconfirmed,
             },
           ]) => {
             const row = templateRow.cloneNode(true);
@@ -85,8 +89,11 @@ function loadCountrySupportTable(elem, fetch) {
             row.querySelector('[data-item=dialing-code]').innerText = prettyDialingCode(
               countryCode,
             );
-            updateCell(row.querySelector('[data-item=sms]'), supportsSms);
-            updateCell(row.querySelector('[data-item=voice]'), supportsVoice);
+            updateCell(row.querySelector('[data-item=sms]'), supportsSmsUnconfirmed ?? supportsSms);
+            updateCell(
+              row.querySelector('[data-item=voice]'),
+              supportsVoiceUnconfirmed ?? supportsVoice,
+            );
             tbody.appendChild(row);
           },
         );

--- a/spec/e2e/country_support_spec.js
+++ b/spec/e2e/country_support_spec.js
@@ -16,6 +16,14 @@ describe('country support', () => {
         supports_sms: true,
         supports_voice: false,
       },
+      UY: {
+        name: 'Uruguay',
+        country_code: '598',
+        supports_sms: true,
+        supports_sms_unconfirmed: false,
+        supports_voice: true,
+        supports_voice_unconfirmed: false,
+      },
     },
   };
 
@@ -39,12 +47,22 @@ describe('country support', () => {
     await goto('/help/manage-your-account/international-phone-support/');
 
     const table = await page.waitForSelector('.js-country-support:not([hidden]) table');
-    expect((await table.$$('tbody tr')).length).toBe(2);
+    expect((await table.$$('tbody tr')).length).toBe(3);
     expect(await table.$eval('tbody tr:nth-child(1) td:nth-child(1)', (el) => el.innerText)).toBe(
       'Canada (CA)',
     );
     expect(await table.$eval('tbody tr:nth-child(2) td:nth-child(1)', (el) => el.innerText)).toBe(
       'United States (US)',
     );
+
+    expect(await table.$eval('tbody tr:nth-child(3) td:nth-child(1)', (el) => el.innerText)).toBe(
+      'Uruguay (UY)',
+    );
+    expect(
+      await table.$eval('tbody tr:nth-child(3) td:nth-child(3)', (el) => el.innerText.trim()),
+    ).toBe('No');
+    expect(
+      await table.$eval('tbody tr:nth-child(3) td:nth-child(4)', (el) => el.innerText.trim()),
+    ).toBe('No');
   });
 });


### PR DESCRIPTION
- "supports_X_unconfirmed" fields (new signups) overrides the plain "supports_X" fields so that the table more accurately reflects what new users experience