### PR TITLE
Update contact center call-handling hours of operation

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -24,7 +24,7 @@ contact_page:
   required: required
   call_us:
     title: Call us
-    operating_hours: Operating hours are Monday-Friday 11:00 am to 3:00 pm ET.
+    operating_hours: Operating hours are Monday-Friday 11:00 am to 8:00 pm ET.
   support_request_form:
     title: Submit a help ticket
     other: Other

--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -24,6 +24,7 @@ contact_page:
   required: required
   call_us:
     title: Call us
+    operating_hours: Operating hours are Monday-Friday 11:00 am to 3:00 pm ET.
   support_request_form:
     title: Submit a help ticket
     other: Other

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -24,6 +24,7 @@ contact_page:
   required: requerido
   call_us:
     title: Llámenos
+    operating_hours: El horario operativo es de lunes a viernes de 11:00 am a 3:00 pm hora del este.
   support_request_form:
     title: Enviar un tíquet de ayuda
     other: Otro

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -24,7 +24,7 @@ contact_page:
   required: requerido
   call_us:
     title: Llámenos
-    operating_hours: El horario operativo es de lunes a viernes de 11:00 am a 3:00 pm hora del este.
+    operating_hours: El horario operativo es de lunes a viernes de 11:00 am a 8:00 pm hora del este.
   support_request_form:
     title: Enviar un tíquet de ayuda
     other: Otro

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -24,7 +24,7 @@ contact_page:
   required: obligatoire
   call_us:
     title: Appelez-nous
-    operating_hours: Les heures d'ouverture sont du lundi au vendredi de 11 h à 15 h (heure de l'Est).
+    operating_hours: Les heures d'ouverture sont du lundi au vendredi de 11 h à 20 h (heure de l'Est).
   support_request_form:
     title: Soumettre un ticket d'assistance
     other: Other

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -24,6 +24,7 @@ contact_page:
   required: obligatoire
   call_us:
     title: Appelez-nous
+    operating_hours: Les heures d'ouverture sont du lundi au vendredi de 11 h à 15 h (heure de l'Est).
   support_request_form:
     title: Soumettre un ticket d'assistance
     other: Other

--- a/_includes/contact_phone.html
+++ b/_includes/contact_phone.html
@@ -2,5 +2,5 @@
 <p>
   {{ site.contact_phone_number }}
   <br />
-  {{ site.data.[page.lang].settings.contact_page.operating_hours }}
+  {{ site.data.[page.lang].settings.contact_page.call_us.operating_hours }}
 </p>


### PR DESCRIPTION
The contact center is going to expand their call-handling hours of operation starting 11/7 to 11am – 8pm eastern. This PR separates the hours of operation for calls and the contact form, and adds the new hours of operation for handling calls. 

This will be merged on 11/7 and – if everything goes according to today's plan – shown full time (so, no more taking the phone number off the page unless there is an exceptional circumstance).