### PR TITLE
Build JavaScript files to site output directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-assets/js/build
 assets/js/jquery/3.5.1/jquery.min.js
 _site
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-assets/js/build
 _site/
 .sass-cache/
 node_modules/

--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ collections:
 
 # Scripts
 scripts:
-  - /assets/js/build/main.js
+  - /assets/js/main.js
 
 # Styles
 styles:
@@ -94,7 +94,6 @@ include:
   - docs/accessibility-assessment-ial2-identity-verification-process.pdf
 
 exclude:
-  - assets/js/build/main.js.LICENSE.txt
   - babel.config.json
   - CONTRIBUTING.md
   - docs
@@ -103,6 +102,7 @@ exclude:
   - LICENSE.md
   - Makefile*
   - assets/scss
+  - assets/js
   - node_modules
   - OLD_URLS.yml
   - package-lock.json
@@ -115,6 +115,7 @@ exclude:
   - webpack.config.js
 keep_files:
   - assets/css
+  - assets/js
 
 plugins:
   - jekyll-redirect-from

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -10,5 +10,5 @@
 {% endfor %}{% endfor %}
 {% if layout.includes_touchpoints %}
   <script src="https://touchpoints.app.cloud.gov/touchpoints/58f51d4d.js"></script>
-  <script src="{{'/assets/js/build/touchpoints_translations.js' | relative_url}}"></script>
-{% endif %}  
+  <script src="{{'/assets/js/touchpoints_translations.js' | relative_url}}"></script>
+{% endif %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -199,7 +199,7 @@ collections:
           name: 'scripts',
           widget: 'file',
           allow_multiple: true,
-          default: '/assets/js/build/contact.js',
+          default: '/assets/js/contact.js',
           i18n: duplicate,
         }
       - { label: 'Permalink', name: 'permalink', widget: 'string', i18n: true }

--- a/content/_help/manage-your-account/international-phone-support._en.md
+++ b/content/_help/manage-your-account/international-phone-support._en.md
@@ -5,7 +5,7 @@ category: manage-your-account
 permalink: /help/manage-your-account/international-phone-support/
 order: 6
 scripts:
-  - /assets/js/build/country_support.js
+  - /assets/js/country_support.js
 redirect_from:
   - /en/help/manage-your-account/international-phone-support/
 ---

--- a/content/_help/manage-your-account/international-phone-support._es.md
+++ b/content/_help/manage-your-account/international-phone-support._es.md
@@ -5,7 +5,7 @@ category: manage-your-account
 permalink: /es/help/manage-your-account/international-phone-support/
 order: 6
 scripts:
-  - /assets/js/build/country_support.js
+  - /assets/js/country_support.js
 ---
 Utilice la siguiente información para determinar si puede utilizar su número de teléfono internacional como método de autenticación de dos factores para recibir SMS (mensajes de texto) o llamadas telefónicas.
 

--- a/content/_help/manage-your-account/international-phone-support._fr.md
+++ b/content/_help/manage-your-account/international-phone-support._fr.md
@@ -5,7 +5,7 @@ category: manage-your-account
 permalink: /fr/help/manage-your-account/international-phone-support/
 order: 6
 scripts:
-  - /assets/js/build/country_support.js
+  - /assets/js/country_support.js
 ---
 Utilisez les informations ci-dessous pour déterminer si votre numéro de téléphone international peut être utilisé comme méthode d'authentification à deux facteurs pour recevoir des SMS (messages texte) et/ou des appels téléphoniques. 
 

--- a/content/_partners/business-inquiries._en.md
+++ b/content/_partners/business-inquiries._en.md
@@ -4,6 +4,6 @@ permalink: /partners/business-inquiries/
 title: >-
     Business inquiries
 scripts:
-  - /assets/js/build/partners_contact.js
+  - /assets/js/partners_contact.js
 redirect_from: partners/contact/
 ---

--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -36,7 +36,7 @@ report_issue_content: >-
 
   If you want to report an issue, please review our vulnerability disclosure policy [vulnerability disclosure policy](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/ "Follow link") and contact us using our [vulnerability disclosure form](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform "Follow link").
 scripts:
-  - /assets/js/build/contact.js
+  - /assets/js/contact.js
 permalink: /contact/
 redirect_from:
   - /en/contact/

--- a/content/_policy/contact._es.md
+++ b/content/_policy/contact._es.md
@@ -37,6 +37,6 @@ report_issue_content: >-
   Si deseas reportar un problema, consulta nuestra [política de divulgación de vulnerabilidades](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/ "Follow link") y contáctanos mediante nuestro [formulario de divulgación de vulnerabilidades](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform "Follow link").
 
 scripts:
-  - /assets/js/build/contact.js
+  - /assets/js/contact.js
 permalink: /es/contact/
 ---

--- a/content/_policy/contact._fr.md
+++ b/content/_policy/contact._fr.md
@@ -36,6 +36,6 @@ report_issue_content: >-
   Si vous souhaitez signaler un problème, veuillez consulter [notre politique en matière de divulgation des vulnérabilités](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/responding-to-public-disclosure-vulnerabilities/) et nous contacter en utilisant [notre formulaire de divulgation des vulnérabilités](https://docs.google.com/forms/d/e/1FAIpQLScuo4xCzBlpLnoq7-bDAVAxtJci03by7S-Q-Z_JUBDloK01QA/viewform).
 
 scripts:
-  - /assets/js/build/contact.js
+  - /assets/js/contact.js
 permalink: /fr/contact/
 ---

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe '_site' do
     allowlisted_files = %w[
       admin/config.yml
       assets/css/main.css.map
+      assets/js/main.js.LICENSE.txt
       browserconfig.xml
       manifest.json
       robots.txt

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
 
   output: {
     filename: '[name].js',
-    path: `${__dirname}/assets/js/build`,
+    path: `${__dirname}/_site/assets/js`,
   },
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   entry: {
     main: './assets/js/main.js',
     contact: './assets/js/contact.js',
+    faqs: './assets/js/faqs.js',
     partners_contact: './assets/js/partners/contact.js',
     touchpoints_translations: './assets/js/touchpoints_translations.js',
     country_support: './assets/js/country_support.js',


### PR DESCRIPTION
This pull request changes the JavaScript to directly output files into the built `_site` directory.

Currently, JavaScript files are built to the `assets` source directory, which has several downsides:

- It's prone to race conditions which can occur between when JavaScript and Jekyll builds start and finish
- It relies on Jekyll to copy JavaScript assets, which is both slow, and triggers Jekyll rebuilds on JavaScript file changes despite the fact that Jekyll is not responsible for transforming these files
- It requires additional workarounds to differentiate and ignore JavaScript artifacts, as opposed to treating `_site` as the primary artifact of the build

This change also follows from previous efforts which apply a similar approach to Sass (#1000 changes to compile Sass directly to `_site/assets/css`).

**Testing Instructions:**

- Observe that JavaScript files continue to load and apply their expected behavior in the live preview
- Observe in local development:
   1. The order of builds does not matter between `npm run build` and `bundle exec jekyll build` (`rm -rf _site` between tests, check that `_site/assets/js` exists after build is complete)
   2. When running `make run`, changes to local JavaScript files are reflected after refreshing the page