### PR TITLE
Update GSA links to use www subdomain

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -28,7 +28,7 @@ contact_page:
   support_request_form:
     title: Submit a help ticket
     other: Other
-    required_text: Required fields are marked with an asterisk 
+    required_text: Required fields are marked with an asterisk
     agencies:
       'Central Intelligence Agency': Central Intelligence Agency
       'Consumer Financial Protection Bureau': Consumer Financial Protection Bureau
@@ -40,7 +40,7 @@ contact_page:
       'Department of the Interior': Department of the Interior
       'Department of Labor': Department of Labor
       'Department of Transportation': Department of Transportation
-      'Department of the Treasury': Department of the Treasury 
+      'Department of the Treasury': Department of the Treasury
       'Department of Veterans Affairs': Department of Veterans Affairs
       'DOI ePermits': DOI ePermits
       'DOD Moves.mil (Homes or Office)': DOD Move.mil (Homes or Office)
@@ -55,7 +55,7 @@ contact_page:
       'Health and Human Services': Health and Human Services
       'HHS Grants.gov': HHS Grants.gov
       'HHS National Institutes of Health (NIH)': HHS National Institues of Health (NIH)
-      'Housing and Urban Development': Housing and Urban Development 
+      'Housing and Urban Development': Housing and Urban Development
       'Internal Revenue Service (IRS)': Internal Revenue Service (IRS)
       'Library of Congress': Library of Congress
       'National Aeronautics and Space Administration': National Aeronautics and Space Administration
@@ -110,11 +110,11 @@ contact_page:
       delete_account: How do I delete my Login.gov account?
       device_notification: I have received an alert about a new sign in on my Login.gov account
       email_delivery_issue: I am not receiving the Login.gov confirmation email
-      feedback: I have feedback about Login.gov 
+      feedback: I have feedback about Login.gov
       forgot_password: I forgot my Login.gov password and can't reset it
       how_to_link: How do I link my partner agency account with Login.gov?
-      how_to_create_with_verification: How do I create a Login.gov account with identity verification? 
-      how_to_verify: How/why do I verify my identify? 
+      how_to_create_with_verification: How do I create a Login.gov account with identity verification?
+      how_to_verify: How/why do I verify my identify?
       international_number: I have an international number and am not receiving my security code
       interest_in_partnership: I'm interested in using Login.gov for my government agency
       invalid_email: Login.gov is not accepting my email address. It says it is invalid
@@ -123,13 +123,13 @@ contact_page:
       issues_with_face_touch_unlock: I'm having issue with using face or touch unlock
       letter_in_mail: I didn't get my letter by mail or it expired
       locked_out: I am locked out of my account
-      lost_access: I've lost access to my phone or email address 
+      lost_access: I've lost access to my phone or email address
       lost_2fa_method: Lost two-factor authentication method
       multiple_otps: I am receiving many security codes when signing in
       new_account: My email/username and password are not working
       new_backup_codes: How do I get new backup codes?
       new_personal_key: How do I get a new personal key?
-      new_device_notification: I've received a new device notification email 
+      new_device_notification: I've received a new device notification email
       no_otp_received: No OTP received
       no_phone: I can't create my Login.gov account because I don't have a phone
       none: '--None--'
@@ -332,7 +332,7 @@ identifier:
     links: Important links
     logo: GSA logo
     usa_gov: U.S. government information and services
