### PR TITLE
Revert Business Inquires PR

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -228,7 +228,7 @@ nav:
   anchor_to_top: Back to top
   become_a_partner: Become a partner
   contact_us:
-    title: Business inquiries
+    title: Contact us
     sections:
       - name: Find answers to commonly asked questions
         url: '#find-answers-to-commonly-asked-questions'

--- a/_includes/partners/checklist.html
+++ b/_includes/partners/checklist.html
@@ -7,6 +7,6 @@
         <li>{{ item.text }}</li>
       {% endfor %}
     </ul>
-    <a class="usa-nav__link caret" href="{{ site.baseurl }}/partners/business-inquiries/">Contact us to learn more</a>
+    <a class="usa-nav__link caret" href="{{ site.baseurl }}/partners/contact/">Contact us to learn more</a>
   </section>
 </article>

--- a/_includes/partners/footer.html
+++ b/_includes/partners/footer.html
@@ -22,7 +22,7 @@
             <section>
               <h6>{{ site.data.[page.lang].settings.nav.groups.support }}</h6>
               <a class="font-xs" href="{{ '/partners/faq/' | locale_url }}">{{ site.data.[page.lang].settings.nav.faq }}</a>
-              <a class="font-xs" href="{{ '/partners/business-inquiries/' | locale_url }}">{{ site.data.[page.lang].settings.nav.contact_us.title }}</a>
+              <a class="font-xs" href="{{ '/partners/contact/' | locale_url }}">{{ site.data.[page.lang].settings.nav.contact_us.title }}</a>
             </section>
           </div>
           <div class="system-status">

--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -83,7 +83,7 @@
 
       <a
         class="usa-link desktop:display-none padding-y-1 margin-y-3 text-no-underline text-bold"
-        href="{{ site.baseurl }}/partners/business-inquiries/"
+        href="{{ site.baseurl }}/partners/contact/"
       >
         {{ site.data.[page.lang].settings.nav.contact_us.title }}
       </a>

--- a/_includes/partners/partners-banner.html
+++ b/_includes/partners/partners-banner.html
@@ -1,7 +1,7 @@
 <aside class="partners-banner">
   <div class="partners-banner__backdrop">
     <div class="partners-banner__content">
-      {% if page.url == "/partners/" or page.url == "/partners/business-inquiries/" %}
+      {% if page.url == "/partners/" or page.url == "/partners/contact/" %}
         <header class="partners-banner__tagline">
           Still have questions?
         </header>
@@ -15,7 +15,7 @@
           Ready to partner with Login.gov?
         </header>
         <p class="margin-bottom-0">
-          <a class="partners-banner__link" href="{{ '/partners/business-inquiries/' | locale_url }}">
+          <a class="partners-banner__link" href="{{ '/partners/contact/' | locale_url }}">
             Contact us
           </a>
         </p>

--- a/_layouts/partners/contact.html
+++ b/_layouts/partners/contact.html
@@ -27,7 +27,7 @@ layout: base
                   <a href="{{ '/partners/faq/' | locale_url }}">FAQ</a>
                 </li>
                 <li class="usa-sidenav__item">
-                  <a href="#main-content" class="usa-current">Business inquiries</a>
+                  <a href="#main-content" class="usa-current">Contact us</a>
                 </li>
               </ul>
             </nav>

--- a/_layouts/partners/faq.html
+++ b/_layouts/partners/faq.html
@@ -111,7 +111,7 @@ layout: base
                                 </ul>
                             </li>
                             <li class="usa-sidenav__item">
-                              <a href="{{ '/partners/business-inquiries/' | locale_url }}">Business inquiries</a>
+                              <a href="{{ '/partners/contact/' | locale_url }}">Contact us</a>
                             </li>
                           </ul>
                         </nav>

--- a/_layouts/partners/get-started.html
+++ b/_layouts/partners/get-started.html
@@ -24,7 +24,7 @@ layout: base
                             <h3 class="usa-process-list__heading">{{ page.partnership_steps_header1 }}</h3>
                             <div class="margin-top-05">
                                 {{ page.partnership_steps_body1 }}
-                                <a href="{{ site.baseurl }}/partners/business-inquiries/" class="caret">Contact an account manager to get started</a>
+                                <a href="{{ site.baseurl }}/partners/contact/" class="caret">Contact an account manager to get started</a>
                             </div>
                         </li>
                         <li class="usa-process-list__item">

--- a/content/_partners/business-inquiries._en.md
+++ b/content/_partners/business-inquiries._en.md
@@ -1,9 +1,0 @@
----
-layout: partners/contact
-permalink: /partners/business-inquiries/
-title: >-
-    Business inquiries
-scripts:
-  - /assets/js/build/partners_contact.js
-redirect_from: partners/contact/
----

