### PR TITLE
Fix (hide) Touchpoints survey heading

### DIFF
--- a/_sass/components/_layout.scss
+++ b/_sass/components/_layout.scss
@@ -125,7 +125,7 @@ article.container,
   margin-top: 2rem;
 }
 
-#fba-modal-title,
+.fba-modal-title,
 .section-title-view {
   display: none;
 }


### PR DESCRIPTION
Why: The "yes/no survey" heading was not meant to be displayed, and this appeared to have regressed as a result of a change in how Touchpoints renders this content (see https://github.com/GSA/touchpoints/commit/7fb2a5f230e2e920a72e4c1a5b0789452f4b7600)

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/225434134-11b1281a-8d92-4f49-b464-469f81ff29a1.png)|![image](https://user-images.githubusercontent.com/1779930/225434676-2fd41e17-6e1f-4f09-8ae8-2afece9bfa65.png)
