### PR TITLE
[LG-9385] 508 - The structure of information cannot be understood by assistive technology

### DIFF
--- a/_includes/components/2-col.html
+++ b/_includes/components/2-col.html
@@ -1,4 +1,4 @@
-<div class="container {{ include.class }} page-content__prose">
+<div class="container container--mod {{ include.class }} page-content__prose">
   <div class="one-account page-content__prose tablet:grid-row">
     <div class="tablet:grid-col-6 pad-left-element">
       <img

--- a/_includes/components/2-col.html
+++ b/_includes/components/2-col.html
@@ -1,4 +1,4 @@
-<div class="container {{ include.class }} page-content__prose">
+<article class="container {{ include.class }} page-content__prose">
   <div class="one-account page-content__prose tablet:grid-row">
     <div class="tablet:grid-col-6 pad-left-element">
       <img
@@ -51,4 +51,4 @@
     </div>
   </div>
 
-</div>
+</article>

--- a/_includes/components/2-col.html
+++ b/_includes/components/2-col.html
@@ -1,4 +1,4 @@
-<article class="container {{ include.class }} page-content__prose">
+<div class="container {{ include.class }} page-content__prose">
   <div class="one-account page-content__prose tablet:grid-row">
     <div class="tablet:grid-col-6 pad-left-element">
       <img
@@ -51,4 +51,4 @@
     </div>
   </div>
 
-</article>
+</div>

--- a/_includes/components/3-col.html
+++ b/_includes/components/3-col.html
@@ -1,4 +1,4 @@
-<article class="container {{ include.class }}">
+<div class="container {{ include.class }}">
     <header class="intro"><h2>{{ include.heading }}</h2></header>
     <div class="grid-row">
       <div class="tablet:grid-col">
@@ -14,5 +14,5 @@
         {{ include.col3 | markdownify }}
       </div>
     </div>
-  </article>
+  </div>
 

--- a/_includes/components/3-col.html
+++ b/_includes/components/3-col.html
@@ -1,4 +1,4 @@
-<div class="container {{ include.class }}">
+<article class="container {{ include.class }}">
     <header class="intro"><h2>{{ include.heading }}</h2></header>
     <div class="grid-row">
       <div class="tablet:grid-col">
@@ -14,5 +14,5 @@
         {{ include.col3 | markdownify }}
       </div>
     </div>
-  </div>
+  </article>
 

--- a/_includes/components/3-col.html
+++ b/_includes/components/3-col.html
@@ -1,4 +1,4 @@
-<div class="container {{ include.class }}">
+<div class="container container--mod {{ include.class }}">
     <header class="intro"><h2>{{ include.heading }}</h2></header>
     <div class="grid-row">
       <div class="tablet:grid-col">

--- a/_includes/components/create-an-account.html
+++ b/_includes/components/create-an-account.html
@@ -1,7 +1,7 @@
 <div class="{{ include.class }}">
     <div class="container">
       <div class="grid-row">
-        <div class="desktop:grid-col-7">
+        <div class="container--mod desktop:grid-col-7">
           <header class="intro">
             {{include.intro | markdownify }}
           </header>

--- a/_includes/components/create-an-account.html
+++ b/_includes/components/create-an-account.html
@@ -1,7 +1,7 @@
 <div class="{{ include.class }}">
     <div class="container">
       <div class="grid-row">
-        <div class="desktop:grid-col-7">
+        <article class="desktop:grid-col-7">
           <header class="intro">
             {{include.intro | markdownify }}
           </header>
@@ -17,7 +17,7 @@
             {{ include.step3 | markdownify }}
             <div class="mobile step-3-img"></div>
           </div>
-        </div>
+        </article>
         <div class="sidebar desktop:grid-col-4 desktop:grid-offset-1 desktop-lg:grid-col-3 desktop-lg:grid-offset-2">
           <div class="box">
             {{ include.info | markdownify }}

