### PR TITLE
Revert "Add outage message for Salesforce outage"

### DIFF
--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -20,28 +20,28 @@ common_applications:
 
 {{ page.help_center_content | markdownify }}
 
-{{ page.intro_content | markdownify }}
-
-{% if site.contact_phone_number_enabled and site.contact_phone_number and
-   site.contact_phone_number_location == 'top' %}
-  {% include contact_phone.html %}
-{% endif %}
-
 <contact-us-form
   maintenance-alert-id="contact-us-maintenance-alert"
   maintenance-start-time="{{ site.contact_maintenance_start_time }}"
   maintenance-end-time="{{ site.contact_maintenance_end_time }}"
   class="page-content__section"
 >
+  {{ page.intro_content | markdownify }}
+
+  {% if site.contact_phone_number_enabled and site.contact_phone_number and
+     site.contact_phone_number_location == 'top' %}
+    {% include contact_phone.html %}
+  {% endif %}
+
   <div class="desktop:grid-col-9">
     {% include contact_form.html common_applications=layout.common_applications %}
   </div>
-</contact-us-form>
 
-{% if site.contact_phone_number_enabled and site.contact_phone_number and
-   site.contact_phone_number_location == 'bottom' %}
-  {% include contact_phone.html %}
-{% endif %}
+  {% if site.contact_phone_number_enabled and site.contact_phone_number and
+     site.contact_phone_number_location == 'bottom' %}
+    {% include contact_phone.html %}
+  {% endif %}
+</contact-us-form>
 
 <div class="page-content__section">{{ page.partner_content | markdownify }}</div>
 <div class="page-content__section">{{ page.report_issue_content | markdownify }}</div>

--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -25,7 +25,7 @@ help_center_content: >-
   * [I need to change my information or manage my account](/help/manage-your-account/overview/)
 
   * [Browse more help articles](/help/)
-maintenance_window_content: Due to an unexpected outage, we can't review online support requests right now. You can still call our support center, which is always open.
+maintenance_window_content: Login.gov’s Contact Center is currently undergoing maintenance from <strong>%{start_time} - %{end_time}.</strong> Visit some common topics below for assistance.
 partner_content: >-
   ## Partner with Login.gov
 

--- a/content/_policy/contact._es.md
+++ b/content/_policy/contact._es.md
@@ -25,7 +25,7 @@ help_center_content: >-
   * [Necesito cambiar mi información o administrar mi cuenta](/es/help/manage-your-account/overview/)
 
   * [Explorar más artículos de ayuda](/es/help/)
-maintenance_window_content: Debido a una interrupción inesperada, no podemos revisar las solicitudes de soporte en línea en este momento. Todavía puede llamar a nuestro centro de soporte, que siempre está abierto.
+maintenance_window_content: El centro de atención de Login.gov estará en mantenimiento desde <strong>%{start_time} y hasta %{end_time}</strong>. Consulte los temas comunes que aparecen a continuación para obtener ayuda.
 partner_content: >-
   ## Asociarse con Login.gov
 

--- a/content/_policy/contact._fr.md
+++ b/content/_policy/contact._fr.md
@@ -24,7 +24,7 @@ help_center_content: >-
   * [Je dois modifier mes informations ou gérer mon compte](/fr/help/manage-your-account/overview/)
 
   * [Parcourir d’autres articles d’aide](/fr/help/)
-maintenance_window_content: En raison d'une panne inattendue, nous ne pouvons pas examiner les demandes d'assistance en ligne pour le moment. Vous pouvez toujours appeler notre centre d'assistance, qui est toujours ouvert.
+maintenance_window_content: Le centre de contact de Login.gov est actuellement en cours de maintenance <strong>%{start_time} au %{end_time}</strong>. Consultez les sujets courants ci-dessous pour obtenir de l'aide.
 partner_content: >-
   ## Partenaire avec Login.gov
 


### PR DESCRIPTION
This reverts commit 3b21b3d617a0f9868ad001a3f73f3a704365a57a from #1032

The banner has been disabled via config in the pages admin, so this puts back the old message and old layout