### PR TITLE
LG-9967: Support option for phone available in planned maintenance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ contact_phone_number_location: 'bottom' # acceptable values are 'top' and 'botto
 # Contact page maintenance window
 contact_maintenance_start_time: null
 contact_maintenance_end_time: null
+contact_maintenance_phone_available: true
 
 # Unplanned outage configuration
 contact_unplanned_outage: false

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -13,7 +13,12 @@ common_applications:
 {% if site.contact_maintenance_start_time and site.contact_maintenance_end_time %}
   <div id="contact-us-maintenance-alert" class="usa-alert usa-alert--warning" hidden>
     <div class="usa-alert__body">
-      <p class="usa-alert__text">{{ page.maintenance_window_content }}</p>
+      <p class="usa-alert__text">
+        {{ page.maintenance_window_content }}
+        {% if site.contact_maintenance_phone_available %}
+          {{ page.phone_available_content }}
+        {% endif %}
+      </p>
     </div>
   </div>
 {% endif %}
@@ -22,10 +27,9 @@ common_applications:
   <div class="usa-alert usa-alert--warning">
     <div class="usa-alert__body">
       <p class="usa-alert__text">
+        {{ page.unplanned_outage_content }}
         {% if site.contact_unplanned_outage_phone_available %}
-          {{ page.unplanned_outage_phone_available_content }}
-        {% else %}
-          {{ page.unplanned_outage_content }}
+          {{ page.phone_available_content }}
         {% endif %}
       </p>
     </div>

--- a/content/_policy/contact._en.md
+++ b/content/_policy/contact._en.md
@@ -26,7 +26,7 @@ help_center_content: >-
 
   * [Browse more help articles](/help/)
 maintenance_window_content: Login.gov’s Contact Center is currently undergoing maintenance from <strong>%{start_time} - %{end_time}.</strong> Visit some common topics below for assistance.
-unplanned_outage_phone_available_content: Due to an outage, we can't review online support requests. You can call our support center anytime at (844) 875-6446.
+phone_available_content: You can call our support center anytime at (844) 875-6446.
 unplanned_outage_content: Due to an outage, we can't review online support requests.
 partner_content: >-
   ## Partner with Login.gov

--- a/content/_policy/contact._es.md
+++ b/content/_policy/contact._es.md
@@ -26,7 +26,7 @@ help_center_content: >-
 
   * [Explorar más artículos de ayuda](/es/help/)
 maintenance_window_content: El centro de atención de Login.gov estará en mantenimiento desde <strong>%{start_time} y hasta %{end_time}</strong>. Consulte los temas comunes que aparecen a continuación para obtener ayuda.
-unplanned_outage_phone_available_content: Debido a un problema técnico, no podemos revisar las solicitudes de asistencia en línea. Puede llamar a nuestro centro de asistencia en cualquier momento al (844) 875-6446.
+phone_available_content: Puede llamar a nuestro centro de asistencia en cualquier momento al (844) 875-6446.
 unplanned_outage_content: Debido a un problema técnico, no podemos revisar las solicitudes de asistencia en línea.
 partner_content: >-
   ## Asociarse con Login.gov

--- a/content/_policy/contact._fr.md
+++ b/content/_policy/contact._fr.md
@@ -25,7 +25,7 @@ help_center_content: >-
 
   * [Parcourir d’autres articles d’aide](/fr/help/)
 maintenance_window_content: Le centre de contact de Login.gov est actuellement en cours de maintenance <strong>%{start_time} au %{end_time}</strong>. Consultez les sujets courants ci-dessous pour obtenir de l'aide.
-unplanned_outage_phone_available_content: En raison d'une panne, nous ne pouvons pas traiter les demandes d'assistance en ligne. Vous pouvez appeler notre centre d'assistance à tout moment au (844) 875-6446
+phone_available_content: Vous pouvez appeler notre centre d'assistance à tout moment au (844) 875-6446.
 unplanned_outage_content: En raison d'une panne, nous ne pouvons pas traiter les demandes d'assistance en ligne.
 partner_content: >-
   ## Partenaire avec Login.gov


### PR DESCRIPTION
## 🎫 Ticket

[LG-9967](https://cm-jira.usa.gov/browse/LG-9967)

## 🛠 Summary of changes

Adds a new option to configure whether to mention the availability of the contact center phone number during a scheduled maintenance window.

**Why?** The default maintenance window content does not mention the contact center phone number, but it will be available during the upcoming planned maintenance window on June 10th.

## 📜 Testing Plan

Test the following combinations of outages to ensure content appears as expected, by adding these to a local `_config.dev.yml` file:

**Planned outage, phone available:**

```yml
contact_maintenance_start_time: '2023-05-10T16:00:00Z'
contact_maintenance_end_time: '2023-06-10T16:05:00Z'
```

([See expected screenshot](https://github.com/18F/identity-site/assets/1779930/eb462220-177c-486f-9ebf-f021776290d5))

**Planned outage, phone unavailable:**

```yml
contact_maintenance_start_time: '2023-05-10T16:00:00Z'
contact_maintenance_end_time: '2023-06-10T16:05:00Z'
contact_maintenance_phone_available: false
```

([See expected screenshot](https://github.com/18F/identity-site/assets/1779930/1e03d5fc-e45e-4321-a19f-4b6055642c94))

**Unplanned outage, phone available:**

```yml
contact_unplanned_outage: true
contact_unplanned_outage_phone_available: true
```

([See expected screenshot](https://github.com/18F/identity-site/assets/1779930/6243cac3-3a8d-41e1-9210-7409de5d7bc7))

**Unplanned outage, phone unavailable:**

```yml
contact_unplanned_outage: false
contact_unplanned_outage_phone_available: false
```

([See expected screenshot](https://github.com/18F/identity-site/assets/1779930/2ed016f9-8037-4b43-bd80-97f84faaa5d0))

## 📸 Screenshots

Before|After
---|---
![image](https://github.com/18F/identity-site/assets/1779930/1e03d5fc-e45e-4321-a19f-4b6055642c94)|![image](https://github.com/18F/identity-site/assets/1779930/eb462220-177c-486f-9ebf-f021776290d5)
