### PR TITLE
Add lint to catch stray files exported to final site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,16 +103,25 @@ include:
   - .well-known
 
 exclude:
+  - assets/img/favicons
+  - assets/js/build/main.js.LICENSE.txt
+  - babel.config.json
+  - CONTRIBUTING.md
+  - docs
   - Gemfile*
+  - jest.config.js
+  - LICENSE.md
   - Makefile*
   - node_modules
+  - OLD_URLS.yml
+  - package-lock.json
   - package.json
+  - README.md
   - scripts
   - spec
-  - webpack.config.js
+  - svgo.config.js
   - vendor
-  - /_pages/remove_content_from_these_redirects.todo
-
+  - webpack.config.js
 keep_files:
   - /assets/js/build/*
 
@@ -122,6 +131,9 @@ plugins:
   - jekyll-autoprefixer
 
 default_locale: en
+
+redirect_from:
+  json: false
 
 help_pages:
   - get-started

--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,6 @@ include:
   - docs/accessibility-assessment-ial2-identity-verification-process.pdf
 
 exclude:
-  - assets/img/favicons
   - assets/js/build/main.js.LICENSE.txt
   - babel.config.json
   - CONTRIBUTING.md

--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,8 @@ defaults:
 include:
   # dotfiles are excluded by default
   - .well-known
+  - docs/accessibility-assessment-ial1-account-creation.pdf
+  - docs/accessibility-assessment-ial2-identity-verification-process.pdf
 
 exclude:
   - assets/img/favicons

--- a/_plugins/style_guide_assets.rb
+++ b/_plugins/style_guide_assets.rb
@@ -7,9 +7,7 @@ require 'fileutils'
 
 def copy_assets(origin, destination)
   origin_glob = File.join(origin, '**/*')
-  origin_files = Dir.glob(origin_glob).
-    reject { |f| File.directory?(f) }.
-    reject { |f| f.include?('/favicons/') }
+  origin_files = Dir.glob(origin_glob).reject { |f| File.directory?(f) }
 
   origin_files.each do |origin_file|
     filename = origin_file.gsub(origin, '').gsub(%r{^/}, '')

--- a/_plugins/style_guide_assets.rb
+++ b/_plugins/style_guide_assets.rb
@@ -7,7 +7,9 @@ require 'fileutils'
 
 def copy_assets(origin, destination)
   origin_glob = File.join(origin, '**/*')
-  origin_files = Dir.glob(origin_glob).reject { |f| File.directory?(f) }
+  origin_files = Dir.glob(origin_glob).
+    reject { |f| File.directory?(f) }.
+    reject { |f| f.include?('/favicons/') }
 
   origin_files.each do |origin_file|
     filename = origin_file.gsub(origin, '').gsub(%r{^/}, '')

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe '_site' do
       .css
       .gif
       .html
+      .ico
       .jpeg
       .jpg
       .js
@@ -22,14 +23,14 @@ RSpec.describe '_site' do
       admin/config.yml
       assets/css/main.css.map
       browserconfig.xml
-      favicon.ico
       manifest.json
       robots.txt
     ].to_set.freeze
 
     files = Dir.glob('**/*', base: SITE_ROOT).
       reject { |file| File.directory?(File.join(SITE_ROOT, file)) }.
-      reject { |file| allowlisted_files.include?(file) }
+      reject { |file| allowlisted_files.include?(file) }.
+      reject { |file| allowlisted_files.include?(File.basename(file)) }
 
     expect(files).to all(
       satisfy do |file|

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe '_site' do
+  it 'only outputs HTML pages and their corresponding assets' do
+    allowed_extensions = %w[
+      .css
+      .gif
+      .html
+      .jpeg
+      .jpg
+      .js
+      .pdf
+      .png
+      .svg
+      .ttf
+      .woff
+      .woff2
+      .xml
+    ].to_set.freeze
+
+    allowlisted_files = %w[
+      admin/config.yml
+      assets/css/main.css.map
+      browserconfig.xml
+      favicon.ico
+      manifest.json
+      robots.txt
+    ].to_set.freeze
+
+    files = Dir.glob('**/*', base: SITE_ROOT).
+      reject { |file| File.directory?(File.join(SITE_ROOT, file)) }.
+      reject { |file| allowlisted_files.include?(file) }
+
+    expect(files).to all(
+      satisfy do |file|
+        allowed_extensions.include?(File.extname(file)) && !file.include?('config')
+      end
+    )
+  end
+end


### PR DESCRIPTION
Yes, we're an open source repo, but no, having the README accessible at https://login.gov/README.md is kind of sloppy.

Before:
- https://login.gov/README.md resolves (and others!! 😱 )

After:
- They do not!