--- a/content/_partners/contact._en.md
+++ b/content/_partners/contact._en.md
@@ -1,0 +1,8 @@
+---
+layout: partners/contact
+permalink: /partners/contact/
+title: >-
+    Contact us
+scripts:
+  - /assets/js/build/partners_contact.js
+---

--- a/content/_partners/contact._en.md
+++ b/content/_partners/contact._en.md
@@ -5,4 +5,5 @@ title: >-
     Contact us
 scripts:
   - /assets/js/build/partners_contact.js
+redirect_from: /partners/business-inquiries/
 ---

--- a/content/_partners/faq._en.md
+++ b/content/_partners/faq._en.md
@@ -60,7 +60,7 @@ general_accordion:
         id: a-6
         title: How do we partner with Login.gov?
         content: >-
-            [Contact our Partnerships Team to get started](/partners/business-inquiries/){:class="external-link"}. We’ll work with you to understand and capture your needs and requirements at a high level. Together, we’ll decide whether Login.gov makes sense for your particular agency and use case. If we decide to move forward, the next step is to sign an [Interagency Agreement (IAA)](/partners/get-started/#interagency-agreement-iaa-process). This signals a mutual commitment which allows us to commit further resources to technical discovery and integration and migration planning.
+            [Contact our Partnerships Team to get started](/partners/contact/){:class="external-link"}. We’ll work with you to understand and capture your needs and requirements at a high level. Together, we’ll decide whether Login.gov makes sense for your particular agency and use case. If we decide to move forward, the next step is to sign an [Interagency Agreement (IAA)](/partners/get-started/#interagency-agreement-iaa-process). This signals a mutual commitment which allows us to commit further resources to technical discovery and integration and migration planning.
 logistics_accordion:
     -
         id: b-1

--- a/content/_partners/state-and-local._en.md
+++ b/content/_partners/state-and-local._en.md
@@ -19,7 +19,7 @@ partnership_steps_title: >-
 partnership_steps_header1: >-
   Introductions and determine compatibility
 partnership_steps_body1: >-
-  During the introduction call, an account manager will walk through Login.gov services and answer any questions that you have. This step will determine if Login.gov is a good fit for your agency. [Contact our Partnerships Team to get started](/partners/business-inquiries/){:class="external-link"}.
+  During the introduction call, an account manager will walk through Login.gov services and answer any questions that you have. This step will determine if Login.gov is a good fit for your agency. [Contact our Partnerships Team to get started](/partners/contact/){:class="external-link"}.
 partnership_steps_header2: >-
   Estimate usage and test integrations
 partnership_steps_body2: >-

--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -29,7 +29,7 @@ help_center_content: >-
 partner_content: >-
   ## Partner with Login.gov
 
-  Interested in using Login.gov at your agency? Please [visit our partners website](/partners/) or [contact us](/partners/business-inquiries/).
+  Interested in using Login.gov at your agency? Please [visit our partners website](/partners/) or [contact us](/partners/contact/).
 
 report_issue_content: >-
   ## Report an issue

--- a/content/_policy/contact._es.md
+++ b/content/_policy/contact._es.md
@@ -29,7 +29,7 @@ help_center_content: >-
 partner_content: >-
   ## Asociarse con Login.gov
 
-  ¿Está interesado en utilizar Login.gov en su agencia? [Visite el sitio web de nuestros socios](/partners/) o [póngase en contacto con nosotros](/partners/business-inquiries/).
+  ¿Está interesado en utilizar Login.gov en su agencia? [Visite el sitio web de nuestros socios](/partners/) o [póngase en contacto con nosotros](/partners/contact/).
 
 report_issue_content: >-
   ## Reportar un problema

--- a/content/_policy/contact._fr.md
+++ b/content/_policy/contact._fr.md
@@ -28,7 +28,7 @@ help_center_content: >-
 partner_content: >-
   ## Partenaire avec Login.gov
 
-  Souhaitez-vous utiliser Login.gov dans votre agence? Veuillez [visiter le site web de nos partenaires](/partners/) ou [nous contacter](/partners/business-inquiries/).
+  Souhaitez-vous utiliser Login.gov dans votre agence? Veuillez [visiter le site web de nos partenaires](/partners/) ou [nous contacter](/partners/contact/).
 
 report_issue_content: >-
   ## Signaler un problème


### PR DESCRIPTION
Reverts #969, which introduced a bug that hid the "contact form" from help center pages behind a different name

| before revert | after revert |
| ---- | ---- |
| <img width="814" alt="Screen Shot 2022-10-24 at 5 03 35 PM" src="https://user-images.githubusercontent.com/458784/197652663-9d71b2f0-43df-4da7-ab76-1bc60d7cbab8.png"> | <img width="814" alt="Screen Shot 2022-10-24 at 5 03 38 PM" src="https://user-images.githubusercontent.com/458784/197652672-d6f3ff72-c81c-4453-810f-3f3093eeaf8a.png"> |