--- a/_includes/components/create-an-account.html
+++ b/_includes/components/create-an-account.html
@@ -1,7 +1,7 @@
 <div class="{{ include.class }}">
     <div class="container">
       <div class="grid-row">
-        <article class="desktop:grid-col-7">
+        <div class="desktop:grid-col-7">
           <header class="intro">
             {{include.intro | markdownify }}
           </header>
@@ -17,7 +17,7 @@
             {{ include.step3 | markdownify }}
             <div class="mobile step-3-img"></div>
           </div>
-        </article>
+        </div>
         <div class="sidebar desktop:grid-col-4 desktop:grid-offset-1 desktop-lg:grid-col-3 desktop-lg:grid-offset-2">
           <div class="box">
             {{ include.info | markdownify }}

--- a/_includes/partners/checklist.html
+++ b/_includes/partners/checklist.html
@@ -1,4 +1,4 @@
-<article class="container is-login-for-you">
+<div class="container is-login-for-you">
   <header class="intro"><h2>{{ include.heading }}</h2></header>
   <section>
     <p>Use our checklist to see if partnership is right for you:</p>
@@ -9,4 +9,4 @@
     </ul>
     <a class="usa-nav__link caret" href="{{ site.baseurl }}/partners/business-inquiries/">Contact us to learn more</a>
   </section>
-</article>
+</div>

--- a/_includes/partners/checklist.html
+++ b/_includes/partners/checklist.html
@@ -1,4 +1,4 @@
-<div class="container is-login-for-you">
+<article class="container is-login-for-you">
   <header class="intro"><h2>{{ include.heading }}</h2></header>
   <section>
     <p>Use our checklist to see if partnership is right for you:</p>
@@ -9,4 +9,4 @@
     </ul>
     <a class="usa-nav__link caret" href="{{ site.baseurl }}/partners/business-inquiries/">Contact us to learn more</a>
   </section>
-</div>
+</article>

--- a/_includes/partners/checklist.html
+++ b/_includes/partners/checklist.html
@@ -1,4 +1,4 @@
-<div class="container is-login-for-you">
+<div class="container container--mod is-login-for-you">
   <header class="intro"><h2>{{ include.heading }}</h2></header>
   <section>
     <p>Use our checklist to see if partnership is right for you:</p>

--- a/_includes/partners/x-col.html
+++ b/_includes/partners/x-col.html
@@ -1,4 +1,4 @@
-<div class="container {{ include.class }}">
+<div class="container container--mod {{ include.class }}">
   <header class="intro"><h2>{{ include.heading }}</h2></header>
   <div class='grid-container'>
     <div class="grid-row grid-gap-lg" aria-label="{{ include.label }}">

--- a/_includes/partners/x-col.html
+++ b/_includes/partners/x-col.html
@@ -1,4 +1,4 @@
-<div class="container {{ include.class }}">
+<article class="container {{ include.class }}">
   <header class="intro"><h2>{{ include.heading }}</h2></header>
   <div class='grid-container'>
     <div class="grid-row grid-gap-lg" aria-label="{{ include.label }}">
@@ -21,4 +21,4 @@
   {% if include.link and include.link != '' %}
     {{ include.link | markdownify }}
   {% endif %}
-</div>
+</article>

--- a/_includes/partners/x-col.html
+++ b/_includes/partners/x-col.html
@@ -1,4 +1,4 @@
-<article class="container {{ include.class }}">
+<div class="container {{ include.class }}">
   <header class="intro"><h2>{{ include.heading }}</h2></header>
   <div class='grid-container'>
     <div class="grid-row grid-gap-lg" aria-label="{{ include.label }}">
@@ -21,4 +21,4 @@
   {% if include.link and include.link != '' %}
     {{ include.link | markdownify }}
   {% endif %}
-</article>
+</div>

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -7,7 +7,7 @@ includes_touchpoints: true
 {% assign parent_url = page.url | replace: slug_permalink %}
 {% assign related_questions = site.help | where_exp: "item", "item.url contains parent_url" | sort: 'order' %}
 
