### PR TITLE
Try busting CircleCI cache to resolve main build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Gemfile.lock" }}
+            - v3-dependencies-{{ checksum "Gemfile.lock" }}
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "package-lock.json" }}
@@ -28,7 +28,7 @@ commands:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v3-dependencies-{{ checksum "Gemfile.lock" }}
       - save_cache:
           paths:
             - ./node_modules


### PR DESCRIPTION
Example failure: https://app.circleci.com/pipelines/github/18F/identity-site/3821/workflows/a6430e89-9072-486b-840e-b0f549274335/jobs/19124

Based on some hints that the `ffi` "cannot open shared object file" error could potentially be related to CircleCI cache:

- https://github.com/ffi/ffi/issues/881
- https://github.com/docker-library/ruby/issues/371

It doesn't _seem_ like it should be an issue, since the exact same cache state had previously passed in #1003.

If it doesn't work, we could explore some of the other options mentioned in comments on the above issue:

- https://github.com/ffi/ffi/issues/881#issuecomment-987996289
- https://github.com/ffi/ffi/issues/881#issuecomment-1189739345