### PR TITLE
Fix appearance of phone support sticky headers

### DIFF
--- a/_includes/country_support_table.html
+++ b/_includes/country_support_table.html
@@ -23,10 +23,10 @@ Should include these translations as includes:
   <table hidden class="usa-table--borderless usa-table--sticky-header">
     <thead>
       <tr>
-        <th scope="col" class="usa-table--sticky-header--heading">{{ include.heading_country }}</th>
-        <th scope="col" class="usa-table--sticky-header--heading">{{ include.heading_dialing_code }}</th>
-        <th scope="col" class="usa-table--sticky-header--heading">{{ include.heading_sms }}</th>
-        <th scope="col" class="usa-table--sticky-header--heading">{{ include.heading_voice }}</th>
+        <th scope="col" class="usa-table__header--sticky">{{ include.heading_country }}</th>
+        <th scope="col" class="usa-table__header--sticky">{{ include.heading_dialing_code }}</th>
+        <th scope="col" class="usa-table__header--sticky">{{ include.heading_sms }}</th>
+        <th scope="col" class="usa-table__header--sticky">{{ include.heading_voice }}</th>
       </tr>
     </thead>
     <tbody>

--- a/_sass/components/_sticky-table.scss
+++ b/_sass/components/_sticky-table.scss
@@ -1,12 +1,23 @@
-@use '../colors' as *;
+@use 'uswds-core' as *;
 
-.usa-table--sticky-header {
+.usa-table--sticky-header,
+.page-content__prose .usa-table--sticky-header {
   position: relative;
 
-  .usa-table--sticky-header--heading,
-  thead th.usa-table--sticky-header--heading {
-    background-color: $white;
+  .usa-table__header--sticky,
+  thead th.usa-table__header--sticky {
+    background-color: color('white');
     position: sticky;
     top: 0;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 0;
+      height: 1px;
+      width: 100%;
+      background: color($theme-table-border-color);
+    }
   }
 }


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes the appearance of headers on the international phone support help center page.

Why?

- Expected to show with a white background, but wasn't appearing as expected due to CSS specificity conflict
- Add border for visual distinction

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-fix-sticky-header-bg/help/manage-your-account/international-phone-support/
3. ~Scroll page and observe table header appearance~ Cry because our preview environments aren't set up to load the data 😢 

## 📸 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-site/assets/1779930/5ed90c6d-3e04-4d67-9aad-4c966b9092e6)|![image](https://github.com/18F/identity-site/assets/1779930/3a0c74f0-3a64-4495-b785-6872fc18fd28)