-<div class="container">
+<article class="container">
   <div class="page-content grid-row">
     <div class="page-content__prose grid-col-12 desktop:grid-col-8 help-article">
       <h1>{{page.title}}</h1>
@@ -24,4 +24,4 @@ includes_touchpoints: true
       {% include help/nav_sidenav.html %}
     </div>
   </div>
-</div>
+</article>

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -7,7 +7,7 @@ includes_touchpoints: true
 {% assign parent_url = page.url | replace: slug_permalink %}
 {% assign related_questions = site.help | where_exp: "item", "item.url contains parent_url" | sort: 'order' %}
 
-<article class="container">
+<div class="container">
   <div class="page-content grid-row">
     <div class="page-content__prose grid-col-12 desktop:grid-col-8 help-article">
       <h1>{{page.title}}</h1>
@@ -24,4 +24,4 @@ includes_touchpoints: true
       {% include help/nav_sidenav.html %}
     </div>
   </div>
-</article>
+</div>

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -7,7 +7,7 @@ includes_touchpoints: true
 {% assign parent_url = page.url | replace: slug_permalink %}
 {% assign related_questions = site.help | where_exp: "item", "item.url contains parent_url" | sort: 'order' %}
 
-<div class="container">
+<div class="container container--mod">
   <div class="page-content grid-row">
     <div class="page-content__prose grid-col-12 desktop:grid-col-8 help-article">
       <h1>{{page.title}}</h1>

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -43,12 +43,12 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
 {% include hero.html heading=heading class="bg-none" %}
 
 <div class="container">
-  <div class="page-content grid-row">
+  <article class="page-content grid-row">
     <div class="desktop:display-none grid-col-12 margin-bottom-3">{{ sidenav }}</div>
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
       {{ content }}
       <a href="#top" class="anchor-to-top">{{ site.data[page.lang].settings.nav.anchor_to_top }}</a>
     </div>
     <div class="display-none desktop:display-block grid-offset-1 grid-col-3">{{ sidenav }}</div>
-  </div>
+  </article>
 </div>

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -43,12 +43,12 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
 {% include hero.html heading=heading class="bg-none" %}
 
 <div class="container">
-  <article class="page-content grid-row">
+  <div class="page-content grid-row">
     <div class="desktop:display-none grid-col-12 margin-bottom-3">{{ sidenav }}</div>
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
       {{ content }}
       <a href="#top" class="anchor-to-top">{{ site.data[page.lang].settings.nav.anchor_to_top }}</a>
     </div>
     <div class="display-none desktop:display-block grid-offset-1 grid-col-3">{{ sidenav }}</div>
-  </article>
+  </div>
 </div>

--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -43,7 +43,7 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
 {% include hero.html heading=heading class="bg-none" %}
 
 <div class="container">
-  <div class="page-content grid-row">
+  <div class="page-content container--mod grid-row">
     <div class="desktop:display-none grid-col-12 margin-bottom-3">{{ sidenav }}</div>
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
       {{ content }}

