### PR TITLE
Use h2 for footer navigation section headings

### DIFF
--- a/_includes/components/footer-navigation.html
+++ b/_includes/components/footer-navigation.html
@@ -22,7 +22,7 @@
         {% assign section_key = section[0] %}
         {% assign section_value = section[1] %}
         <section class="grid-col-6 tablet:grid-col-auto margin-y-2 footer-navigation__section">
-          <h1>{{ site.data.[page.lang].settings.nav.groups[section_key] }}</h1>
+          <h2>{{ site.data.[page.lang].settings.nav.groups[section_key] }}</h2>
           <ul>
             {% for section_link in section_value %}
               {% assign section_link_key = section_link[0] %}

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -10,14 +10,14 @@
     @include unstyled-list;
   }
 
-  h1,
+  h2,
   a {
     font-size: $base-font-sm;
     color: color('primary-dark');
   }
 }
 
-.footer-navigation__section h1 {
+.footer-navigation__section h2 {
   margin: 0;
 }
 


### PR DESCRIPTION
**Why**: Try to limit to single `h1` per page, avoid treating footer navigation headings as equal hierarchy to page heading.

Related:
- https://www.a11yproject.com/posts/how-to-accessible-heading-structure/
- https://gsa-tts.slack.com/archives/C02BT4H5Q/p1676588237094159