### PR TITLE
LG-9389: Reset focus to top of content for "Back to top" links

### DIFF
--- a/_layouts/sidenav.html
+++ b/_layouts/sidenav.html
@@ -47,7 +47,7 @@ below. Note: This does not apply to Help pages, which is far more complex. {% en
     <div class="desktop:display-none grid-col-12 margin-bottom-3">{{ sidenav }}</div>
     <div class="page-content__prose grid-col-12 desktop:grid-col-8">
       {{ content }}
-      <a href="#top" class="anchor-to-top">{{ site.data[page.lang].settings.nav.anchor_to_top }}</a>
+      <a href="#main-content" class="anchor-to-top">{{ site.data[page.lang].settings.nav.anchor_to_top }}</a>
     </div>
     <div class="display-none desktop:display-block grid-offset-1 grid-col-3">{{ sidenav }}</div>
   </div>

--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -55,4 +55,21 @@ describe('accessibility', () => {
       );
     });
   }
+
+  describe('"Back to top" link', () => {
+    it('resets keyboard tabbing to the beginning of content', async () => {
+      await goto('/about-us/');
+      const backToTopLinkHandle = await page.$('.page-content__prose .anchor-to-top');
+      await page.click(backToTopLinkHandle);
+      await page.keyboard.press('Tab');
+      const isFocusBeforeBackToTop = await page.evaluate(
+        (backToTopLink) =>
+          backToTopLink.compareDocumentPosition(document.activeElement) ===
+          Node.DOCUMENT_POSITION_PRECEDING,
+        backToTopLinkHandle,
+      );
+
+      expect(isFocusBeforeBackToTop).toEqual(true);
+    });
+  });
 });

--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -60,7 +60,7 @@ describe('accessibility', () => {
     it('resets focus to the beginning of content', async () => {
       await goto('/about-us/');
       const backToTopLinkHandle = await page.$('.page-content__prose .anchor-to-top');
-      await page.click(backToTopLinkHandle);
+      await backToTopLinkHandle.click();
       await page.keyboard.press('Tab');
       const isFocusBeforeBackToTop = await page.evaluate(
         (backToTopLink) =>

--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -57,7 +57,7 @@ describe('accessibility', () => {
   }
 
   describe('"Back to top" link', () => {
-    it('resets keyboard tabbing to the beginning of content', async () => {
+    it('resets focus to the beginning of content', async () => {
       await goto('/about-us/');
       const backToTopLinkHandle = await page.$('.page-content__prose .anchor-to-top');
       await page.click(backToTopLinkHandle);


### PR DESCRIPTION
## 🎫 Ticket

[LG-9389](https://cm-jira.usa.gov/browse/LG-9389)

## 🛠 Summary of changes

Updates the "Back to top" link to reset focus to the beginning of the page's main content area, so that someone navigating content with keyboard or assistive technology can proceed as expected from the top of content.

The "Back to top" link now links to the same anchor target as the "Skip to main content" skip link at the beginning of the page.

**Technical Notes:**

The previous `href="#top"` is a valid anchor reference, but its behaviors defined in the specification seem to specifically exclude any change in focus, vs. if there's a target element associated with the `href`:

>if document's indicated part is top of the document, then: [...] Scroll to the beginning of the document for document.
>
>[...]
>
>Otherwise: [...] Let target be document's indicated part. [...] Run the focusing steps for target

https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-lg-9389-back-to-top/about-us/
2. Click the "Back to top" link at the bottom of the page
3. Press <kbd>Tab</kbd> on your keyboard

**Before:** Focus would shift to the next focusable element _after_ the "Back to top" link (the sidebar content on desktop)
**After:** Focus shifts to the next focusable element within the main content area (a link in the content section)

