### PR TITLE
LG-9311 Correct number of upload attempts from 10 to 5 for all three languages

### DIFF
--- a/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._en.md
+++ b/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._en.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 You are not required to upload a picture of yourself, or take a selfie, for identity verification. However, a [clear photo of your state-issued ID](/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/) is required for identity verification. If you’ve taken a photo that meets the requirements, try the steps below if you’re still getting an error while uploading your state-issued identification.
 
-You can make 10 attempts to upload your document. Once you’ve made 10 attempts, the system will lock you out for six hours as a security precaution.
+You can make 5 attempts to upload your document. Once you’ve made 5 attempts, the system will lock you out for six hours as a security precaution.
 
 Please contact the agency you are trying to access if the steps below do not work and you are unable to complete the identity verification process.
 

--- a/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._es.md
+++ b/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._es.md
@@ -6,7 +6,7 @@ order: 4
 ---
 No es necesario que suba una foto suya o se haga un selfie para verificar su identidad. Sin embargo, se requiere [una foto clara de su documento de identidad emitido por el estado](/es/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/). Si tomaste una foto que cumple con los requisitos, intenta los siguientes pasos si todavía recibes un error al subir tu identificación emitida por el estado.
 
-Tienes 10 intentos para subir tu documento. Una vez que realices los 10 intentos, el sistema te bloqueará durante seis horas como medida de seguridad.
+Tienes 5 intentos para subir tu documento. Una vez que realices los 5 intentos, el sistema te bloqueará durante seis horas como medida de seguridad.
 
 Si los siguientes pasos no funcionan y no puedes completar el proceso de verificación de identidad, ponte en contacto con la agencia a la que intentas acceder.
 

--- a/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._fr.md
+++ b/content/_help/verify-your-identity/troubleshoot-uploading-your-state-issued-id._fr.md
@@ -6,7 +6,7 @@ order: 4
 ---
 Vous n'êtes pas tenu de téléverser une photo de vous-même ou de prendre une autophoto pour vérifier votre identité. Toutefois, [une photo nette de votre pièce d'identité](/fr/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/) délivrée par l'État est nécessaire pour la vérification de votre identité. Si vous avez pris une photo qui répond aux exigences, essayez les étapes ci-dessous si vous obtenez toujours une erreur lors du téléchargement de votre pièce d'identité délivrée par l'État.
 
-Vous pouvez faire 10 tentatives pour télécharger votre document. Après ces 10 tentatives, le système vous bloquera pendant six heures par mesure de sécurité.
+Vous pouvez faire 5 tentatives pour télécharger votre document. Après ces 5 tentatives, le système vous bloquera pendant six heures par mesure de sécurité.
 
 Veuillez contacter l'agence à laquelle vous essayez d'accéder si les étapes ci-dessous ne fonctionnent pas et si vous ne parvenez pas à terminer le processus de vérification de l'identité.
 


### PR DESCRIPTION
## 🎫 Ticket
[LG-9311](https://cm-jira.usa.gov/browse/LG-9311)

## 🛠 Summary of changes
Update `/help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/` in all three languages to state that a user will be rate-limited after 5 attempts to upload their drivers license.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] View /help/verify-your-identity/troubleshoot-uploading-your-state-issued-id/ in all three languages and check that it shows 5 upload attempts.

## 👀 Screenshots
<details>
<summary>Before:</summary>
  
![10 attempts](https://user-images.githubusercontent.com/2381438/232914905-a16b2321-01d5-4729-8c51-92bf1e600653.png)
</details>

<details>
<summary>After:</summary>
  
![5 attempts](https://user-images.githubusercontent.com/2381438/232914920-e69116b4-16c4-4884-8133-9aa8eb759529.png)

</details>