-  disclaimer: An official website of the [General Services Administration](https://gsa.gov)
+  disclaimer: An official website of the [General Services Administration](https://www.gsa.gov)
   links:
     about_agency: About GSA
     accessibility: Accessibility support

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -47,7 +47,7 @@ contact_page:
       'DOL Foreign Labor Application Gateway (FLAG)': Portal de solicitud de mano de obra extranjera (FLAG) del Departamento del Trabajo (DOL)
       'DOT Delphi eInvoicing': Facturación electrónica en Delphi del Departamento de Transporte (DOT)
       'DOT FMCSA (Motor Carrier Safety)': FMCSA del Departamento de Transporte (Seguridad de Autotransportes)
-      'DOT National Registry of Certified Medical Examiners': Registro Nacional de Examinadores Médicos Certificados del Departamento de Transporte      
+      'DOT National Registry of Certified Medical Examiners': Registro Nacional de Examinadores Médicos Certificados del Departamento de Transporte
       'Environmental Protection Agency': Agencia de Protección Ambiental
       'FDIC Resolution Request Management Portal': Portal de administración de resoluciones de solicitudes de la Corporación Federal de Seguro de Depósitos (FDIC)
       'General Services Administration': Administración de Servicios Generales
@@ -111,11 +111,11 @@ contact_page:
       concerned_login_email: Estoy preocupado por el correo electrónico de Login.gov que he recibido
       delete_account: ¿Cómo elimino mi cuenta de Login.gov?
       device_notification: He recibido una alerta sobre un nuevo inicio de sesión en mi cuenta de Login.gov
-      feedback: Tengo comentarios sobre Login.gov 
+      feedback: Tengo comentarios sobre Login.gov
       email_delivery_issue: No recibo el correo electrónico de confirmación de Login.gov
       forgot_password: Olvidé mi contraseña de Login.gov y no puedo restablecerla
       how_to_link: ¿Cómo puedo vincular la cuenta de mi agencia asociada con Login.gov?
-      how_to_create_with_verification: ¿Cómo puedo crear una cuenta en Login.gov con verificación de identidad? 
+      how_to_create_with_verification: ¿Cómo puedo crear una cuenta en Login.gov con verificación de identidad?
       how_to_verify: ¿Cómo/por qué verifico mi identidad?
       interest_in_partnership: Estoy interesado en utilizar Login.gov para mi agencia gubernamental
       international_number: Tengo un número internacional y no recibo mi código de seguridad
@@ -125,12 +125,12 @@ contact_page:
       issues_with_face_touch_unlock: Tengo problemas con el uso del desbloqueo facial o táctil
       letter_in_mail: No he recibido mi carta por correo o ha caducado
       locked_out: Estoy bloqueado en mi cuenta
-      lost_access: He perdido el acceso a mi teléfono o dirección de correo electrónico  
+      lost_access: He perdido el acceso a mi teléfono o dirección de correo electrónico
       lost_2fa_method: Método autenticación de dos factores perdido
       multiple_otps: Recibo códigos de seguridad de Login.gov que no he solicitado
       new_account: Mi correo electrónico/nombre de usuario y contraseña no funcionan
       new_backup_codes: ¿Cómo consigo nuevos códigos de copia de seguridad?
-      new_device_notification: He recibido un correo electrónico de notificación de nuevo dispositivo 
+      new_device_notification: He recibido un correo electrónico de notificación de nuevo dispositivo
       new_personal_key: ¿Cómo puedo obtener una nueva clave personal?
       no_otp_received: No se ha recibido ningún pedido de pago
       no_phone: No puedo crear mi cuenta de Login.gov porque no tengo un teléfono
@@ -338,7 +338,7 @@ identifier:
     links: Enlaces importantes
     logo: Logo de la GSA
     usa_gov: Información y servicios del Gobierno de EE. UU.
-  disclaimer: Un sitio web oficial de [General Services Administration](https://gsa.gov)
+  disclaimer: Un sitio web oficial de [General Services Administration](https://www.gsa.gov)
   links:
     about_agency: Acerca de GSA
     accessibility: Soporte de accesibilidad

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -48,7 +48,7 @@ contact_page:
       'DOT FMCSA (Motor Carrier Safety)': FMCSA du Département des transports (Sécurité des transporteurs routiers)
       'DOT Delphi eInvoicing': DOT Delphi eInvoicing
       'DOT National Registry of Certified Medical Examiners': Registre national des médecins agréés du Département des transports
-      'Environmental Protection Agency': Agence de protection de l'environnement 
+      'Environmental Protection Agency': Agence de protection de l'environnement
       'FDIC Resolution Request Management Portal': FDIC demande un portail de gestion des résolutions
       'General Services Administration': Administration des services généraux
       'GSA Sam.gov': GSA SAM.gov
@@ -111,7 +111,7 @@ contact_page:
       delete_account: Comment supprimer mon compte Login.gov?
       device_notification: J'ai reçu une alerte concernant une nouvelle ouverture de session sur mon compte Login.gov
       email_delivery_issue: Je ne reçois pas le courriel de confirmation de Login.gov
-      feedback: J'ai des commentaires à propos de Login.gov 
+      feedback: J'ai des commentaires à propos de Login.gov
       forgot_password: J'ai oublié mon mot de passe Login.gov et je ne peux pas le réinitialiser
       how_to_link: Comment puis-je lier le compte de mon agence partenaire avec Login.gov?
       how_to_create_with_verification: Comment puis-je créer un compte Login.gov avec vérification d'identité?
@@ -120,17 +120,17 @@ contact_page:
       interest_in_partnership: Je suis intéressé par l'utilisation de Login.gov pour mon agence gouvernementale
       invalid_email: Login.gov n'accepte pas mon adresse courriel. Il est indiqué qu'elle n'est pas valide
       invalid_otp: Login.gov indique que mon code de sécurité n'est pas valide
-      issue_with_partner_agency: J'ai un problème avec cette agence partenaire 
+      issue_with_partner_agency: J'ai un problème avec cette agence partenaire
       issues_with_face_touch_unlock: J'ai un problème avec le déverrouillage facial ou tactile
       letter_in_mail: Je n'ai pas reçu ma lettre par la poste ou elle a expiré
       locked_out: Je suis bloqué sur mon compte
-      lost_access: J'ai perdu l'accès à mon téléphone ou à mon adresse électronique 
+      lost_access: J'ai perdu l'accès à mon téléphone ou à mon adresse électronique
       lost_2fa_method: Authentification à deux facteurs perdue
       multiple_otps: Je reçois de nombreux codes de sécurité lors de l'ouverture de session
       new_account: Mon courriel/nom d'utilisateur et mon mot de passe ne fonctionnent pas
       new_backup_codes: Comment obtenir de nouveaux codes de sauvegarde?
       new_personal_key: Comment obtenir une nouvelle clé personnelle?
-      new_device_notification: J'ai reçu une notification par adresse électronique d'un nouvel appareil 
+      new_device_notification: J'ai reçu une notification par adresse électronique d'un nouvel appareil
       no_otp_received: Aucun OTP reçu
       no_phone: Je ne peux pas créer mon compte Login.gov parce que je n'ai pas de téléphone.
       none: '--Aucun--'
@@ -417,7 +417,7 @@ identifier:
     links: Liens importants
     logo: Logo de GSA
     usa_gov: Informations et services du gouvernement américain
-  disclaimer: Un site Web officiel de [General Services Administration](https://gsa.gov)
+  disclaimer: Un site Web officiel de [General Services Administration](https://www.gsa.gov)
   links:
     about_agency: À propos de GSA
     accessibility: Support de l'accessibilité

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -37,7 +37,7 @@
       aria-label="{{ site.data.[page.lang].settings.identifier.accessible_labels.identifier }}">
       <div class="usa-identifier__container">
         <div class="usa-identifier__logos">
-          <a href="https://gsa.gov" class="usa-identifier__logo">
+          <a href="https://www.gsa.gov" class="usa-identifier__logo">
             <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/assets/img/gsa-logo.svg"
               alt="{{ site.data.[page.lang].settings.identifier.accessible_labels.logo }}" />
           </a>
@@ -55,7 +55,7 @@
       <div class="usa-identifier__container">
         <ul class="usa-identifier__required-links-list">
           <li class="usa-identifier__required-links-item">
-            <a href="https://gsa.gov" class="usa-identifier__required-link">
+            <a href="https://www.gsa.gov" class="usa-identifier__required-link">
               {{ site.data.[page.lang].settings.identifier.links.about_agency }}
             </a>
           </li>

--- a/_includes/partners/footer.html
+++ b/_includes/partners/footer.html
@@ -38,7 +38,7 @@
       aria-label="{{ site.data.[page.lang].settings.identifier.accessible_labels.identifier }}">
       <div class="usa-identifier__container">
         <div class="usa-identifier__logos">
-          <a href="https://gsa.gov" class="usa-identifier__logo">
+          <a href="https://www.gsa.gov" class="usa-identifier__logo">
             <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/assets/img/gsa-logo.svg"
               alt="{{ site.data.[page.lang].settings.identifier.accessible_labels.logo }}" />
           </a>
@@ -56,7 +56,7 @@
       <div class="usa-identifier__container">
         <ul class="usa-identifier__required-links-list">
           <li class="usa-identifier__required-links-item">
-            <a href="https://gsa.gov" class="usa-identifier__required-link">
+            <a href="https://www.gsa.gov" class="usa-identifier__required-link">
               {{ site.data.[page.lang].settings.identifier.links.about_agency }}
             </a>
           </li>


### PR DESCRIPTION
Why: Since it's the canonical URL (avoid an unnecessary redirect)

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1673266030524959