### PR TITLE
Remove lingering IE11 supports

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     country_support: './assets/js/country_support.js',
   },
 
-  target: ['web', 'es5'],
+  target: ['web'],
 
   output: {
     filename: '[name].js',
@@ -22,7 +22,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules\/(?!uswds|receptor)/,
+        exclude: /node_modules/,
         use: ['babel-loader'],
       },
     ],


### PR DESCRIPTION
**Why?**

- It should have been included in #1019
- Improve build times

There's a non-negligible improvement on Webpack build times with these changes, about 17% faster (2370ms to 1968ms for an average of 5 runs).