### PR TITLE
Add config to block email addresses that spam the contact center

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,10 @@ contact_maintenance_end_time: null
 # Unplanned outage configuration
 contact_unplanned_outage: false
 
+# hex-digested SHA256 of email addresses
+contact_spam_email_addresses:
+- 4de348ef053db5f71a4c72f4c894d49161bf7d30ea81d1903d43eb6f143871d9
+
 # Used to load country code support
 idp_base_url: https://secure.login.gov
 # for local development:

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -410,6 +410,7 @@
     method="POST"
     onSubmit="return remapvalues(this); return true;"
     class="usa-form"
+    data-spam-email-addresses="{{ site.contact_spam_email_addresses | join: ',' }}"
   >
     <input type="hidden" name="retURL" value="https://login.gov{{ '/' | locale_url }}" />
     <input type="hidden" name="orgid" value="{{ site.contact_form_orgid }}" />

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -5,10 +5,6 @@ async function sha256(message) {
   return array.map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
-function emailIsSpam(email, spamEmails) {
-  return spamEmails.includes(sha256(email));
-}
-
 function verifyCanSubmitEntry() {
   const debug = Array.prototype.slice.apply(document.getElementsByName('debug'))[0];
   if (debug && +debug.value) {

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -22,7 +22,7 @@ function verifyCanSubmitEntry() {
 
   let alreadyAttemptedSubmission = false;
   form.addEventListener('submit', (event) => {
-    if (spamEmailDigests.includes(sha256Hex(emailInput.value))) {
+    if (spamEmailDigests.includes(sha256(emailInput.value))) {
       event.preventDefault();
       window.location = '/';
       return;

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -21,7 +21,7 @@ function verifyCanSubmitEntry() {
   const piiErrorText = document.getElementById('pii-warning-message');
   const descriptionInput = document.getElementById('description');
   const emailInput = document.getElementById('email');
-  const spamEmailDigests = (form.dataset.spamEmailAddresses || '').split(',');
+  const spamEmailDigests = (form.dataset.spamEmailAddresses || '').split(',').filter(Boolean);
 
   let alreadyAttemptedSubmission = false;
   form.addEventListener('submit', (event) => {

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,8 +1,9 @@
-async function sha256(message) {
-  const data = new TextEncoder().encode(message);
-  const buffer = await crypto.subtle.digest('SHA-256', data);
-  const array = Array.from(new Uint8Array(buffer));
-  return array.map((b) => b.toString(16).padStart(2, '0')).join('');
+import { sha256 } from 'js-sha256';
+
+function sha256Hex(message) {
+  const hash = sha256.create();
+  hash.update(message);
+  return hash.hex();
 }
 
 function verifyCanSubmitEntry() {
@@ -21,7 +22,7 @@ function verifyCanSubmitEntry() {
 
   let alreadyAttemptedSubmission = false;
   form.addEventListener('submit', (event) => {
-    if (spamEmailDigests.includes(await sha256(emailInput.value))) {
+    if (spamEmailDigests.includes(sha256Hex(emailInput.value))) {
       event.preventDefault();
       return;
     }

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,11 +1,5 @@
 import { sha256 } from 'js-sha256';
 
-function sha256Hex(message) {
-  const hash = sha256.create();
-  hash.update(message);
-  return hash.hex();
-}
-
 function verifyCanSubmitEntry() {
   const debug = Array.prototype.slice.apply(document.getElementsByName('debug'))[0];
   if (debug && +debug.value) {

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -25,7 +25,7 @@ function verifyCanSubmitEntry() {
 
   let alreadyAttemptedSubmission = false;
   form.addEventListener('submit', (event) => {
-    if (emailIsSpam(emailInput.value, spamEmailDigests)) {
+    if (spamEmailDigests.includes(await sha256(emailInput.value))) {
       event.preventDefault();
       return;
     }

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,3 +1,16 @@
+async function sha256(message) {
+  const data = new TextEncoder().encode(message);
+  const buffer = await crypto.subtle.digest("SHA-256", data);
+  const array = Array.from(new Uint8Array(buffer));
+  return array
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function emailIsSpam(email, spamEmails) {
+  return spamEmails.includes(sha256(email));
+}
+
 function verifyCanSubmitEntry() {
   const debug = Array.prototype.slice.apply(document.getElementsByName('debug'))[0];
   if (debug && +debug.value) {
@@ -9,8 +22,16 @@ function verifyCanSubmitEntry() {
   const piiError = document.getElementById('pii-warning');
   const piiErrorText = document.getElementById('pii-warning-message');
   const descriptionInput = document.getElementById('description');
+  const emailInput = document.getElementById('email');
+  const spamEmailDigests = (form.dataset.spamEmailAddresses || '').split(',');
+
   let alreadyAttemptedSubmission = false;
   form.addEventListener('submit', (event) => {
+    if (emailIsSpam(emailInput.value, spamEmailDigests)) {
+      event.preventDefault();
+      return;
+    }
+
     const captcha = document.getElementById('g-recaptcha-response');
     if (!captcha || !captcha.value) {
       event.preventDefault();

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -24,6 +24,7 @@ function verifyCanSubmitEntry() {
   form.addEventListener('submit', (event) => {
     if (spamEmailDigests.includes(sha256Hex(emailInput.value))) {
       event.preventDefault();
+      window.location = '/';
       return;
     }
 

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,10 +1,8 @@
 async function sha256(message) {
   const data = new TextEncoder().encode(message);
-  const buffer = await crypto.subtle.digest("SHA-256", data);
+  const buffer = await crypto.subtle.digest('SHA-256', data);
   const array = Array.from(new Uint8Array(buffer));
-  return array
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return array.map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 function emailIsSpam(email, spamEmails) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "babel-loader": "^8.2.4",
         "concurrently": "^7.6.0",
         "identity-style-guide": "^6.5.0",
+        "js-sha256": "^0.9.0",
         "webpack": "^5.76.1",
         "webpack-cli": "^5.0.1",
         "whatwg-fetch": "^3.6.2"
@@ -8974,6 +8975,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -20252,6 +20258,11 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
       "dev": true
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-loader": "^8.2.4",
     "concurrently": "^7.6.0",
     "identity-style-guide": "^6.5.0",
+    "js-sha256": "^0.9.0",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1",
     "whatwg-fetch": "^3.6.2"

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe '_site' do
     allowlisted_files = %w[
       admin/config.yml
       assets/css/main.css.map
+      assets/js/contact.js.LICENSE.txt
       assets/js/main.js.LICENSE.txt
       browserconfig.xml
       manifest.json


### PR DESCRIPTION
## 🎫 Ticket

Based on request [in Slack](https://gsa-tts.slack.com/archives/C0NGESUN5/p1679931537439049)

## 🛠 Summary of changes

Adds a site config where we can add SHA 256 of individual email addresses that misbehave, so we can prevent submissions from them that spam the contact center

## 📜 Testing Plan

- [x] Add a known email to the config
- [x] Enter it in local development
- [x] Submission should be silently blocked

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

