### PR TITLE
Upgrade jekyll-sass-converter to published gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '~> 3.1.2'
 gem 'jekyll', '>= 4.3.0'
 gem 'jekyll-redirect-from', '>= 0.15.0'
 gem 'jekyll-sitemap', '>= 1.4.0'
-gem 'jekyll-sass-converter', git: 'https://github.com/jekyll/jekyll-sass-converter', ref: '13d2054'
+gem 'jekyll-sass-converter', '>= 3.0.0'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/jekyll/jekyll-sass-converter
-  revision: 13d2054514b23ee3f221c4c51eb25bea9bc951f5
-  ref: 13d2054
-  specs:
-    jekyll-sass-converter (2.2.0)
-      sass-embedded (~> 1.54)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -23,8 +15,8 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.21.9)
-    google-protobuf (3.21.9-x86_64-linux)
+    google-protobuf (3.21.12)
+    google-protobuf (3.21.12-x86_64-linux)
     html-proofer (3.19.2)
       addressable (~> 2.3)
       mercenary (~> 0.3)
@@ -54,6 +46,8 @@ GEM
       webrick (~> 1.7)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
@@ -106,7 +100,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.56.1)
+    sass-embedded (1.57.1)
       google-protobuf (~> 3.21)
       rake (>= 10.0.0)
     terminal-table (3.0.2)
@@ -125,7 +119,7 @@ DEPENDENCIES
   html-proofer (~> 3.19.2)
   jekyll (>= 4.3.0)
   jekyll-redirect-from (>= 0.15.0)
-  jekyll-sass-converter!
+  jekyll-sass-converter (>= 3.0.0)
   jekyll-sitemap (>= 1.4.0)
   nokogiri (>= 1.11.0)
   pry


### PR DESCRIPTION
Follow-up to #1003. In #1003, we opted for a Git reference to the yet-unpublished new version of `jekyll-sass-converter`. The new version has now been published to RubyGems, and we should prefer to use the gem version over cloning the Git reference (assumed to be more "stable", and faster install time).