--- a/_sass/components/_typography.scss
+++ b/_sass/components/_typography.scss
@@ -5,7 +5,7 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-article p {
+div p {
   line-height: $line-height;
 }
 

--- a/_sass/components/_typography.scss
+++ b/_sass/components/_typography.scss
@@ -5,7 +5,7 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-div p {
+.container--mod p {
   line-height: $line-height;
 }
 

--- a/content/_landing/help._en.md
+++ b/content/_landing/help._en.md
@@ -7,7 +7,7 @@ hero: true
 redirect_from:
   - /en/help/
 ---
-<article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">
@@ -27,4 +27,4 @@ redirect_from:
     </li>
     {% endfor %}
   </ul>
-</article>
+</div>

--- a/content/_landing/help._en.md
+++ b/content/_landing/help._en.md
@@ -7,7 +7,7 @@ hero: true
 redirect_from:
   - /en/help/
 ---
-<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">
@@ -27,4 +27,4 @@ redirect_from:
     </li>
     {% endfor %}
   </ul>
-</div>
+</article>

--- a/content/_landing/help._en.md
+++ b/content/_landing/help._en.md
@@ -7,7 +7,7 @@ hero: true
 redirect_from:
   - /en/help/
 ---
-<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<div class="container--mod grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">

--- a/content/_landing/help._es.md
+++ b/content/_landing/help._es.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /es/help/
 hero: true
 ---
-<article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">
@@ -25,4 +25,4 @@ hero: true
     </li>
     {% endfor %}
   </ul>
-</article>
+</div>

--- a/content/_landing/help._es.md
+++ b/content/_landing/help._es.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /es/help/
 hero: true
 ---
-<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<div class="container--mod grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">

--- a/content/_landing/help._es.md
+++ b/content/_landing/help._es.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /es/help/
 hero: true
 ---
-<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">
@@ -25,4 +25,4 @@ hero: true
     </li>
     {% endfor %}
   </ul>
-</div>
+</article>

--- a/content/_landing/help._fr.md
+++ b/content/_landing/help._fr.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /fr/help/
 hero: true
 ---
-<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">
@@ -25,4 +25,4 @@ hero: true
     </li>
     {% endfor %}
   </ul>
-</div>
+</article>

--- a/content/_landing/help._fr.md
+++ b/content/_landing/help._fr.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /fr/help/
 hero: true
 ---
-<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<div class="container--mod grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">

--- a/content/_landing/help._fr.md
+++ b/content/_landing/help._fr.md
@@ -5,7 +5,7 @@ layout: help_landing
 permalink: /fr/help/
 hero: true
 ---
-<article class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
+<div class="grid-container-tablet-lg tablet-lg:padding-x-0 margin-top-9 padding-bottom-1">
   <ul class="usa-card-group grid-row tablet:flex-align-center usa-list usa-list--unstyled">
     {% for item in site.data[page.lang].settings["help_page"]["categories"] %}
     <li class="card">
@@ -25,4 +25,4 @@ hero: true
     </li>
     {% endfor %}
   </ul>
-</article>
+</div>


### PR DESCRIPTION
## 🎫 Ticket

[LG-9385: 508 - The structure of information cannot be understood by assistive technology
](https://cm-jira.usa.gov/browse/LG-9385)

## 🛠 Summary of changes

**Explanation**
This ticket/PR was born out of an audit conducted by the VA. One of the findings they reported was "On the Create an account | Login.gov screen (Create an account), under Create an account, the information starting with When you’re ready to create your secure … is read as an article." This 
means that when a user uses a web rotor to navigate a website through landmarks, the part of the website containing content is in an `article` landmark. This happens because that part of the page is coded as an `<article>` which means that the element is announced as `article`

![image](https://user-images.githubusercontent.com/17969963/235501961-c7c03afe-4442-4b3b-b5fd-8081599fa12f.png)

**Fix**
Change instances of `<article>` to a `<div>`. With this change, we get rid of extra noise in the web rotor while still being accessible to the user. 

Notes:

- Bug only shows in web rotor. When doing a full-screen read, the landmark is not announced

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Turn on the screenreader of your choice. In this test, I used VoiceOver. Browser combinations does matter because the feature is dependent on the screenreader, not the browser
- Access "Create your account" page on https://localhost:400/create-an-account
- Open the web rotor when on the page. In VoiceOver, the web rotor can be accessed by using `VO-U`. In my manual test, `VO` is the same as the caps lock key
- Observe that article is listed on the landmark menu 

## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/17969963/235501961-c7c03afe-4442-4b3b-b5fd-8081599fa12f.png) |![image](https://user-images.githubusercontent.com/17969963/235515743-448b2c62-d2af-4186-a6cf-ccbb2ec81226.png)|

## Additional notes
- The `complementary` landmark is for the "Your one account for government" banner. Currently, this is marked as an `<aside>` element. This is because the element is outside of the `<main>` content. This is not highlighted as a failure in the VPAT assessment, but I think it would be worth a second look as it is outside of the `<main>` container.
