### PR TITLE
LG-9179: Sort "Contact Us" common agencies alphabetically

### DIFF
--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -473,24 +473,21 @@
         site.data.[page.lang].settings.contact_page.support_request_form.form_helpers.select_agency
         }}
       </option>
+      {% assign all_applications_sorted = site.data[page.lang].settings.contact_page.support_request_form.agencies | sort_by_values %}
       <optgroup
         label="{{ site.data.[page.lang].settings.contact_page.support_request_form.labels.agency_application_common }}"
       >
-        {% for common_application in include.common_applications %}
-        <option value="{{ common_application }}">
-          {{
-          site.data[page.lang].settings.contact_page.support_request_form.agencies[common_application]
-          }}
-        </option>
+        {% for application in all_applications_sorted %}
+          {% if include.common_applications contains application.key %}
+            <option value="{{ application.key }}">{{ application.value }}</option>
+          {% endif %}
         {% endfor %}
       </optgroup>
       <optgroup
         label="{{ site.data.[page.lang].settings.contact_page.support_request_form.labels.agency_application_all }}"
       >
-        {% assign all_applications_sorted =
-        site.data[page.lang].settings.contact_page.support_request_form.agencies | sort_by_values %}
         {% for application in all_applications_sorted %}
-        <option value="{{ application.key }}">{{ application.value }}</option>
+          <option value="{{ application.key }}">{{ application.value }}</option>
         {% endfor %}
       </optgroup>
       <optgroup
@@ -521,8 +518,8 @@
 
     <!-- START: Description -->
     <label class="usa-label" for="description">
-      {{ 
-        site.data.[page.lang].settings.contact_page.support_request_form.labels.description 
+      {{
+        site.data.[page.lang].settings.contact_page.support_request_form.labels.description
       }}<abbr title="{{ site.data.[page.lang].settings.contact_page.required }}" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <div class="usa-hint">

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -478,7 +478,8 @@
         label="{{ site.data.[page.lang].settings.contact_page.support_request_form.labels.agency_application_common }}"
       >
         {% for application in all_applications_sorted %}
-          {% if include.common_applications contains application.key %}
+          {% assign common_application = include.common_applications | find_exp: 'item', 'item == application.key' %}
+          {% if common_application %}
             <option value="{{ application.key }}">{{ application.value }}</option>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
## 🎫 Ticket

[LG-9179](https://cm-jira.usa.gov/browse/LG-9179)

## 🛠 Summary of changes

Updates the list of Common Applications in the Partner Agency dropdown of the Contact Us page to be listed alphabetically, in order to reduce cognitive load in trying to navigate the list of common applications.

Related: #1058

See Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1679494482124409?thread_ts=1679489133.583309&cid=C01710KMYUB

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-lg-9179-contact-common-alphabetical/contact/
2. (Optional) Change the page language
3. Expand "Partner Agency" dropdown
4. Observe that the list of Common Applications is sorted alphabetically

## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/1779930/227013098-12dfbc67-1871-40e1-9602-24a523ca6cdf.png) | ![image](https://user-images.githubusercontent.com/1779930/227013047-4ff7e582-5501-4baf-8be7-918ef3de676d.png) |