### PR TITLE
Replace broken link for US Code authority

### DIFF
--- a/content/_policy/rules-of-use._en.md
+++ b/content/_policy/rules-of-use._en.md
@@ -24,7 +24,7 @@ The Login.gov service offers the public secure and private online access to part
 
 The Login.gov service partners with other federal agencies (“partners”) to allow you to access those services with just one Login.gov account, eliminating the need to create many separate accounts across government.
 
-The Login.gov service protects your account by implementing strong security measures and protects your privacy by collecting the minimally necessary information from you and, in turn, revealing to partners only the information necessary for those partners to execute their service. And Login.gov never shares validated personal information with a federal partner unless: 
+The Login.gov service protects your account by implementing strong security measures and protects your privacy by collecting the minimally necessary information from you and, in turn, revealing to partners only the information necessary for those partners to execute their service. And Login.gov never shares validated personal information with a federal partner unless:
 
 1. You provided explicit consent (which you can revoke that at any time);
 2. Disclosure is required by law; or
@@ -100,7 +100,7 @@ In the unlikely event that the Login.gov service is discontinued, information on
 
 ## 6. Authorities
 
-The Login.gov service is operated within the United States, but is accessible globally for public use. The Login.gov service is operated by the General Services Administration under authorities and guidance found in [6 USC § 1523 (b)(1)(A)-(E)](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section1523&num=0&edition=prelim), the E-Government Act of 2002 (Pub. L. 107–347, 44 U.S.C. 3501 note), and [40 USC § 501](https://www.gsa.gov/cdnstatic/CNXII__Eligibility_to_Use_GSA.pdf), and [OMB M-19-17](https://www.whitehouse.gov/wp-content/uploads/2019/05/M-19-17.pdf).
+The Login.gov service is operated within the United States, but is accessible globally for public use. The Login.gov service is operated by the General Services Administration under authorities and guidance found in [6 USC § 1523 (b)(1)(A)-(E)](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section1523&num=0&edition=prelim), the E-Government Act of 2002 (Pub. L. 107–347, 44 U.S.C. 3501 note), and [40 USC § 501](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title40-section501&num=0&edition=prelim), and [OMB M-19-17](https://www.whitehouse.gov/wp-content/uploads/2019/05/M-19-17.pdf).
 
 ## 7. Service Operation and Customer Support
 

--- a/content/_policy/rules-of-use._es.md
+++ b/content/_policy/rules-of-use._es.md
@@ -22,7 +22,7 @@ El servicio Login.gov ofrece al público un acceso en Internet seguro y privado 
 
 El servicio Login.gov se asocia con otras agencias federales ("socios") para permitirle acceder a esos servicios con una sola cuenta Login.gov, lo que elimina la necesidad de crear muchas cuentas separadas en todo el gobierno.
 
-El servicio Login.gov protege su cuenta mediante la aplicación de fuertes medidas de seguridad y protege su privacidad mediante la recopilación de la información mínimamente necesaria de usted y, a su vez, revelando a los socios sólo la información necesaria para que esos socios puedan ejecutar su servicio. Y Login.gov nunca comparte información personal validada con un socio federal a menos que: 
+El servicio Login.gov protege su cuenta mediante la aplicación de fuertes medidas de seguridad y protege su privacidad mediante la recopilación de la información mínimamente necesaria de usted y, a su vez, revelando a los socios sólo la información necesaria para que esos socios puedan ejecutar su servicio. Y Login.gov nunca comparte información personal validada con un socio federal a menos que:
 
 1. Usted haya dado su consentimiento explícito (que puede revocar en cualquier momento);
 2. La divulgación sea exigida por ley; o
@@ -70,7 +70,7 @@ Los autenticadores de los que dispone actualmente en el servicio Login.gov son:
 
 Login.gov no renueva, reemite ni caduca autenticadores, pero puede revocar un autenticador asociado a su cuenta en cualquier momento y, si lo desea, volver a añadirlo más adelante. El servicio Login.gov no emite autenticadores físicos. Los autenticadores que no sean frases de contraseña o códigos de seguridad requieren hardware o software que usted mismo proporciona.
 
-Cuando registra un autenticador en el servicio Login.gov, acepta que lo utilicemos como autenticador para acceder a su cuenta. Si se registra para mensajes SMS o de voz, nos autoriza a enviar mensajes de texto y a realizar llamadas telefónicas a su número de teléfono. 
+Cuando registra un autenticador en el servicio Login.gov, acepta que lo utilicemos como autenticador para acceder a su cuenta. Si se registra para mensajes SMS o de voz, nos autoriza a enviar mensajes de texto y a realizar llamadas telefónicas a su número de teléfono.
 
 En el caso de los autenticadores físicos, como códigos de seguridad impresos, un token de hardware o un teléfono, protéjalos guardándolos en un lugar seguro o con usted. No permita que se dañen. Si se pierden, rompen o dañan, puede perder el acceso a su cuenta.
 
@@ -96,7 +96,7 @@ En el improbable caso de que el servicio de Login.gov sea interrumpido, la infor
 
 ## 6. Autoridades
 
-El servicio Login.gov es operado dentro de los Estados Unidos, pero es accesible globalmente para uso público. El servicio Login.gov es operado por la Administración de Servicios Generales bajo las autoridades y directrices que se encuentran en [6 USC § 1523 (b)(1)(A)-(E)](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section1523&num=0&edition=prelim), la Ley de Gobierno Electrónico de 2002 (Pub. L. 107-347, 44 U.S.C. 3501 nota), [40 USC § 501](https://www.gsa.gov/cdnstatic/CNXII__Eligibility_to_Use_GSA.pdf), y [OMB M-19-17](https://www.whitehouse.gov/wp-content/uploads/2019/05/M-19-17.pdf).
+El servicio Login.gov es operado dentro de los Estados Unidos, pero es accesible globalmente para uso público. El servicio Login.gov es operado por la Administración de Servicios Generales bajo las autoridades y directrices que se encuentran en [6 USC § 1523 (b)(1)(A)-(E)](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section1523&num=0&edition=prelim), la Ley de Gobierno Electrónico de 2002 (Pub. L. 107-347, 44 U.S.C. 3501 nota), [40 USC § 501](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title40-section501&num=0&edition=prelim), y [OMB M-19-17](https://www.whitehouse.gov/wp-content/uploads/2019/05/M-19-17.pdf).
 
 ## 7. Funcionamiento del servicio y atención al cliente
 

--- a/content/_policy/rules-of-use._fr.md
+++ b/content/_policy/rules-of-use._fr.md
@@ -95,7 +95,7 @@ Dans le cas peu probable où le service Login.gov serait interrompu, les renseig
 
 ## 6. Autorités
 
-Le service Login.gov est exploité aux États-Unis, mais il est accessible au public dans le monde entier. Le service Login.gov est géré par l'Administration des services généraux en vertu des pouvoirs et des directives énoncés dans [6 USC § 1523 (b)(1)(A)-(E)](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section1523&num=0&edition=prelim), la loi sur le gouvernement électronique de 2002 (Pub. L. 107–347, 44 U.S.C. 3501 note), [40 USC § 501](https://www.gsa.gov/cdnstatic/CNXII__Eligibility_to_Use_GSA.pdf), et [OMB M-19-17](https://www.whitehouse.gov/wp-content/uploads/2019/05/M-19-17.pdf).
+Le service Login.gov est exploité aux États-Unis, mais il est accessible au public dans le monde entier. Le service Login.gov est géré par l'Administration des services généraux en vertu des pouvoirs et des directives énoncés dans [6 USC § 1523 (b)(1)(A)-(E)](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section1523&num=0&edition=prelim), la loi sur le gouvernement électronique de 2002 (Pub. L. 107–347, 44 U.S.C. 3501 note), [40 USC § 501](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title40-section501&num=0&edition=prelim), et [OMB M-19-17](https://www.whitehouse.gov/wp-content/uploads/2019/05/M-19-17.pdf).
 
 ## 7. Exploitation des services et assistance à la clientèle
 


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces a link which currently 404s with an up-to-date reference, using a direct link to the relevant US Code, following the pattern from the US code reference immediately preceding it in the same sentence.

This will fix an ongoing build failure present on all branches.

Old link (404): https://www.gsa.gov/cdnstatic/CNXII__Eligibility_to_Use_GSA.pdf
New link: https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title40-section501&num=0&edition=prelim

Related Slack thread: https://gsa-tts.slack.com/archives/C0NGESUN5/p1686312424292629

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-replace-404-link/policy/rules-of-use/
2. Click "40 USC § 501", under "6. Authorities"
3. Observe that you see content related to 40 USC § 501