### PR TITLE
LG-9179: Sort Contact Us agencies case-insensitive

### DIFF
--- a/_plugins/sort_by_values.rb
+++ b/_plugins/sort_by_values.rb
@@ -4,7 +4,7 @@ module Jekyll
     # @return [Array<Hash>] entry-like hashes with 'key' and 'value'
     def sort_by_values(hash)
       hash.
-        sort_by { |_key, value| value }.
+        sort_by { |_key, value| value.downcase }.
         map { |key, value| { 'key' => key, 'value' => value } }
     end
   end


### PR DESCRIPTION
**Why:** As a user submitting a support ticket, I expect that I can scan for the name of the relevant agency in an ordered list, so that I can quickly find and select it from the long list of options.

**Testing Instructions:**

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-lg-9179-contact-form-agency-sort/contact/
2. Expand "Partner Agency" dropdown
3. Find "myTreasury" partner agency option

_Before:_ You'd find it at the very end of the list (see [live page](https://login.gov/contact/))
_After:_ You'll find it alphabetically between "Library of Congress" and "National Aeronautics and Space Administration"