### PR TITLE
LG-8824:  Add "American Samoa" to verify-your-identity-in-person help content

### DIFF
--- a/content/_help/verify-your-identity/verify-your-identity-in-person._en.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person._en.md
@@ -28,7 +28,7 @@ Once you complete the steps on Login.gov, we’ll email you a barcode and a dead
 
 Bring the same ID you used on Login.gov. Your ID must not be expired. At this time, only the following state-issued identification is accepted: 
 
-* Driver’s license from all 50 states, the District of Columbia (DC), and other US territories (Guam, US Virgin Islands, Mariana Islands and Puerto Rico)
+* Driver’s license from all 50 states, the District of Columbia (DC), and other US territories (Guam, US Virgin Islands, American Samoa, Mariana Islands and Puerto Rico)
 * A non-driver’s license state-issued ID card
 
   * This is an identity document issued by the state, the District of Columbia (DC), or US territory that asserts identity but does not give driving privileges.

--- a/content/_help/verify-your-identity/verify-your-identity-in-person._es.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person._es.md
@@ -27,7 +27,7 @@ Una vez que haya completado los pasos en Login.gov, le enviaremos por correo ele
 
 Lleve el mismo documento de identidad que utilizó en Login.gov. Su identificación no debe estar vencida. En este momento, solo se aceptan las siguientes identificaciones emitidas por el estado: 
 
-* Licencia de conducir de los 50 estados, del Distrito de Columbia (DC) y de otros territorios de Estados Unidos (Guam, Islas Vírgenes de Estados Unidos, Islas Marianas y Puerto Rico)
+* Licencia de conducir de los 50 estados, del Distrito de Columbia (DC) y de otros territorios de Estados Unidos (Guam, Islas Vírgenes de Estados Unidos, Samoa Americana, Islas Marianas y Puerto Rico)
 * Una identificación emitida por el estado que no sea una licencia de conducir
 
   * Se trata de un documento de identidad emitido por el estado, el Distrito de Columbia (DC) o un territorio de EE.UU. que confirme la identidad, pero no otorga privilegios de conducción.

--- a/content/_help/verify-your-identity/verify-your-identity-in-person._fr.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person._fr.md
@@ -27,7 +27,7 @@ Une fois que vous aurez complété les étapes sur Login.gov, nous vous enverron
 
 Apportez la même carte d'identité que vous avez utilisée sur Login.gov. Votre pièce d'identité ne doit pas être périmée. Pour l'instant, seules les pièces d'identité suivantes, délivrées par l'État, sont acceptées : 
 
-* Un permis de conduire des 50 États, du district de Columbia (D. C.) et des autres territoires américains (Guam, îles Vierges américaines, îles Mariannes et Porto Rico).
+* Un permis de conduire des 50 États, du district de Columbia (D. C.) et des autres territoires américains (Guam, îles Vierges américaines, Samoa américaines, îles Mariannes et Porto Rico).
 * Une carte d'identité sans permis de conduire délivrée par l'État.
 * * Il s'agit d'un document d'identité délivré par l'État, le district de Columbia (D. C.) ou le territoire américain, qui atteste de l'identité mais ne donne pas le droit de conduire.
 


### PR DESCRIPTION
### 🎫  Ticket
[LG-8824](https://cm-jira.usa.gov/browse/LG-8824)

### 🛠️  Summary of changes
Add "American Samoa" to /help/verify-your-identity/verify-your-identity-in-person.  It should be added to section "Your state-issued ID" after US Virgin Islands.

###  📜  Testing plan
Visit each view below. Find section Your state-issued ID. Confirm American Samoa has been added. Translation for each language can be found in the ticket. 

- [ ] Visit https://login.gov/help/verify-your-identity/verify-your-identity-in-person/ to confirm "American Samoa" has been added to the list of accepted driver licenses
- [ ] Visit https://login.gov/es/help/verify-your-identity/verify-your-identity-in-person/ to confirm "Samoa Americana" has been added to the list of accepted driver licenses
- [ ] Visit https://login.gov/fr/help/verify-your-identity/verify-your-identity-in-person/ to confirm "Samoa américaines" has been added to the list of accepted driver licenses

### 📓  Dev Notes
📝 make lint returns 79 valid files
📝 npm test for `gyamada/lg-8824-add-american-samoa-v2` & `main` return the same results: 1 failed, 383 passed with the failure observed in this file `contact_us_form_element_spect.ts`