### PR TITLE
Upgrade Login.gov Design System to v7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ You can then view the site in your browser at http://localhost:4000 .
 
 Optionally, you can add a `_config.dev.yml` file to the root directory to list configuration which should only apply for local development. Any settings in this file will override an equivalent setting in the base Jekyll `_config.yml` configuration. For example, you may want to configure Sass `style` to `expanded` to debug the non-minified styles, or temporarily disable non-English locales to improve rebuild times.
 
-To develop locally in conjunction with [`identity-style-guide`](https://github.com/18F/identity-style-guide/), run the following commands:
-
-1. In the `identity-style-guide` directory, run `npm link`. This will create a symlink that will make changes to this repo accessible in `identity-site`.
-2. In the `identity-site` directory, run `npm link identity-style-guide`. This will use the copy from your local machine in place of the one downloaded from NPM.
-
-While developing, you may want to automatically rebuild changes made to the style guide by running `npm start` in the `identity-style-guide` directory. Changes made in your local `identity-style-guide` repository will automatically trigger the static site to build.
-
 To run specs:
 
 ```

--- a/_plugins/style_guide_assets.rb
+++ b/_plugins/style_guide_assets.rb
@@ -23,7 +23,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
   destination_fonts_dir = File.join(site.config['destination'], 'assets/fonts')
   destination_img_dir = File.join(site.config['destination'], 'assets/img')
 
-  uswds_assets_root = File.join(Dir.pwd, 'node_modules/identity-style-guide/dist/assets/')
+  uswds_assets_root = File.join(Dir.pwd, 'node_modules/@18f/identity-design-system/dist/assets/')
   origin_fonts_dir = File.join(uswds_assets_root, 'fonts')
   origin_img_dir = File.join(uswds_assets_root, 'img')
 

--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -1,17 +1,19 @@
+@use 'uswds-core' as *;
+
 $white: #fff;
-$grey-lightest: color("base-lightest");
-$grey: color("base");
-$grey-darker: color("base-darker");
-$black: color("base-darkest");
+$grey-lightest: color('base-lightest');
+$grey: color('base');
+$grey-darker: color('base-darker');
+$black: color('base-darkest');
 
-$blue: color("primary");
-$blue-light: color("primary-light");
-$blue-lighter: color("primary-lighter");
-$blue-lightest: color("primary-lightest");
-$blue-mid: color("primary-dark");
-$navy: color("primary-darker");
+$blue: color('primary');
+$blue-light: color('primary-light');
+$blue-lighter: color('primary-lighter');
+$blue-lightest: color('primary-lightest');
+$blue-mid: color('primary-dark');
+$navy: color('primary-darker');
 
-$red: color("secondary");
+$red: color('secondary');
 
-$error: color("error");
-$success: color("success");
+$error: color('error');
+$success: color('success');

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -1,13 +1,13 @@
-@import "colors";
-@import "variables";
+@forward 'colors';
+@forward 'variables';
 
-@import "mixins/all";
-@import "components/all";
+@forward 'mixins/all';
+@forward 'components/all';
 
-@import "pages/home";
-@import "pages/what_is_login";
-@import "pages/who_uses_login";
-@import "pages/create_an_account";
-@import "pages/not_found";
-@import "pages/policy";
-@import "pages/partners";
+@forward 'pages/home';
+@forward 'pages/what_is_login';
+@forward 'pages/who_uses_login';
+@forward 'pages/create_an_account';
+@forward 'pages/not_found';
+@forward 'pages/policy';
+@forward 'pages/partners';

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use 'colors' as *;
+
 $base-font-size: 16px;
 $base-font-sm: ($base-font-size - 3);
 $base-font-xs: ($base-font-size * 0.75);
@@ -9,10 +12,9 @@ $base-font-color: $grey-darker;
 
 $link-text-decoration: underline !default;
 
-$border-width: 1px !default;
 $border-color: $blue-light;
 $border-color-secondary: $blue-mid !default;
-$border-style: $border-width solid $border-color;
+$border-style: 1px solid $border-color;
 $border-radius: 8px;
 
 $icon-width: 0.8rem;
@@ -22,7 +24,7 @@ $space-1: 0.5rem !default;
 
 $bold-font-weight: bold;
 
-$container-size: "desktop-lg";
+$container-size: 'desktop-lg';
 $max-width: units($container-size);
 $max-width-sm: 368px; // used in footer .questions_addl_info
 $max-width-custom: ($max-width - 7); // 1168px

--- a/_sass/components/_alert.scss
+++ b/_sass/components/_alert.scss
@@ -1,0 +1,6 @@
+@use 'uswds-core' as *;
+
+// Upstream fix: https://github.com/uswds/uswds/pull/5187
+.usa-alert .usa-alert__body::before {
+  height: units(2);
+}

--- a/_sass/components/_already-have-an-account.scss
+++ b/_sass/components/_already-have-an-account.scss
@@ -1,33 +1,36 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+
 .one-account-banner.already-have-an-account-banner .one-account-banner__backdrop {
-    height: 22rem;
+  height: 22rem;
 
-    &::before {
-        background-image: none;
-        content: '';
+  &::before {
+    background-image: none;
+    content: '';
+  }
+
+  .one-account-banner__content {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .one-account-banner__content:nth-child(2) {
+    border-top: 1px solid $white;
+
+    @include at-media('tablet') {
+      border-left: 1px solid $white;
+      border-top: none;
+      padding-top: 0;
     }
-
-    .one-account-banner__content {
-        align-items: center;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-    }
-
-    .one-account-banner__content:nth-child(2) {
-        border-top: 1px solid $white;
-
-        @include at-media("tablet") {
-            border-left: 1px solid $white;
-            border-top: none;
-            padding-top: 0;
-        }
-    }
+  }
 }
 
-@include at-media("tablet") {
-    .one-account-banner.already-have-an-account-banner .one-account-banner__backdrop {
-        height: 11rem;
-        flex-direction: row;
-        justify-content: center;
-    }
+@include at-media('tablet') {
+  .one-account-banner.already-have-an-account-banner .one-account-banner__backdrop {
+    height: 11rem;
+    flex-direction: row;
+    justify-content: center;
+  }
 }

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -1,3 +1,8 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+@use '../mixins/all' as *;
+@use '../variables' as *;
+
 .one-account-banner,
 .partners-banner {
   background-color: $white;
@@ -25,7 +30,7 @@
 
 .one-account-banner__backdrop::before,
 .partners-banner__backdrop::before {
-  @include u-pin("all");
+  @include u-pin('all');
   opacity: 0.6;
   content: '';
 }
@@ -35,16 +40,16 @@
   background-position: -22rem -6rem;
   background-repeat: no-repeat;
   background-size: 160%;
-  @include at-media("mobile-lg") {
+  @include at-media('mobile-lg') {
     background-size: 120%;
   }
 
-  @include at-media("tablet") {
+  @include at-media('tablet') {
     background-size: 90%;
     opacity: 0.9;
   }
 
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     background-size: 70%;
   }
 }
@@ -53,16 +58,16 @@
   background-image: url(../img/partners/banners/partners-login.svg);
   background-repeat: no-repeat;
   background-position: -6rem -6rem;
-  @include at-media("card") {
+  @include at-media('card') {
     background-size: 70%;
   }
 
-  @include at-media("tablet") {
+  @include at-media('tablet') {
     background-size: 40%;
     opacity: 0.9;
   }
 
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     background-size: 30%;
   }
 }

--- a/_sass/components/_box-info.scss
+++ b/_sass/components/_box-info.scss
@@ -1,17 +1,20 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+@use '../variables' as *;
+
 .box {
   background: $blue-lightest;
   border-radius: $border-radius;
   letter-spacing: $base-letter-spacing;
   line-height: $line-height;
-  padding: $container-spacing-sm ($container-spacing * 0.5) $container-spacing
-    $container-spacing;
+  padding: $container-spacing-sm ($container-spacing * 0.5) $container-spacing $container-spacing;
 
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     margin: 0 0 ($container-spacing-sm * 2) ($container-spacing-sm * -2);
   }
 
   &::before {
-    content: "";
+    content: '';
     background: url(../img/alerts/info.svg) no-repeat;
     background-size: 26px;
     position: absolute;
@@ -20,7 +23,7 @@
     height: $container-spacing-sm;
     width: 2rem;
 
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       left: $container-spacing-sm * -0.5;
     }
   }

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -1,31 +1,35 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+@use '../variables' as *;
+
 .card {
   width: 100%;
   padding-bottom: ($container-spacing-sm * 2);
 
-  @include at-media("tablet-lg") {
+  @include at-media('tablet-lg') {
     width: 50%;
     padding-left: $container-spacing-sm;
   }
 
-  img { 
+  img {
     background-color: $white;
-    
-    @include at-media("tablet-lg") {
+
+    @include at-media('tablet-lg') {
       max-width: none;
-   }
+    }
   }
 
   h2 {
     margin-top: 0;
     font-size: 1.125rem;
     line-height: 24px;
-    
-    @include at-media("tablet-lg") {
+
+    @include at-media('tablet-lg') {
       font-size: 1.375rem;
       line-height: $line-height;
     }
   }
-  
+
   a {
     text-decoration: underline;
     text-underline-position: under;

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 .footer {
   background-color: color('primary-lightest');
 }

--- a/_sass/components/_form.scss
+++ b/_sass/components/_form.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+
 .usa-form {
   max-width: none;
 }
@@ -7,7 +10,7 @@
 }
 
 .usa-label.text-normal {
-  @include u-text("normal");
+  @include u-text('normal');
 }
 
 .usa-input,
@@ -16,28 +19,24 @@
 .usa-select,
 .usa-combo-box__input,
 .usa-range {
-  margin-top: units(.5);
+  margin-top: units(0.5);
 }
 
-[type="search"],
+[type='search'],
 .usa-search__input {
   margin-top: 0;
 }
 
 .usa-hint {
-  @include typeset(
-    $theme-form-font-family,
-    $theme-body-font-size,
-    $theme-body-line-height
-  );
+  @include typeset($theme-form-font-family, $theme-body-font-size, $theme-body-line-height);
   color: $grey;
   margin-bottom: units(2);
-  margin-top: units(.5);
+  margin-top: units(0.5);
   max-width: units($theme-input-max-width);
 }
 
 .form-actions {
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     @include u-margin-y(8);
   }
 }

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -1,3 +1,5 @@
+@use '../variables' as *;
+
 header {
   &.intro {
     border-bottom: $border-style;
@@ -7,9 +9,10 @@ header {
   }
 }
 
-.usa-banner__header-text, .usa-banner__button-text {
-  font-size: .75rem;
-  line-height: 1.5em
+.usa-banner__header-text,
+.usa-banner__button-text {
+  font-size: 0.75rem;
+  line-height: 1.5em;
 }
 
 .create-account-btn-link {

--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -1,3 +1,7 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+@use '../variables' as *;
+
 .hero {
   background-color: $navy;
   color: $white;
@@ -13,9 +17,9 @@
 
   .hero__title {
     font-size: 1.875rem; // 30px
-    line-height: 1.375em;  // 22px
+    line-height: 1.375em; // 22px
 
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       font-size: 2.5rem; // 40px
     }
   }
@@ -24,7 +28,7 @@
     font-size: 1.125rem; // 18px
     line-height: $line-height;
 
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       font-size: 1.25rem; // 20px
     }
   }
@@ -41,38 +45,38 @@
 
 .hero {
   padding: 0;
-  @include at-media("tablet") {
+  @include at-media('tablet') {
     height: 16rem;
   }
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     height: 20rem;
   }
-  
+
   > .container {
     height: 100%;
     background-repeat: no-repeat;
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       background-image: url(../img/header@2x.png);
       background-position: 100% 50%;
       background-size: 650px;
     }
   }
-  
+
   &.partners {
-    @include at-media("tablet") {
-    background: no-repeat url(../img/partners/heroes/partners-hero.svg) 80% / 100% ;
-    background-size: 30%;
+    @include at-media('tablet') {
+      background: no-repeat url(../img/partners/heroes/partners-hero.svg) 80% / 100%;
+      background-size: 30%;
       > .container {
         background: none;
       }
     }
-    
-    @include at-media("desktop") {
-    height: 28rem;
+
+    @include at-media('desktop') {
+      height: 28rem;
     }
   }
 
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     &.what-is-login {
       > .container {
         line-height: 1.375em;
@@ -81,7 +85,7 @@
         background-size: 45%;
       }
     }
-    
+
     &.who-uses-login {
       background-image: url(../img/who-uses-login/who-uses-illo-header/who-uses-illo-header@2x.png);
       background-position: right center;

--- a/_sass/components/_language-picker.scss
+++ b/_sass/components/_language-picker.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 .language-picker {
   position: relative;
   width: auto;
@@ -6,7 +9,7 @@
     @include u-bg('primary-lightest');
     @include u-border(1px, 'primary-light');
     @include u-radius($theme-button-border-radius);
-    margin: .25rem 0 0;
+    margin: 0.25rem 0 0;
     overflow: visible;
     padding: 0;
     position: absolute;
@@ -38,17 +41,17 @@
   padding: units(1.5);
   padding-right: units(3);
 
-  &.usa-accordion__button[aria-expanded="false"],
-  &.usa-accordion__button[aria-expanded="true"] {
-    background-size: .8125rem;
+  &.usa-accordion__button[aria-expanded='false'],
+  &.usa-accordion__button[aria-expanded='true'] {
+    background-size: 0.8125rem;
   }
 
-  &.usa-accordion__button[aria-expanded="false"] {
-    background-image: url(../img/angle-arrow-down-primary.svg);
+  &.usa-accordion__button[aria-expanded='false'] {
+    background-image: url(../img/angle-arrow-down.svg);
   }
 
-  &.usa-accordion__button[aria-expanded="true"] {
-    background-image: url(../img/angle-arrow-up-primary.svg);
+  &.usa-accordion__button[aria-expanded='true'] {
+    background-image: url(../img/angle-arrow-up.svg);
   }
 }
 

--- a/_sass/components/_layout.scss
+++ b/_sass/components/_layout.scss
@@ -1,3 +1,7 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+@use '../mixins/all' as *;
+
 main {
   background: white;
 }

--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -42,7 +42,11 @@ ol.number-list,
 ul.help-question-list {
   list-style-type: none;
   margin-left: 0;
-  padding-left: 0;
+
+  &,
+  .page-content__prose & {
+    padding-left: 0;
+  }
 
   > li {
     @include u-margin-y(1);

--- a/_sass/components/_list.scss
+++ b/_sass/components/_list.scss
@@ -1,4 +1,7 @@
+@use 'uswds-core' as *;
 @use 'sass:math';
+@use '../colors' as *;
+@use '../variables' as *;
 
 .list {
   @include usa-link-style;

--- a/_sass/components/_nav-secondary.scss
+++ b/_sass/components/_nav-secondary.scss
@@ -1,3 +1,6 @@
+@use '../colors' as *;
+@use '../variables' as *;
+
 .nav-secondary {
   color: red;
 
@@ -21,7 +24,7 @@
         border-left: $triangle-size solid transparent;
         border-right: $triangle-size solid transparent;
         bottom: 0;
-        content: "";
+        content: '';
         left: 50%;
         margin-left: -$triangle-size;
         padding-top: 0.4rem;

--- a/_sass/components/_nav.scss
+++ b/_sass/components/_nav.scss
@@ -1,3 +1,7 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+@use '../variables' as *;
+
 .top-navigation,
 .language-search,
 .login-developers-links {
@@ -155,7 +159,7 @@
   .usa-header--extended .usa-navbar.partners-navbar {
     max-width: 100%;
   }
-  
+
   .usa-nav__primary-item + .usa-nav__primary-item {
     margin-left: 1.5rem;
   }

--- a/_sass/components/_sticky-table.scss
+++ b/_sass/components/_sticky-table.scss
@@ -1,3 +1,5 @@
+@use '../colors' as *;
+
 .usa-table--sticky-header {
   position: relative;
 

--- a/_sass/components/_svg.scss
+++ b/_sass/components/_svg.scss
@@ -1,3 +1,6 @@
+@use '../colors' as *;
+@use '../variables' as *;
+
 .svg-wrapper {
   svg {
     height: $icon-width;

--- a/_sass/components/_typography.scss
+++ b/_sass/components/_typography.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 html {
   font-size: $base-font-size;
 }
@@ -23,14 +26,16 @@ article p {
     line-height: $line-height;
   }
 
-  p, ol, ul {
+  p,
+  ol,
+  ul {
     // TODO: Remove this once we assign `$theme-body-line-height` design system variable.
     line-height: $line-height;
 
     // TODO: Consider respecting or customizing `$theme-text-measure` design system variable.
     max-width: none;
 
-    li  {
+    li {
       ul {
         list-style-type: '⁃  ';
         margin-top: 0.25rem;

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -1,26 +1,27 @@
-@import "site";
-@import "footer";
-@import "form";
-@import "header";
-@import "language-picker";
-@import "list";
-@import "banner";
-@import "already-have-an-account";
-@import "nav";
-@import "hero";
+@forward 'alert';
+@forward 'site';
+@forward 'footer';
+@forward 'form';
+@forward 'header';
+@forward 'language-picker';
+@forward 'list';
+@forward 'banner';
+@forward 'already-have-an-account';
+@forward 'nav';
+@forward 'hero';
 
-@import "partners/hero";
-@import "partners/checklist";
-@import "partners/partners";
+@forward 'partners/hero';
+@forward 'partners/checklist';
+@forward 'partners/partners';
 
-@import "typography";
-@import "svg";
+@forward 'typography';
+@forward 'svg';
 
-@import "nav-secondary";
-@import "nav-sidenav";
-@import "skip-nav";
-@import "layout";
-@import "box-info";
-@import "card";
+@forward 'nav-secondary';
+@forward 'nav-sidenav';
+@forward 'skip-nav';
+@forward 'layout';
+@forward 'box-info';
+@forward 'card';
 
-@import "sticky-table";
+@forward 'sticky-table';

--- a/_sass/components/partners/_checklist.scss
+++ b/_sass/components/partners/_checklist.scss
@@ -1,3 +1,5 @@
+@use 'uswds-core' as *;
+
 .container.is-login-for-you {
   @include usa-link-style;
   text-align: left;

--- a/_sass/components/partners/_hero.scss
+++ b/_sass/components/partners/_hero.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../../variables' as *;
+
 .partners-hero {
   padding-top: $container-spacing-sm;
   padding-bottom: $container-spacing-sm;
@@ -11,20 +14,20 @@
   .hero__title {
     font-size: 1.875rem;
     line-height: 1.375em;
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       font-size: 2.5rem;
     }
   }
   .hero__description {
     font-size: 1.125rem;
     line-height: $line-height;
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       font-size: 1.25rem;
     }
   }
 }
 
-@include at-media("desktop") {
+@include at-media('desktop') {
   .partners-hero {
     height: 20rem;
     padding: 0;

--- a/_sass/components/partners/_partners.scss
+++ b/_sass/components/partners/_partners.scss
@@ -1,103 +1,106 @@
 // Shared styles that are unique to the Partner site redesign
 
+@use 'uswds-core' as *;
+@use '../../variables' as *;
+
 .partners-container {
-    padding-bottom: 4rem;
-    padding-top: 2rem;
+  padding-bottom: 4rem;
+  padding-top: 2rem;
 }
 
 .partners-title {
-    font-size: 2.5em;
+  font-size: 2.5em;
 }
 
 .partners-border {
-    border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid $border-color;
 }
 
 .partners-body {
-    max-width: 640px;
-    line-height: 1.5em;
-    h4 {
-        font-size: 1.125em;
-    }
+  max-width: 640px;
+  line-height: 1.5em;
+  h4 {
+    font-size: 1.125em;
+  }
 }
 
 .partners-body--wide {
-    max-width: 880px;
+  max-width: 880px;
 }
 
 .external-link {
-    background: url(../img/partners/external-link.svg) no-repeat center right;
-    padding-right: 10px;
-    color:  #0071BB;
+  background: url(../img/partners/external-link.svg) no-repeat center right;
+  padding-right: 10px;
+  color: #0071bb;
 }
 
 .thumbs-up {
-    padding-left: 2.75rem;
-    background: url(../img/partners/thumbs-up.svg) no-repeat top 12px left;
+  padding-left: 2.75rem;
+  background: url(../img/partners/thumbs-up.svg) no-repeat top 12px left;
 }
 
 .partners-subtitle {
-    max-width: 880px;
-    line-height: 1.5em;
-    font-size: 1.25em;
+  max-width: 880px;
+  line-height: 1.5em;
+  font-size: 1.25em;
 }
 
 .caret {
-    background: url(../img/partners/caret.svg) no-repeat center right;
-    padding-right: 15px;
-    color:  #0071BB;
+  background: url(../img/partners/caret.svg) no-repeat center right;
+  padding-right: 15px;
+  color: #0071bb;
 }
 
 #security-experience-container {
-    @include at-media("tablet") {
-        background: url(../img/partners/security-experience.svg) no-repeat top 14% right 7%;
-        background-size: 35%;
-    }
+  @include at-media('tablet') {
+    background: url(../img/partners/security-experience.svg) no-repeat top 14% right 7%;
+    background-size: 35%;
+  }
 }
 
 .security-list {
-    font-size: 1rem;
-    line-height: 1.5em;
+  font-size: 1rem;
+  line-height: 1.5em;
 }
 
 .usa-accordion__heading p {
-    margin: 0px;
+  margin: 0px;
 }
 
 .accordion-container {
-    padding-right: 5%;
+  padding-right: 5%;
 }
 
 .section-title-right {
-    float: right;
-    margin-top: 20px;
+  float: right;
+  margin-top: 20px;
 }
 
 .section-title-left {
-    float: left;
+  float: left;
 }
 
 .partners-blue-box {
-    border-radius: 25px;
-    background: #205493;
-    color: white;
-    height: 100%;
-    padding-left: 20px;
-    padding-right: 20px;
-    padding-top: 30px;
-    padding-bottom: 30px;
+  border-radius: 25px;
+  background: #205493;
+  color: white;
+  height: 100%;
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 30px;
+  padding-bottom: 30px;
 }
 
 .usa-process-list > .usa-process-list__item {
-    max-width: 100% !important; // Hate this, but USWDS sets a max-width of 72px
+  max-width: 100% !important; // Hate this, but USWDS sets a max-width of 72px
 }
 
 .usa-accordion__heading h4 {
-    font-size: $base-font-size;
+  font-size: $base-font-size;
 }
 
 .partners-usa-button--active {
-    color: #112e51 !important;
-    background-color:rgba(0, 0, 0, 0) !important;
-    box-shadow: inset 0 0 0 1px #112e51 !important;
+  color: #112e51 !important;
+  background-color: rgba(0, 0, 0, 0) !important;
+  box-shadow: inset 0 0 0 1px #112e51 !important;
 }

--- a/_sass/mixins/all.scss
+++ b/_sass/mixins/all.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 /// Mixin to prefix a property
 /// @author Hugo Giraudel
 /// @param {String} $property - Property name
@@ -25,7 +28,7 @@
     padding-left: $container-spacing-sm;
     padding-right: $container-spacing-sm;
 
-    @include at-media("desktop") {
+    @include at-media('desktop') {
       padding-left: $container-spacing;
       padding-right: $container-spacing;
     }

--- a/_sass/pages/_create_an_account.scss
+++ b/_sass/pages/_create_an_account.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 .create-an-account {
   padding-top: $container-spacing;
   padding-bottom: $container-spacing;
@@ -25,7 +28,7 @@
   }
 }
 
-@include at-media("tablet") {
+@include at-media('tablet') {
   .create-an-account {
     line-height: 1.875rem;
     .step {

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -1,3 +1,5 @@
+@use 'uswds-core' as *;
+
 .container.why-login-gov {
   @include usa-link-style;
   text-align: left;
@@ -6,18 +8,15 @@
 
   .hdr {
     &.individuals {
-      background: url(../img/homepage/icon-individuals/icon-individuals.svg) -0.4rem
-        center no-repeat;
+      background: url(../img/homepage/icon-individuals/icon-individuals.svg) -0.4rem center no-repeat;
     }
 
     &.partners {
-      background: url(../img/homepage/icon-partner/icon-partners.svg) -0.4rem center
-        no-repeat;
+      background: url(../img/homepage/icon-partner/icon-partners.svg) -0.4rem center no-repeat;
     }
 
     &.developers {
-      background: url(../img/homepage/icon-developers/icon-developers.svg) -0.4rem
-        center no-repeat;
+      background: url(../img/homepage/icon-developers/icon-developers.svg) -0.4rem center no-repeat;
     }
   }
 
@@ -26,7 +25,7 @@
     position: relative;
 
     &::after {
-      content: "";
+      content: '';
       display: inline-block;
       background: url(../img/caret-right.svg) left center no-repeat;
       font-size: 1.5rem;
@@ -43,7 +42,7 @@
   }
 }
 
-@include at-media-max("desktop") {
+@include at-media-max('desktop') {
   .container.why-login-gov {
     .tablet\:grid-col {
       + .tablet\:grid-col {

--- a/_sass/pages/_partners.scss
+++ b/_sass/pages/_partners.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../colors' as *;
+
 .login-developers-links {
   & span {
     padding-bottom: 0;
@@ -14,7 +17,7 @@
 
 .partners-actions {
   display: block;
-  @include at-media("card") {
+  @include at-media('card') {
     & a {
       width: 100%;
       &:first-child {
@@ -22,7 +25,7 @@
       }
     }
   }
-  @include at-media("desktop") {
+  @include at-media('desktop') {
     position: absolute;
     bottom: 1rem;
     right: 0;
@@ -47,18 +50,15 @@
   .hdr {
     padding: 0.75rem 0 0.75rem 2.75rem;
     &.authentication {
-      background: url(../img/partners/partners-authentication.svg) -0.2rem
-      center no-repeat;
+      background: url(../img/partners/partners-authentication.svg) -0.2rem center no-repeat;
     }
 
     &.identity {
-      background: url(../img/partners/partners-identity.svg) -0.2rem center
-      no-repeat;
+      background: url(../img/partners/partners-identity.svg) -0.2rem center no-repeat;
     }
 
     &.multilingual {
-      background: url(../img/partners/partners-multilingual.svg) -0.2rem
-      center no-repeat;
+      background: url(../img/partners/partners-multilingual.svg) -0.2rem center no-repeat;
     }
   }
 
@@ -127,7 +127,7 @@
   }
 }
 
-@include at-media-max("desktop") {
+@include at-media-max('desktop') {
   .container.partners {
     .tablet\:grid-col {
       + .tablet\:grid-col {

--- a/_sass/pages/_policy.scss
+++ b/_sass/pages/_policy.scss
@@ -1,3 +1,5 @@
+@use '../colors' as *;
+
 nav.policy {
   li {
     border-left: 0;
@@ -28,7 +30,7 @@ nav.policy {
 
   h2 {
     &::after {
-      content: "";
+      content: '';
       display: block;
       height: 1rem;
       width: 4rem;
@@ -73,7 +75,7 @@ nav.policy {
     list-style-type: none;
 
     li:before {
-      content: "";
+      content: '';
       display: inline-block;
       height: 2px;
       width: 5px;

--- a/_sass/pages/_what_is_login.scss
+++ b/_sass/pages/_what_is_login.scss
@@ -1,3 +1,6 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 .container.what-is-login {
   .one-account,
   .secure-account-container,
@@ -14,8 +17,8 @@
     display: block;
 
     &.one-account-img {
-      background: url(../img/what-is-login/one-account/what-is-one-account.png)
-        center center/contain no-repeat;
+      background: url(../img/what-is-login/one-account/what-is-one-account.png) center
+        center/contain no-repeat;
       height: 17rem;
     }
   }
@@ -35,7 +38,7 @@
   }
 }
 
-@include at-media("tablet") {
+@include at-media('tablet') {
   .container.what-is-login {
     .secure-account-container {
       padding: 2rem 0;

--- a/_sass/pages/_who_uses_login.scss
+++ b/_sass/pages/_who_uses_login.scss
@@ -1,13 +1,16 @@
+@use 'uswds-core' as *;
+@use '../variables' as *;
+
 #our-partners {
   line-height: $line-height;
 }
 
 .container.who-uses-login {
-  line-height: 1.875rem; 
+  line-height: 1.875rem;
 
   .partners {
-    background: url(../img/who-uses-login/who-uses-illo-partners/who-uses-illo-partners.svg)
-      left center no-repeat;
+    background: url(../img/who-uses-login/who-uses-illo-partners/who-uses-illo-partners.svg) left
+      center no-repeat;
     padding: 3rem 0 3rem 40%;
   }
 
@@ -22,14 +25,12 @@
       line-height: $line-height;
 
       &:first-child {
-        background: url(../img/who-uses-login/icon-shield/icon-shield.svg) left
-          top no-repeat;
+        background: url(../img/who-uses-login/icon-shield/icon-shield.svg) left top no-repeat;
         padding: 0 2rem 0 3rem;
       }
 
       &:last-child {
-        background: url(../img/homepage/icon-partner/icon-partners.svg) 0.4rem -0.5rem
-          no-repeat;
+        background: url(../img/homepage/icon-partner/icon-partners.svg) 0.4rem -0.5rem no-repeat;
         border-left: $border-style;
         margin-left: -0.75rem;
         padding: 0 2rem 0 4rem;
@@ -47,7 +48,7 @@
   margin-bottom: 5rem;
 }
 
-@include at-media-max("desktop") {
+@include at-media-max('desktop') {
   .container.who-uses-login {
     h2 {
       margin-top: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-import { accordion, banner, comboBox, datePicker, navigation } from 'identity-style-guide';
+import { accordion, banner, comboBox, datePicker, header } from '@18f/identity-design-system';
 
-const components = [accordion, banner, comboBox, datePicker, navigation];
+const components = [accordion, banner, comboBox, datePicker, header];
 components.forEach((component) => component.on());

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -1,2 +1,8 @@
-@import "identity-style-guide/dist/assets/scss/styles";
-@import "../../_sass"
+@use 'uswds-core' with (
+  $theme-utility-breakpoints: (
+    'tablet': true,
+    'desktop': true
+  )
+);
+@forward 'uswds';
+@forward '../../_sass';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@18f/identity-build-sass": "^1.0.0",
+        "@18f/identity-build-sass": "^1.1.0",
+        "@18f/identity-design-system": "^7.0.0",
         "@babel/core": "^7.12.9",
         "@babel/preset-env": "^7.12.7",
         "@babel/preset-typescript": "^7.18.6",
         "babel-loader": "^8.2.4",
         "concurrently": "^7.6.0",
         "core-js": "^3.29.1",
-        "identity-style-guide": "^6.5.0",
         "webpack": "^5.76.1",
         "webpack-cli": "^5.0.1"
       },
@@ -92,17 +92,29 @@
       }
     },
     "node_modules/@18f/identity-build-sass": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-1.0.0.tgz",
-      "integrity": "sha512-GfyJSuLiOnN5FFFPK6pTjal7Dal6jRj0K1V2oEIDDd6yQVK9HW+O2q9DGPOwfQLuNPnRr/8LM4mQeGrpD7AJxg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-1.1.0.tgz",
+      "integrity": "sha512-nJeNQB+8tiQsvc6oh7UON1EsRK1MTuc9n5bMS9MIS2Mxa6mKkZDSGBdSR2TINAEdgQLlLlDOziRNTez4Um29jg==",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.21.5",
         "chokidar": "^3.5.3",
         "lightningcss": "^1.16.1",
         "sass-embedded": "^1.56.1"
       },
       "bin": {
         "build-sass": "cli.js"
+      }
+    },
+    "node_modules/@18f/identity-design-system": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.0.tgz",
+      "integrity": "sha512-rLw1oTK7qzGw+A2B7gYLjEOqX49MOkbe/yyK3M8e+DXpqFOxU1/GjxVzVOr/RuyzhsOeoIT+//xaqPr4dxZA5Q==",
+      "dependencies": {
+        "@uswds/uswds": "^3.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">6"
       }
     },
     "node_modules/@axe-core/puppeteer": {
@@ -2380,9 +2392,9 @@
       }
     },
     "node_modules/@types/jest/node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2722,9 +2734,9 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2917,9 +2929,9 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2958,9 +2970,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2990,12 +3002,29 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@uswds/uswds": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "dependencies": {
+        "classlist-polyfill": "1.0.3",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -3878,9 +3907,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -3892,10 +3921,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4058,9 +4087,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001434",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4069,6 +4098,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -4208,23 +4241,23 @@
       ]
     },
     "node_modules/cheerio-select/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dev": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/cheerio-select/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -4260,23 +4293,23 @@
       ]
     },
     "node_modules/cheerio/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dev": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/cheerio/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -4286,9 +4319,9 @@
       }
     },
     "node_modules/cheerio/node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -4299,9 +4332,9 @@
       ],
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "node_modules/cheerio/node_modules/parse5": {
@@ -4689,9 +4722,9 @@
       }
     },
     "node_modules/concurrently/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -5280,11 +5313,6 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ]
-    },
-    "node_modules/domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -6005,9 +6033,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -6015,15 +6043,21 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/estraverse": {
@@ -6162,12 +6196,15 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -7425,19 +7462,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/identity-style-guide": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.5.0.tgz",
-      "integrity": "sha512-P/ZsOodZn3XyX6LYgrtDKzWe447rPkTUxAYADIGAcl13wv7ghQZJjaL1g1PySzG5PAvxeeoyOJYfRW58NRMUCw==",
-      "dependencies": {
-        "domready": "1.0.8",
-        "uswds": "^2.13.3"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">6"
       }
     },
     "node_modules/ieee754": {
@@ -8764,9 +8788,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -9705,9 +9729,9 @@
       }
     },
     "node_modules/meow/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -10020,9 +10044,9 @@
       }
     },
     "node_modules/node-notifier/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -10052,9 +10076,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -10444,9 +10468,9 @@
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -11124,11 +11148,11 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -12470,9 +12494,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+      "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -12913,21 +12937,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
-      "dependencies": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
-        "object-assign": "4.1.1",
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13211,9 +13220,9 @@
       }
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+      "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -13520,14 +13529,22 @@
       }
     },
     "@18f/identity-build-sass": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-1.0.0.tgz",
-      "integrity": "sha512-GfyJSuLiOnN5FFFPK6pTjal7Dal6jRj0K1V2oEIDDd6yQVK9HW+O2q9DGPOwfQLuNPnRr/8LM4mQeGrpD7AJxg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-build-sass/-/identity-build-sass-1.1.0.tgz",
+      "integrity": "sha512-nJeNQB+8tiQsvc6oh7UON1EsRK1MTuc9n5bMS9MIS2Mxa6mKkZDSGBdSR2TINAEdgQLlLlDOziRNTez4Um29jg==",
       "requires": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.21.5",
         "chokidar": "^3.5.3",
         "lightningcss": "^1.16.1",
         "sass-embedded": "^1.56.1"
+      }
+    },
+    "@18f/identity-design-system": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.0.tgz",
+      "integrity": "sha512-rLw1oTK7qzGw+A2B7gYLjEOqX49MOkbe/yyK3M8e+DXpqFOxU1/GjxVzVOr/RuyzhsOeoIT+//xaqPr4dxZA5Q==",
+      "requires": {
+        "@uswds/uswds": "^3.4.1"
       }
     },
     "@axe-core/puppeteer": {
@@ -15318,9 +15335,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.22",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "version": "17.0.24",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+          "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -15584,9 +15601,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -15699,9 +15716,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -15726,9 +15743,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -15747,11 +15764,22 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
           "dev": true
         }
+      }
+    },
+    "@uswds/uswds": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "requires": {
+        "classlist-polyfill": "1.0.3",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -16440,14 +16468,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       }
     },
     "bser": {
@@ -16556,9 +16584,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001434",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -16632,32 +16660,32 @@
           "dev": true
         },
         "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
           "dev": true,
           "requires": {
             "dom-serializer": "^2.0.0",
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
+            "domhandler": "^5.0.3"
           }
         },
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
           "dev": true
         },
         "htmlparser2": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-          "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
           "dev": true,
           "requires": {
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
+            "domhandler": "^5.0.3",
             "domutils": "^3.0.1",
-            "entities": "^4.3.0"
+            "entities": "^4.4.0"
           }
         },
         "parse5": {
@@ -16716,20 +16744,20 @@
           "dev": true
         },
         "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
           "dev": true,
           "requires": {
             "dom-serializer": "^2.0.0",
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
+            "domhandler": "^5.0.3"
           }
         },
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
           "dev": true
         }
       }
@@ -17021,9 +17049,9 @@
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -17473,11 +17501,6 @@
         }
       }
     },
-    "domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
-    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -17749,9 +17772,9 @@
           "dev": true
         },
         "eslint-scope": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+          "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -17759,9 +17782,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
           "dev": true
         },
         "estraverse": {
@@ -18131,9 +18154,9 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
           "dev": true
         }
       }
@@ -19087,15 +19110,6 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "identity-style-guide": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.5.0.tgz",
-      "integrity": "sha512-P/ZsOodZn3XyX6LYgrtDKzWe447rPkTUxAYADIGAcl13wv7ghQZJjaL1g1PySzG5PAvxeeoyOJYfRW58NRMUCw==",
-      "requires": {
-        "domready": "1.0.8",
-        "uswds": "^2.13.3"
       }
     },
     "ieee754": {
@@ -20104,9 +20118,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -20712,9 +20726,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -20971,9 +20985,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -20993,9 +21007,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -21284,9 +21298,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
           "dev": true
         },
         "parse5": {
@@ -21794,11 +21808,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -22770,9 +22784,9 @@
           }
         },
         "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+          "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
           "requires": {
             "@types/json-schema": "^7.0.8",
             "ajv": "^6.12.5",
@@ -23102,18 +23116,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
-      "requires": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
-        "object-assign": "4.1.1",
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -23236,9 +23238,9 @@
       },
       "dependencies": {
         "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+          "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
           "requires": {
             "@types/json-schema": "^7.0.8",
             "ajv": "^6.12.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "login.gov static site",
   "scripts": {
     "prebuild:css": "mkdir -p _site/assets/css",
-    "build:css": "build-sass assets/scss/*.scss --out-dir=_site/assets/css",
+    "build:css": "build-sass assets/scss/*.scss --load-path=node_modules/@18f/identity-design-system/packages --out-dir=_site/assets/css",
     "watch:css": "npm run build:css -- --watch",
     "build:js": "webpack --config webpack.config.js",
     "watch:js": "webpack -w --config webpack.config.js",
@@ -57,14 +57,14 @@
     "vnu-jar": "^21.10.12"
   },
   "dependencies": {
-    "@18f/identity-build-sass": "^1.0.0",
+    "@18f/identity-build-sass": "^1.1.0",
+    "@18f/identity-design-system": "^7.0.0",
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-typescript": "^7.18.6",
     "babel-loader": "^8.2.4",
     "concurrently": "^7.6.0",
     "core-js": "^3.29.1",
-    "identity-style-guide": "^6.5.0",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1"
   }

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe '_site' do
       .png
       .svg
       .ttf
+      .webp
       .woff
       .woff2
       .xml


### PR DESCRIPTION
## 🛠 Summary of changes

Upgrades the version of the Login.gov Design System from 6.7.0 to 7.0.0.

Primarily, this involves:

- Upgrading USWDS v2 to v3
- Migrating Sass syntax to new Dart-based `@use` & `@forward`

Recommend reviewing with whitespace changes hidden: [`pull/1071/files?w=1`](https://github.com/18F/identity-site/pull/1071/files?w=1). Unfortunately a fair bit of diff noise because Prettier formatting was applied. This should be enforced in a future pull request using [`@18f/identity-stylelint-config`](https://www.npmjs.com/package/@18f/identity-stylelint-config).

## 📜 Testing Plan

1. Compare preview site to live site (including partner subsite and help center)
   - Preview: https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-lgds-7/
   - Live: https://login.gov/