### PR TITLE
Bugfix: add class to span in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -51,7 +51,7 @@
             class="usa-nav__link {% if page.url contains '/create-an-account/' %}usa-current{% endif %}"
             href="{{ '/create-an-account/' | locale_url }}"
           >
-            <span>{{ site.data.[page.lang].settings.nav.create_an_account }}</span>
+            <span class="usa-nav__link__inner">{{ site.data.[page.lang].settings.nav.create_an_account }}</span>
           </a>
         </li>
         <li class="usa-nav__primary-item">


### PR DESCRIPTION
This PR fixes the border bottom for the menu item on the brochure site to ensure uniformity

Before
![Before image of menu item with red underneath the link text](https://user-images.githubusercontent.com/17969963/196785341-c0826b5f-de41-4073-9b4c-ca612a33cebc.png)

After
![After image of menu item with a red bottom border](https://user-images.githubusercontent.com/17969963/196785616-edf2a755-8d8f-4bbe-9379-c6bb296c0ae6.png)
