### PR TITLE
LG-9129: Add configuration for contact phone outage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ contact_maintenance_end_time: null
 
 # Unplanned outage configuration
 contact_unplanned_outage: false
+contact_unplanned_outage_phone_available: false
 
 # Used to load country code support
 idp_base_url: https://secure.login.gov

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -21,7 +21,13 @@ common_applications:
 {% if site.contact_unplanned_outage %}
   <div class="usa-alert usa-alert--warning">
     <div class="usa-alert__body">
-      <p class="usa-alert__text">{{ page.unplanned_outage_both_form_and_phone}}</p>
+      <p class="usa-alert__text">
+        {% if site.contact_unplanned_outage_phone_available %}
+          {{ page.unplanned_outage_phone_available_content }}
+        {% else %}
+          {{ page.unplanned_outage_content }}
+        {% endif %}
+      </p>
     </div>
   </div>
 {% endif %}

--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -26,8 +26,8 @@ help_center_content: >-
 
   * [Browse more help articles](/help/)
 maintenance_window_content: Login.gov’s Contact Center is currently undergoing maintenance from <strong>%{start_time} - %{end_time}.</strong> Visit some common topics below for assistance.
-unplanned_outage_content: Due to an outage, we can't review online support requests. You can call our support center anytime at (844) 875-6446.
-unplanned_outage_both_form_and_phone: Due to an outage, we can't review online support requests.
+unplanned_outage_phone_available_content: Due to an outage, we can't review online support requests. You can call our support center anytime at (844) 875-6446.
+unplanned_outage_content: Due to an outage, we can't review online support requests.
 partner_content: >-
   ## Partner with Login.gov
 

--- a/content/_policy/contact._es.md
+++ b/content/_policy/contact._es.md
@@ -26,8 +26,8 @@ help_center_content: >-
 
   * [Explorar más artículos de ayuda](/es/help/)
 maintenance_window_content: El centro de atención de Login.gov estará en mantenimiento desde <strong>%{start_time} y hasta %{end_time}</strong>. Consulte los temas comunes que aparecen a continuación para obtener ayuda.
-unplanned_outage_content: Debido a un problema técnico, no podemos revisar las solicitudes de asistencia en línea. Puede llamar a nuestro centro de asistencia en cualquier momento al (844) 875-6446.
-unplanned_outage_both_form_and_phone: Debido a un problema técnico, no podemos revisar las solicitudes de asistencia en línea.
+unplanned_outage_phone_available_content: Debido a un problema técnico, no podemos revisar las solicitudes de asistencia en línea. Puede llamar a nuestro centro de asistencia en cualquier momento al (844) 875-6446.
+unplanned_outage_content: Debido a un problema técnico, no podemos revisar las solicitudes de asistencia en línea.
 partner_content: >-
   ## Asociarse con Login.gov
 

--- a/content/_policy/contact._fr.md
+++ b/content/_policy/contact._fr.md
@@ -25,8 +25,8 @@ help_center_content: >-
 
   * [Parcourir d’autres articles d’aide](/fr/help/)
 maintenance_window_content: Le centre de contact de Login.gov est actuellement en cours de maintenance <strong>%{start_time} au %{end_time}</strong>. Consultez les sujets courants ci-dessous pour obtenir de l'aide.
-unplanned_outage_content: En raison d'une panne, nous ne pouvons pas traiter les demandes d'assistance en ligne. Vous pouvez appeler notre centre d'assistance à tout moment au (844) 875-6446
-unplanned_outage_both_form_and_phone: En raison d'une panne, nous ne pouvons pas traiter les demandes d'assistance en ligne.
+unplanned_outage_phone_available_content: En raison d'une panne, nous ne pouvons pas traiter les demandes d'assistance en ligne. Vous pouvez appeler notre centre d'assistance à tout moment au (844) 875-6446
+unplanned_outage_content: En raison d'une panne, nous ne pouvons pas traiter les demandes d'assistance en ligne.
 partner_content: >-
   ## Partenaire avec Login.gov
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-9129](https://cm-jira.usa.gov/browse/LG-9129)

## 🛠 Summary of changes

Adds a new configuration option `contact_unplanned_outage_phone_available` so that we can display the contact center phone number during an outage if it is available.

## 📜 Testing Plan

View the contact form in various states:

1. Default
2. Outage
3. Outage, phone available

Steps to test:

1. Update configuration
2. Run `make run`
3. Visit http://localhost:4000/contact/
4. If outage, warning is shown and form is hidden
5. If outage and phone available, warning content includes phone number

Update configuration:

1. Add `contact_unplanned_outage: true` and/or `contact_unplanned_outage_phone_available: true` to `_config.dev.yml`

## 📸 Screenshots

**Default:**

![localhost_4000_contact_](https://user-images.githubusercontent.com/1779930/230962108-69e91e1f-e51b-4d0c-a91d-a912ec604628.png)

**Outage:**

![localhost_4000_contact_ (1)](https://user-images.githubusercontent.com/1779930/230962117-496d3774-28b7-4e61-a282-98182ad87091.png)

**Outage with phone availalbe:**

![localhost_4000_contact_ (2)](https://user-images.githubusercontent.com/1779930/230962127-26e69c1d-0c3f-46f6-a99e-505e277884d5.png)
