### PR TITLE
LG-6129: Change "security code" to "one-time code" for phone MFA

### DIFF
--- a/content/_help/get-started/authentication-options._en.md
+++ b/content/_help/get-started/authentication-options._en.md
@@ -73,11 +73,11 @@ Physical PIV (personal identity verification) cards or CACs (common access cards
 
 Text messages/SMS or phone calls are convenient but are extremely vulnerable to theft, hackers, and other attacks. You are required to select more than one authentication method if you choose text or voice message.
 
-If you choose to use this less secure option, enter a phone number at which you can receive phone calls or text messages. If you only have a landline, you must receive your security code by phone call. Login.gov cannot send security codes to extensions or voicemails.
+If you choose to use this less secure option, enter a phone number at which you can receive phone calls or text messages. If you only have a landline, you must receive your one-time code by phone call. Login.gov cannot send one-time codes to extensions or voicemails.
 
-We will send a unique security code to that phone number each time you sign in to your Login.gov account. Each security code expires after ten minutes and can only be used once. If you don’t enter the security code within ten minutes, request a new code.
+We will send a unique one-time code to that phone number each time you sign in to your Login.gov account. Each one-time code expires after ten minutes and can only be used once. If you don’t enter the one-time code within ten minutes, request a new code.
 
-After you receive the code, type it into the “one-time security code” field. Each time you sign in to Login.gov you’ll have the option of getting a new security code by phone call or by text. You will receive a new security code each time you sign in to your Login.gov account.
+After you receive the code, type it into the “one-time one-time code” field. Each time you sign in to Login.gov you’ll have the option of getting a new one-time code by phone call or by text. You will receive a new one-time code each time you sign in to your Login.gov account.
 
 ## Backup codes (less secure)
 

--- a/content/_help/get-started/authentication-options._es.md
+++ b/content/_help/get-started/authentication-options._es.md
@@ -22,7 +22,7 @@ Además de su contraseña, es necesario que usted configure por lo menos un mét
 **Autenticación secundaria**
 Le recomendamos que agregue dos métodos de autenticación a su cuenta. Si no puede acceder a su método de autenticación principal (por ejemplo, si pierde su teléfono), tendrá una segunda opción para acceder a su cuenta. Si usted llega a ser bloqueado o pierde su método de autenticación, Login.gov no podrá permitirle acceder a su cuenta.
 
-Si selecciona mensaje de texto o de voz, debe seleccionar un método de autenticación adicional. Login.gov no puede concederle acceso a su cuenta si se bloquea y/o pierde su método de autenticación. 
+Si selecciona mensaje de texto o de voz, debe seleccionar un método de autenticación adicional. Login.gov no puede concederle acceso a su cuenta si se bloquea y/o pierde su método de autenticación.
 Si tiene un bloqueo, tendrá que borrar su cuenta y crear una nueva.
 
 **Seguridad**
@@ -75,11 +75,11 @@ Las tarjetas físicas de PIV (Verificación de Identidad Personal) y las CAC (Ta
 
 Los mensajes de texto y las llamadas telefónicas resultan prácticos, pero son extremadamente vulnerables ante robos, jaqueos y otros ataques. Debe seleccionar más de un método de autenticación, si elige mensaje de texto o de voz.
 
-Si usted elige utilizar esta opción menos segura, ingrese un número de teléfono en el que pueda recibir llamadas telefónicas o mensajes de texto. Si solo tiene un teléfono fijo, debe recibir su código de seguridad por llamada. Iogin.gov no puede enviar códigos de seguridad a extensiones telefónicas o buzones de voz.
+Si usted elige utilizar esta opción menos segura, ingrese un número de teléfono en el que pueda recibir llamadas telefónicas o mensajes de texto. Si sólo tiene un teléfono fijo, debe recibir su código de un solo uso por llamada telefónica. Login.gov no permite enviar códigos de un solo uso a las extensiones o a los buzones de voz.
 
-Le enviaremos un código de seguridad único a ese número de teléfono cada vez que inicie sesión en su cuenta de Login.gov. Cada código de seguridad caduca después de diez minutos y solo se puede usar una vez. Si usted no introduce el código de seguridad en un lapso de diez minutos, solicite uno nuevo.
+Le enviaremos un código de un solo uso a ese número de teléfono cada vez que acceda a su cuenta de login.gov. Cada código único caduca a los diez minutos y sólo puede utilizarse una vez. Si no introduce el código único en los diez primeros minutos, solicite un nuevo código.
 
-Cuando haya recibido el código, escríbalo en el recuadro de "Código de seguridad único". Cada vez que inicie sesión en Login.gov tendrá la opción de recibir un nuevo código de seguridad por llamada telefónica o mensaje de texto. Usted recibirá un nuevo código de seguridad cada vez que inicie sesión en su cuenta de Login.gov.
+Después de haber recibido el código, introdúzcalo en el campo "Código único". Cada vez que acceda a login.gov tendrá la opción de obtener un nuevo código de un solo uso mediante una llamada telefónica o un mensaje de texto. Recibirá un nuevo código de un solo uso cada vez que acceda a su cuenta de login.gov.
 
 ## Códigos de recuperación (menos seguros)
 

--- a/content/_help/get-started/authentication-options._fr.md
+++ b/content/_help/get-started/authentication-options._fr.md
@@ -19,9 +19,9 @@ redirect_from:
 En plus de votre mot de passe, Login.gov exige que vous mettiez en place au moins une méthode d'authentification secondaire pour assurer la sécurité de votre compte. Il s'agit d'une authentification à deux facteurs (A2F). Nous utilisons l'A2F comme un niveau de protection supplémentaire pour sécuriser vos informations.
 
 **Authentification secondaire**
-Nous vous conseillons d'ajouter deux méthodes d'authentification à votre compte. Si vous perdez l'accès à votre principale méthode d'authentification (c'est-à-dire si vous perdez votre téléphone), vous pourrez utiliser une deuxième option pour accéder à votre compte. 
+Nous vous conseillons d'ajouter deux méthodes d'authentification à votre compte. Si vous perdez l'accès à votre principale méthode d'authentification (c'est-à-dire si vous perdez votre téléphone), vous pourrez utiliser une deuxième option pour accéder à votre compte.
 
-Si vous choisissez le texte ou le message vocal, vous devez sélectionner une méthode d'authentification supplémentaire. Login.gov n'est pas en mesure de vous donner accès à votre compte si vous êtes bloqué et/ou si vous perdez votre méthode d'authentification. 
+Si vous choisissez le texte ou le message vocal, vous devez sélectionner une méthode d'authentification supplémentaire. Login.gov n'est pas en mesure de vous donner accès à votre compte si vous êtes bloqué et/ou si vous perdez votre méthode d'authentification.
 
 Si vous êtes bloqué, vous devrez supprimer votre compte et en créer un nouveau.
 
@@ -75,11 +75,11 @@ Les cartes physiques PIV (vérification d'identité personnelle) ou CAC (cartes 
 
 Les messages texte/SMS ou les appels téléphoniques sont pratiques, mais sont extrêmement vulnérables face au vol, au piratage et à d'autres attaques. Vous devez sélectionner plus d'une méthode d'authentification si vous choisissez le texte ou le message vocal.
 
-Si vous choisissez d'utiliser cette option moins sécurisée, saisissez un numéro de téléphone sur lequel vous pouvez recevoir des appels téléphoniques ou des messages texte. Si vous ne disposez que d'une ligne fixe, vous recevrez votre code de sécurité par appel téléphonique. Login.gov ne peut pas envoyer de codes de sécurité aux extensions ou aux messageries vocales.
+Si vous choisissez d'utiliser cette option moins sécurisée, saisissez un numéro de téléphone sur lequel vous pouvez recevoir des appels téléphoniques ou des messages texte. Si vous avez seulement une ligne fixe, vous devez recevoir votre code à usage unique par appel téléphonique. Login.gov ne peut pas envoyer de codes unique à des extensions ou des messages vocaux.
 
-Nous enverrons un code de sécurité unique à ce numéro de téléphone chaque fois que vous vous connecterez à votre compte Login.gov. Chaque code de sécurité expire au bout de dix minutes et ne peut être utilisé qu'une seule fois. Si vous n'avez pas saisi le code de sécurité au bout de dix minutes, demandez un nouveau code.
+Nous enverrons un code unique à ce numéro de téléphone chaque fois que vous vous connecterez à votre compte login.gov. Chaque code à usage unique expire après dix minutes et ne peut être utilisé qu'une seule fois. Si vous ne saisissez pas le code unique dans les dix minutes, demandez un nouveau code.
 
-Après avoir reçu le code, saisissez-le dans le champ « code de sécurité unique ». Chaque fois que vous vous connecterez sur Login.gov, vous aurez le choix entre obtenir le nouveau code de sécurité par téléphone ou par message texte. Vous recevrez un nouveau code de sécurité chaque fois que vous vous connecterez à votre compte Login.gov.
+Après avoir reçu le code, tapez-le dans le champ « Code à usage unique ». Chaque fois que vous vous connecterez à login.gov, vous aurez la possibilité d'obtenir un nouveau code à usage unique par appel téléphonique ou par SMS. Vous recevrez un nouveau code à usage unique chaque fois que vous vous connecterez à votre compte login.gov.
 
 ## Codes de secours (moins sécurisés)
 

--- a/content/_help/trouble-signing-in/how-to-sign-in._en.md
+++ b/content/_help/trouble-signing-in/how-to-sign-in._en.md
@@ -20,7 +20,7 @@ Follow these steps to sign in to Login.gov.
 4. Authenticate using one of the methods you set up. Options include:
 
    * Using face or touch unlock
-   * Entering a one-time code from your authentication application
+   * Entering a security code from your authentication application
    * Using your security key
    * Entering a one-time code that you receive by text or by phone call
    * Entering a backup code

--- a/content/_help/trouble-signing-in/how-to-sign-in._en.md
+++ b/content/_help/trouble-signing-in/how-to-sign-in._en.md
@@ -20,9 +20,9 @@ Follow these steps to sign in to Login.gov.
 4. Authenticate using one of the methods you set up. Options include:
 
    * Using face or touch unlock
-   * Entering a security code from your authentication application
+   * Entering a one-time code from your authentication application
    * Using your security key
-   * Entering a security code that you receive by text or by phone call
+   * Entering a one-time code that you receive by text or by phone call
    * Entering a backup code
    * Using your federal government employee or military ID (PIV or CAC)
 5. You will then be taken to your Login.gov account page.

--- a/content/_help/trouble-signing-in/how-to-sign-in._es.md
+++ b/content/_help/trouble-signing-in/how-to-sign-in._es.md
@@ -20,7 +20,7 @@ Siga estos pasos para iniciar sesión en Login.gov:
    * Usar el desbloqueo facial o táctil
    * Ingresar un código de seguridad de su aplicación de autenticación.
    * Usar su llave de seguridad.
-   * Ingresar un código de seguridad que recibirá por mensaje de texto o llamada telefónica.
+   * Ingrese un código de un solo uso que recibirá mediante un mensaje de texto o una llamada telefónica
    * Ingresar un código de verificación.
    * Utilizar su ID de empleado del Gobierno Federal o del ejército (PIV o CAC)
 5. Entonces, será redirigido la página de su cuenta de Login.gov.

--- a/content/_help/trouble-signing-in/how-to-sign-in._fr.md
+++ b/content/_help/trouble-signing-in/how-to-sign-in._fr.md
@@ -20,7 +20,7 @@ Suivez ces étapes pour vous connecter à Login.gov.
    * Utilisation du déverrouillage facial ou tactile
    * Saisie d'un code de sécurité à partir de votre demande d'authentification
    * Utilisation de votre clé de sécurité
-   * Saisie d'un code de sécurité que vous recevez par SMS ou par appel téléphonique
+   * En saisissant un code à usage unique que vous recevez par SMS ou par appel téléphonique
    * Saisie d'un code de sauvegarde
    * Utilisation de votre carte d'employé du gouvernement fédéral ou de votre carte d'identité militaire (PIV ou CAC)
 5. Vous serez ensuite dirigé vers la page de votre compte Login.gov.


### PR DESCRIPTION
**Why**: As a user consulting the help site, I want to make sure that the references for one-time codes is using the latest terminology so that I have a consistent experience between the application and help pages.