### PR TITLE
LG-9626: add clearer primary navigation name

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -2,8 +2,8 @@ accessible_labels:
   login_link_logo: Login.gov Homepage
   partners_link_logo: Login.gov Partners Homepage
   footer_navigation: Footer navigation
-  primary_navigation: Primary navigation
-  secondary_navigation: Secondary navigation
+  primary_navigation: Primary links navigation
+  secondary_navigation: Secondary links navigation
 actions:
   search: Search
 banner:

--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -2,8 +2,8 @@ accessible_labels:
   login_link_logo: Login.gov Homepage
   partners_link_logo: Login.gov Partners Homepage
   footer_navigation: Footer navigation
-  primary_navigation: Primary links navigation
-  secondary_navigation: Secondary links navigation
+  primary_navigation: Primary links
+  secondary_navigation: Secondary links
 actions:
   search: Search
 banner:

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -2,8 +2,8 @@ accessible_labels:
   login_link_logo:  Página de inicio de Login.gov
   partners_link_logo: Página de inicio Login.gov Partners
   footer_navigation: Navegación de pie de página
-  primary_navigation: Navegación primaria
-  secondary_navigation: Navegación secundaria
+  primary_navigation: Navegación de enlaces primarios
+  secondary_navigation: Navegación de enlaces secundarios
 actions:
   search: Buscar
 banner:

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -2,8 +2,8 @@ accessible_labels:
   login_link_logo:  Página de inicio de Login.gov
   partners_link_logo: Página de inicio Login.gov Partners
   footer_navigation: Navegación de pie de página
-  primary_navigation: Navegación de enlaces primarios
-  secondary_navigation: Navegación de enlaces secundarios
+  primary_navigation: Enlaces primarios
+  secondary_navigation: Enlaces secundarios
 actions:
   search: Buscar
 banner:

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -2,8 +2,8 @@ accessible_labels:
   login_link_logo:  Page d'accueil de Login.gov
   partners_link_logo: Page d'accueil de Login.gov Partners
   footer_navigation: Navigation en bas de page
-  primary_navigation: Navigation par liens primaires
-  secondary_navigation: Navigation par liens secondaires 
+  primary_navigation: Liens primaires
+  secondary_navigation: Liens secondaires 
 actions:
   search: Chercher
 banner:

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -2,8 +2,8 @@ accessible_labels:
   login_link_logo:  Page d'accueil de Login.gov
   partners_link_logo: Page d'accueil de Login.gov Partners
   footer_navigation: Navigation en bas de page
-  primary_navigation: Navigation principale
-  secondary_navigation: Navigation secondaire
+  primary_navigation: Navigation par liens primaires
+  secondary_navigation: Navigation par liens secondaires 
 actions:
   search: Chercher
 banner:


### PR DESCRIPTION
Change the navigation label to "Primary Links and Secondary Links" to prevent the screen reader from reading "navigations" twice. 