### PR TITLE
Side nav incorrectly displayed on Impact stories page

### DIFF
--- a/_layouts/partners/contact.html
+++ b/_layouts/partners/contact.html
@@ -19,7 +19,7 @@ layout: base
             {% include partners/contact.html %}
           </div>
         </div>
-        <div class="tablet:grid-col-3 search-container">
+        <div class="tablet:grid-col-3">
           <section>
             <nav aria-label="Secondary navigation,">
               <ul class="usa-sidenav">

--- a/_layouts/partners/faq.html
+++ b/_layouts/partners/faq.html
@@ -92,7 +92,7 @@ layout: base
                   </div>
                   <a href="#main-content">Back to Top</a>
                 </div>
-                <div class="tablet:grid-col-3 search-container">
+                <div class="tablet:grid-col-3">
                   <section>
                       <nav aria-label="Secondary navigation,">
                           <ul class="usa-sidenav">

--- a/_layouts/partners/faq.html
+++ b/_layouts/partners/faq.html
@@ -9,8 +9,8 @@ layout: base
 <main id="main-content">
     <section>
         <div class="container partners-container">
+          <h1 class="partners-title">{{ page.title }}</h1>
             <div class="grid-row">
-                <h1 class="partners-title">{{ page.title }}</h1>
                 <div class="tablet:grid-col-9 accordion-container">
                   <div class="partners-border"></div>
                   <div class="section-title-row">

--- a/_layouts/partners/sba-impact-story.html
+++ b/_layouts/partners/sba-impact-story.html
@@ -9,8 +9,8 @@ layout: base
 <main id="main-content">
     <section>
         <div class="container partners-container">
+            <h1 class="partners-title">{{ page.title }}</h1>
             <div class="grid-row">
-                <h1 class="partners-title">{{ page.title }}</h1>
                 <div class="tablet:grid-col-8 partners-body">
                     <div class="partners-border"></div>
                     <div>{{ page.subtitle | markdownify }}</div>

--- a/_layouts/partners/sba-impact-story.html
+++ b/_layouts/partners/sba-impact-story.html
@@ -10,8 +10,8 @@ layout: base
     <section>
         <div class="container partners-container">
             <div class="grid-row">
+                <h1 class="partners-title">{{ page.title }}</h1>
                 <div class="tablet:grid-col-8 partners-body">
-                    <h1 class="partners-title">{{ page.title }}</h1>
                     <div class="partners-border"></div>
                     <div>{{ page.subtitle | markdownify }}</div>
                     <div class="partners-body">{{ page.body | markdownify }}</div>
@@ -21,7 +21,7 @@ layout: base
                     <div class="partners-body padding-top-2 padding-bottom-2">{{ page.key_shifts | markdownify }}</div>
                     <a href="{{ '/partners/impact-stories/' | locale_url }}" class="partners-body caret">Read more impact stories</a>
                 </div>
-                <div class="tablet:grid-col-4 padding-left-1">
+                <div class="tablet:grid-col-4 padding-left-2">
                     {% include partners/impact-stories-navigation.html %}
                 </div>
             </div>

--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -7,6 +7,7 @@
 
 .partners-title {
     font-size: 2.5em;
+    width: 100%;
 }
 
 .partners-border {

--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -7,7 +7,6 @@
 
 .partners-title {
     font-size: 2.5em;
-    width: 100%;
 }
 
 .partners-border {
@@ -67,10 +66,6 @@
 
 .accordion-container {
     padding-right: 5%;
-}
-
-.search-container {
-    padding-top: 15px;
 }
 
 .section-title-right {


### PR DESCRIPTION
PR for [LG-7488](https://cm-jira.usa.gov/browse/LG-7488)

Header on impact stories page was not where it should be in the HTML. Also FAQ page sidebar was slightly misaligned as well so I removed a class there. Made the header take up the full width so sidebar and body always start underneath header. See screenshots below

<img width="1149" alt="Screen Shot 2022-11-08 at 11 53 42 AM" src="https://user-images.githubusercontent.com/6639858/200626976-860dbb0a-95a3-4a6a-9ead-0f5e4e45bb0f.png">
<img width="1160" alt="Screen Shot 2022-11-08 at 11 53 35 AM" src="https://user-images.githubusercontent.com/6639858/200626996-3d2fe7e0-9006-4166-9dcf-85de09e185bf.png">
