### PR TITLE
LG-9624: Hide search clear button

### DIFF
--- a/_sass/components/_search.scss
+++ b/_sass/components/_search.scss
@@ -1,0 +1,6 @@
+// Upstream: Remove after at least one of the following is fixed:
+// - https://github.com/uswds/uswds/issues/5277
+// - https://bugs.chromium.org/p/chromium/issues/detail?id=1147314
+.usa-search [type='search']::-webkit-search-cancel-button {
+  display: none;
+}

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -16,6 +16,7 @@
 @forward 'partners/checklist';
 @forward 'partners/hero';
 @forward 'partners/partners';
+@forward 'search';
 @forward 'site';
 @forward 'skip-nav';
 @forward 'sticky-table';

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -1,27 +1,23 @@
 @forward 'alert';
-@forward 'site';
+@forward 'already-have-an-account';
+@forward 'banner';
+@forward 'box-info';
+@forward 'card';
 @forward 'footer';
 @forward 'form';
 @forward 'header';
-@forward 'language-picker';
-@forward 'list';
-@forward 'banner';
-@forward 'already-have-an-account';
-@forward 'nav';
 @forward 'hero';
-
-@forward 'partners/hero';
-@forward 'partners/checklist';
-@forward 'partners/partners';
-
-@forward 'typography';
-@forward 'svg';
-
+@forward 'language-picker';
+@forward 'layout';
+@forward 'list';
+@forward 'nav';
 @forward 'nav-secondary';
 @forward 'nav-sidenav';
+@forward 'partners/checklist';
+@forward 'partners/hero';
+@forward 'partners/partners';
+@forward 'site';
 @forward 'skip-nav';
-@forward 'layout';
-@forward 'box-info';
-@forward 'card';
-
 @forward 'sticky-table';
+@forward 'svg';
+@forward 'typography';


### PR DESCRIPTION
## 🎫 Ticket

[LG-9624](https://cm-jira.usa.gov/browse/LG-9624)

## 🛠 Summary of changes

Styles the search field to hide the "X" clear button that shows in Chrome when text is entered in the field, so that the field provides a consistent experience regardless of input type (mouse vs. keyboard). There should not be any interactive elements which can only be activated with a mouse.

Related:

- https://github.com/uswds/uswds/issues/5277
- https://bugs.chromium.org/p/chromium/issues/detail?id=1147314

## 📜 Testing Plan

1. In Chrome, go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-lg-9624-search-clear-button/
2. Enter text in the search field
3. Observe there is no button to clear the search contents

## 📸 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-site/assets/1779930/e2945c53-a123-4e68-8e16-2f2a5c1ae7ef)|![image](https://github.com/18F/identity-site/assets/1779930/a0ee5560-b10b-4fd9-ac31-2c7e77aa93a6)
