### PR TITLE
Update contact hours to 24/7 for both phone and form, and remove extra support form copy

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -20,15 +20,14 @@ banner:
     secure_heading: Secure .gov websites use HTTPS
     secure_description: 'A <strong>lock</strong> or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.'
 contact_page:
-  operating_hours: Operating hours are Monday-Friday 8:00 am to 8:00 pm ET. We are closed for federal holidays.
+  operating_hours: Operating hours are 24 hours a day, seven days a week.
   required: required
   call_us:
     title: Call us
-    operating_hours: Operating hours are Monday-Friday 8:00 am to 8:00 pm ET.
+    operating_hours: Operating hours are 24 hours a day, seven days a week.
   support_request_form:
     title: Submit a help ticket
     other: Other
-    help_text: Please allow 2 business days for a response. Thank you for your patience. 
     required_text: Required fields are marked with an asterisk 
     agencies:
       'Central Intelligence Agency': Central Intelligence Agency

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -20,15 +20,14 @@ banner:
     secure_heading: os sitios web seguros .gov usan HTTPS
     secure_description: 'Un <strong>candado</strong> o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros.'
 contact_page:
-  operating_hours: El horario operativo es de lunes a viernes de 8:00 am a 8:00 pm hora del este. Cerramos con motivo de los festivos federales.
+  operating_hours: 'El horario de servicio es el siguiente: las 24 horas del día, los siete días de la semana.'
   required: requerido
   call_us:
     title: Llámenos
-    operating_hours: El horario operativo es de lunes a viernes de 8:00 am a 8:00 pm hora del este.
+    operating_hours: 'El horario de servicio es el siguiente: las 24 horas del día, los siete días de la semana.'
   support_request_form:
     title: Enviar un tíquet de ayuda
     other: Otro
-    help_text: Le pedimos que espere 2 días hábiles para recibir una respuesta. Gracias por su paciencia.
     required_text: Los campos obligatorios están marcados con un asterisco
     agencies:
       'Central Intelligence Agency': Agence centrale de renseignement

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -20,15 +20,14 @@ banner:
     secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
     secure_description: 'Un <strong>verrou</strong> ou <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez des informations sensibles uniquement sur des sites Web officiels et sécurisés.'
 contact_page:
-  operating_hours: Les heures d'ouverture sont du lundi au vendredi de 8 h à 20 h (heure de l'Est). Nous sommes fermés les jours fériés fédéraux.
+  operating_hours: Les heures d'ouverture sont de 24 heures par jour, sept jours par semaine.
   required: obligatoire
   call_us:
     title: Appelez-nous
-    operating_hours: Les heures d'ouverture sont du lundi au vendredi de 8 h à 20 h (heure de l'Est).
+    operating_hours: Les heures d'ouverture sont de 24 heures par jour, sept jours par semaine.
   support_request_form:
     title: Soumettre un ticket d'assistance
     other: Other
-    help_text: Veuillez prévoir 2 jours ouvrables pour recevoir une réponse. Nous vous remercions de votre patience.
     required_text: Les champs obligatoires sont marqués d'un astérisque
     agencies:
       'Central Intelligence Agency': Agence centrale de renseignement

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -421,8 +421,7 @@
     {% endif %}
 
     <p>
-      {{ site.data.[page.lang].settings.contact_page.operating_hours }} {{
-      site.data.[page.lang].settings.contact_page.support_request_form.help_text }}
+      {{ site.data.[page.lang].settings.contact_page.operating_hours }}
     </p>
 
     <strong>


### PR DESCRIPTION
The contact center – both phone and contact-us-form support – has moved to 24/7 hours of operation. This PR updates site language to reflect that change. It also removes some language about support tickets taking up to 2 business days; the purpose of this change is to try and encourage folks to select that option (the contact center is aiming for a response in 6 hours or less).