### PR TITLE
Remove reference to design system accessibility link

### DIFF
--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -233,7 +233,7 @@ nav:
       - name: Evaluación
         url: '#evaluación'
       - name: Limitaciones conocidas
-        url: '#políticas-de-accesibilidad'
+        url: '#limitaciones-conocidas'
   anchor_to_top: Volver arriba
   become_a_partner: Convertirse en un compañero
   business_inquiries:

--- a/content/_policy/accessibility._en.md
+++ b/content/_policy/accessibility._en.md
@@ -28,11 +28,6 @@ Our completed accessibility assessment reports can be found below:
 [IAL 1 Account creation report](/docs/accessibility-assessment-ial1-account-creation.pdf)
 [Identity verification report](/docs/accessibility-assessment-identity-verification-process.pdf)
 
-### Accessibility policies
-In addition to completed accessibility reports, Login.gov has compiled a page regarding accessibility policies.
-
-[Login.gov accessibility policies](https://design.login.gov/accessibility/policies/)
-
 ## Known limitations
 Below is a description of the types of accessibility limitations discovered in our evaluations.
 

--- a/content/_policy/accessibility._es.md
+++ b/content/_policy/accessibility._es.md
@@ -25,11 +25,6 @@ En el siguiente enlace se pueden consultar nuestros informes de evaluación de a
 [Informe de creación de Cuenta IAL 1](/docs/accessibility-assessment-ial1-account-creation.pdf)
 [Informe de verificación de Cuenta](/docs/accessibility-assessment-identity-verification-process.pdf)
 
-### Políticas de accesibilidad
-Además de los informes de accesibilidad realizados, Login.gov ha elaborado una página sobre las políticas de accesibilidad.
-
-[Políticas de accesibilidad de Login.gov](https://design.login.gov/accessibility/policies/)
-
 ## Limitaciones conocidas
 A continuación, se describen los tipos de limitaciones de accesibilidad descubiertas en nuestras evaluaciones.
 

--- a/content/_policy/accessibility._fr.md
+++ b/content/_policy/accessibility._fr.md
@@ -25,11 +25,6 @@ Vous trouverez ci-dessous le lien d’accès à nos rapports d’évaluation de 
 [IAL 1 Rapport de création de compte](/docs/accessibility-assessment-ial1-account-creation.pdf)
 [Rapport de vérification de compte](/docs/accessibility-assessment-identity-verification-process.pdf)
 
-### Politiques d’accessibilité
-En plus des rapports d’accessibilité dûment remplis, Login.gov a rassemblé des informations sur les politiques d’accessibilité.
-
-[Politiques d’accessibilité de Login.gov](https://design.login.gov/accessibility/policies/)
-
 ## Limites connues
 Vous trouverez ci-dessous une description des types de limitations d’accessibilité découverts au cours de nos évaluations.
 


### PR DESCRIPTION
**Why?**

* These pages were removed from the design system documentation site between https://github.com/18F/identity-style-guide/pull/178 and https://github.com/18F/identity-style-guide/pull/181
* We are working to remove references to the design system documentation site