### PR TITLE
Restructure README to split guides to docs directory, add "Outages" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,11 @@
 
 The static marketing site for Login.gov
 
-## Branches
+## Guides for Common Workflows
 
-`main` branch is published at https://www.login.gov.
-
-Feature branches should be merged to `main` when they are ready through the normal code review process (have at least **one** person who is not the author Approve the PR).
-
-## Publishing Workflow
-
-Branch off of `main` and make pull requests back to the `main` branch. Cloud.gov Pages will build a live preview for each branch so we suggest using those builds as staging environments to run your proposed changes by the rest of the team.
-
-To view the preview URL for your branch, click the Cloud.gov Pages "Details" link in your pull request's checks.
+- [Branching and Publishing Workflow](./docs/development-workflows/branching-and-publishing-workflow.md)
+- [Netlify CMS](./docs/development-workflows/netlify-cms.md)
+- [Nested Help Articles](./docs/development-workflows/nested-help-articles.md)
 
 ## Development
 
@@ -70,51 +64,6 @@ The lint task will check to see that SVG images are optimized. To optimize image
 
 ```
 npm run optimize-assets
-```
-
-### NetlifyCMS
-[NetlifyCMS](https://www.netlifycms.org/) is an open source content management system that we use to edit content on the brochure site. To develop and make changes to the CMS, or to edit content locally, first comment out the first `backend` block and then uncomment the second `backend` block that contains `proxy_url`. Then, change the branch name to the name of the branch that you are developing on.
-
-After the changes in `admin/config.yml` are saved *and* the site is served locally, run
-```
-npx netlify-cms-proxy-server
-```
-
-You can then view the CMS in your browser at http://localhost:4000/admin.
-
-### Adding nested pages and subdirectories
-Currently the site is organized hierarchically by topic, with each topic constituting a folder and markdown files within that folder constituting the individual web pages about that topic. You might want to add more pages nested under another page already contained within a topic level folder. To do this, do the following:
-- Create the child page at the same level as the parent page. This is so Netlify CMS will pick up on the new page.
-- Add the following front matter fields to the child page: `title`, `child`, `order` and `permalink`.
-- `title` is the title of the article. This is a string.
-- `child` is a boolean value. For pages that are children of other pages, this should be true.
-- `order` is an integer value. It determines the display order of the grandchild pages.
-- `permalink` should be set to the desired url. Since this is a child page, you'll want it to follow this pattern: `/section/category/parent/child/`
-- In the parent page, add a new field to the front matter titled `children`
-- The `children` field is an array of the permalinks of pages that are children to this page
-
-For example: to create a new page at the URL `/help/verify-your-identity/verify-your-identity-in-person/test`
-
-Child page front matter fields:
-```
----
-title: Test
-child: true
-order: 1
-permalink: /help/verify-your-identity/verify-your-identity-in-person/test
----
-```
-
-Parent page front matter fields:
-```
----
-layout: help
-title: Verify your identity in person
-category: verify-your-identity
-children: ['/help/verify-your-identity/verify-your-identity-in-person/test']
-permalink: /help/verify-your-identity/verify-your-identity-in-person/
-order: 7
----
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The static marketing site for Login.gov
 
 ## Guides for Common Workflows
 
+- [Contact Form Outages](./docs/development-workflows/contact-form-outages.md)
 - [Branching and Publishing Workflow](./docs/development-workflows/branching-and-publishing-workflow.md)
 - [Netlify CMS](./docs/development-workflows/netlify-cms.md)
 - [Nested Help Articles](./docs/development-workflows/nested-help-articles.md)

--- a/docs/development-workflows/branching-and-publishing-workflow.md
+++ b/docs/development-workflows/branching-and-publishing-workflow.md
@@ -1,0 +1,13 @@
+# Branching and Publishing Workflow
+
+## Branches
+
+`main` branch is published at https://www.login.gov.
+
+Feature branches should be merged to `main` when they are ready through the normal code review process (have at least **one** person who is not the author Approve the PR).
+
+## Publishing Workflow
+
+Branch off of `main` and make pull requests back to the `main` branch. Cloud.gov Pages will build a live preview for each branch so we suggest using those builds as staging environments to run your proposed changes by the rest of the team.
+
+To view the preview URL for your branch, click the Cloud.gov Pages "Details" link in your pull request's checks.

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -9,18 +9,22 @@ For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cl
 - If **YES**, the contact form is experiencing an unexpected outage:
   - Is the phone line still available for support?
     - If **YES**, use the following configuration:
+
                 contact_unplanned_outage: false
                 contact_unplanned_outage_phone_available: true
     - If **NO**, use the following configuration:
+
                 contact_unplanned_outage: false
                 contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
   - Will the phone line be available during the planned maintenance?
     - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
+
                 contact_maintenance_start_time: 1970-01-01T00:00:00Z
                 contact_maintenance_end_time: 1970-01-01T01:00:00Z
                 contact_maintenance_phone_available: true
-    - If **NO**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings::
+    - If **NO**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
+
                 contact_maintenance_start_time: 1970-01-01T00:00:00Z
                 contact_maintenance_end_time: 1970-01-01T01:00:00Z
                 contact_maintenance_phone_available: false

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -1,0 +1,26 @@
+# Contact Form Outages
+
+This guide is written in a "Choose your own adventure" style to quickly guide you to relevant information, in case of an active outage:
+
+For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cloud.gov/) and [modify site settings](https://pages.cloud.gov/sites/85/settings). Configuration can be edited under "Advanced settings" ► "Live site" ► "Site configuration", either at the end of the configuration textarea, or replacing existing configuration values for the relevant setting names.
+
+**Is the contact form currently experiencing an unexpected outage?**
+
+- If **YES**, the contact form is experiencing an unexpected outage:
+  - Is the phone line still available for support?
+    - If **YES**, use the following configuration:
+        contact_unplanned_outage: false
+        contact_unplanned_outage_phone_available: true
+    - If **NO**, use the following configuration:
+        contact_unplanned_outage: false
+        contact_unplanned_outage_phone_available: false
+- If **NO**, the contact form will be undergoing a planned maintenance in the future:
+  - Will the phone line be available during the planned maintenance?
+    - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
+        contact_maintenance_start_time: 1970-01-01T00:00:00Z
+        contact_maintenance_end_time: 1970-01-01T01:00:00Z
+        contact_maintenance_phone_available: true
+    - If **NO**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings::
+        contact_maintenance_start_time: 1970-01-01T00:00:00Z
+        contact_maintenance_end_time: 1970-01-01T01:00:00Z
+        contact_maintenance_phone_available: false

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -1,6 +1,6 @@
 # Contact Form Outages
 
-This guide is written in a "Choose your own adventure" style to quickly guide you to relevant information, in case of an active outage:
+This guide is written in a "Choose your own adventure" style to quickly guide you to relevant information, in case of an active outage.
 
 For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cloud.gov/) and [modify site settings](https://pages.cloud.gov/sites/85/settings). Configuration can be edited under "Advanced settings" ► "Live site" ► "Site configuration", either at the end of the configuration textarea, or replacing existing configuration values for the relevant setting names.
 

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -10,21 +10,21 @@ For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cl
   - Is the phone line still available for support?
     - If **YES**, use the following configuration:
 
-                contact_unplanned_outage: false
-                contact_unplanned_outage_phone_available: true
+          contact_unplanned_outage: false
+          contact_unplanned_outage_phone_available: true
     - If **NO**, use the following configuration:
 
-                contact_unplanned_outage: false
-                contact_unplanned_outage_phone_available: false
+          contact_unplanned_outage: false
+          contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
   - Will the phone line be available during the planned maintenance?
     - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
 
-                contact_maintenance_start_time: 1970-01-01T00:00:00Z
-                contact_maintenance_end_time: 1970-01-01T01:00:00Z
-                contact_maintenance_phone_available: true
+          contact_maintenance_start_time: 1970-01-01T00:00:00Z
+          contact_maintenance_end_time: 1970-01-01T01:00:00Z
+          contact_maintenance_phone_available: true
     - If **NO**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
 
-                contact_maintenance_start_time: 1970-01-01T00:00:00Z
-                contact_maintenance_end_time: 1970-01-01T01:00:00Z
-                contact_maintenance_phone_available: false
+          contact_maintenance_start_time: 1970-01-01T00:00:00Z
+          contact_maintenance_end_time: 1970-01-01T01:00:00Z
+          contact_maintenance_phone_available: false

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -10,11 +10,11 @@ For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cl
   - Is the phone line still available for support?
     - If **YES**, use the following configuration:
 
-          contact_unplanned_outage: false
+          contact_unplanned_outage: true
           contact_unplanned_outage_phone_available: true
     - If **NO**, use the following configuration:
 
-          contact_unplanned_outage: false
+          contact_unplanned_outage: true
           contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
   - Will the phone line be available during the planned maintenance?

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -9,18 +9,18 @@ For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cl
 - If **YES**, the contact form is experiencing an unexpected outage:
   - Is the phone line still available for support?
     - If **YES**, use the following configuration:
-        contact_unplanned_outage: false
-        contact_unplanned_outage_phone_available: true
+                contact_unplanned_outage: false
+                contact_unplanned_outage_phone_available: true
     - If **NO**, use the following configuration:
-        contact_unplanned_outage: false
-        contact_unplanned_outage_phone_available: false
+                contact_unplanned_outage: false
+                contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
   - Will the phone line be available during the planned maintenance?
     - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
-        contact_maintenance_start_time: 1970-01-01T00:00:00Z
-        contact_maintenance_end_time: 1970-01-01T01:00:00Z
-        contact_maintenance_phone_available: true
+                contact_maintenance_start_time: 1970-01-01T00:00:00Z
+                contact_maintenance_end_time: 1970-01-01T01:00:00Z
+                contact_maintenance_phone_available: true
     - If **NO**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings::
-        contact_maintenance_start_time: 1970-01-01T00:00:00Z
-        contact_maintenance_end_time: 1970-01-01T01:00:00Z
-        contact_maintenance_phone_available: false
+                contact_maintenance_start_time: 1970-01-01T00:00:00Z
+                contact_maintenance_end_time: 1970-01-01T01:00:00Z
+                contact_maintenance_phone_available: false

--- a/docs/development-workflows/nested-help-articles.md
+++ b/docs/development-workflows/nested-help-articles.md
@@ -1,4 +1,4 @@
-## Adding nested pages and subdirectories
+# Nested Help Articles
 
 Currently the site is organized hierarchically by topic, with each topic constituting a folder and markdown files within that folder constituting the individual web pages about that topic. You might want to add more pages nested under another page already contained within a topic level folder. To do this, do the following:
 - Create the child page at the same level as the parent page. This is so Netlify CMS will pick up on the new page.

--- a/docs/development-workflows/nested-help-articles.md
+++ b/docs/development-workflows/nested-help-articles.md
@@ -1,0 +1,35 @@
+## Adding nested pages and subdirectories
+
+Currently the site is organized hierarchically by topic, with each topic constituting a folder and markdown files within that folder constituting the individual web pages about that topic. You might want to add more pages nested under another page already contained within a topic level folder. To do this, do the following:
+- Create the child page at the same level as the parent page. This is so Netlify CMS will pick up on the new page.
+- Add the following front matter fields to the child page: `title`, `child`, `order` and `permalink`.
+- `title` is the title of the article. This is a string.
+- `child` is a boolean value. For pages that are children of other pages, this should be true.
+- `order` is an integer value. It determines the display order of the grandchild pages.
+- `permalink` should be set to the desired url. Since this is a child page, you'll want it to follow this pattern: `/section/category/parent/child/`
+- In the parent page, add a new field to the front matter titled `children`
+- The `children` field is an array of the permalinks of pages that are children to this page
+
+For example: to create a new page at the URL `/help/verify-your-identity/verify-your-identity-in-person/test`
+
+Child page front matter fields:
+```
+---
+title: Test
+child: true
+order: 1
+permalink: /help/verify-your-identity/verify-your-identity-in-person/test
+---
+```
+
+Parent page front matter fields:
+```
+---
+layout: help
+title: Verify your identity in person
+category: verify-your-identity
+children: ['/help/verify-your-identity/verify-your-identity-in-person/test']
+permalink: /help/verify-your-identity/verify-your-identity-in-person/
+order: 7
+---
+```

--- a/docs/development-workflows/netlify-cms.md
+++ b/docs/development-workflows/netlify-cms.md
@@ -1,0 +1,10 @@
+# Netlify CMS
+
+[Netlify CMS](https://www.netlifycms.org/) is an open source content management system that we use to edit content on the brochure site. To develop and make changes to the CMS, or to edit content locally, first comment out the first `backend` block and then uncomment the second `backend` block that contains `proxy_url`. Then, change the branch name to the name of the branch that you are developing on.
+
+After the changes in `admin/config.yml` are saved *and* the site is served locally, run
+```
+npx netlify-cms-proxy-server
+```
+
+You can then view the CMS in your browser at http://localhost:4000/admin.


### PR DESCRIPTION
## 🛠 Summary of changes

Splits the `README.md` file into separate "Guides for Common Workflows" Markdown files, linked at the top of the README. This should better support scalability and help someone find the information they need, since the current README currently contains quite a bit of information, not all of which is always relevant depending on the audience.

It also adds a new guide for handling outages, which is a common workflow, and one which is usually time-sensitive in the case of an unplanned outage.

(Base is temporarily set to #1095, and will update to `main` after #1095 is merged)