### PR TITLE
Remove fetch polyfill

### DIFF
--- a/assets/js/country_support.js
+++ b/assets/js/country_support.js
@@ -29,14 +29,9 @@ const prettyDialingCode = (dialingCode) => {
 };
 
 /**
- * @typedef {(input: RequestInfo, init?: RequestInit) => Promise<Response>} Fetch
- */
-
-/**
  * @param {HTMLElement} elem
- * @param {Fetch} fetch
  */
-function loadCountrySupportTable(elem, fetch) {
+function loadCountrySupportTable(elem) {
   const tbody = elem.querySelector('tbody');
   const templateRow = elem.querySelector('[data-item=template-row]');
   const successIcon = elem.querySelector('[data-item=icon-success]');
@@ -62,7 +57,8 @@ function loadCountrySupportTable(elem, fetch) {
     cell.querySelector('[data-item=icon]').appendChild(clonedIcon);
   };
 
-  fetch(`${idpBaseUrl || ''}/api/country-support?locale=${locale}`)
+  window
+    .fetch(`${idpBaseUrl || ''}/api/country-support?locale=${locale}`)
     .then((response) => {
       if (response.ok) {
         return response.json();
@@ -108,14 +104,4 @@ function loadCountrySupportTable(elem, fetch) {
     });
 }
 
-/** @type {Promise<Fetch>} */
-const fetchPromise =
-  'fetch' in window
-    ? new Promise((resolve) => resolve(window.fetch))
-    : import(/* webpackChunkName: "whatwg-fetch" */ 'whatwg-fetch').then(({ fetch }) => fetch);
-
-fetchPromise.then((fetch) => {
-  Array.from(document.querySelectorAll('.js-country-support')).forEach((elem) =>
-    loadCountrySupportTable(elem, fetch),
-  );
-});
+loadCountrySupportTable(document.querySelector('.js-country-support'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "concurrently": "^7.6.0",
         "identity-style-guide": "^6.5.0",
         "webpack": "^5.76.1",
-        "webpack-cli": "^5.0.1",
-        "whatwg-fetch": "^3.6.2"
+        "webpack-cli": "^5.0.1"
       },
       "devDependencies": {
         "@18f/eslint-plugin-identity": "^2.0.0",
@@ -13239,11 +13238,6 @@
         "iconv-lite": "0.4.24"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -23341,11 +23335,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "concurrently": "^7.6.0",
     "identity-style-guide": "^6.5.0",
     "webpack": "^5.76.1",
-    "webpack-cli": "^5.0.1",
-    "whatwg-fetch": "^3.6.2"
+    "webpack-cli": "^5.0.1"
   }
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) polyfill and related logic.

Why?

- It's available in all supported browsers ([source](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility))
- Reduces maintenance overhead and vulnerability surface area of dependencies
- Simplifies code
- Reduces bundled JavaScript size

## 📜 Testing Plan

View preview at: https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-rm-fetch-polyfill/help/manage-your-account/international-phone-support/

```
make build
npm exec jest spec/e2e/country_support_spec.js
```