### PR TITLE
Add workflow guide for managing site settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ The static marketing site for Login.gov
 
 ## Guides for Common Workflows
 
-- [Contact Form Outages](./docs/development-workflows/contact-form-outages.md)
 - [Branching and Publishing Workflow](./docs/development-workflows/branching-and-publishing-workflow.md)
-- [Netlify CMS](./docs/development-workflows/netlify-cms.md)
+- [Configuring Site Settings](./docs/development-workflows/configuring-site-settings.md)
+- [Contact Form Outages](./docs/development-workflows/contact-form-outages.md)
 - [Nested Help Articles](./docs/development-workflows/nested-help-articles.md)
+- [Netlify CMS](./docs/development-workflows/netlify-cms.md)
 
 ## Development
 
@@ -24,8 +25,6 @@ make run
 ```
 
 You can then view the site in your browser at http://localhost:4000 .
-
-Optionally, you can add a `_config.dev.yml` file to the root directory to list configuration which should only apply for local development. Any settings in this file will override an equivalent setting in the base Jekyll `_config.yml` configuration. For example, you may want to configure Sass `style` to `expanded` to debug the non-minified styles, or temporarily disable non-English locales to improve rebuild times.
 
 To run specs:
 

--- a/docs/development-workflows/configuring-site-settings.md
+++ b/docs/development-workflows/configuring-site-settings.md
@@ -18,7 +18,7 @@ Once you have access to Cloud.gov Pages:
 2. After signing in, click the link for "identity-site" in the list of sites
 3. Click "Site settings" in the sidebar
 4. Expand "Advanced settings"
-5. Enter the configuration overrides under "Live site" or "Preview site", depending on where you want your configuration to apply
+5. Add or edit the settings under "Live site" or "Preview site", depending on where you want your configuration to apply
 6. Click "Save advanced settings"
 
 Saving the settings will automatically trigger a rebuild of the `main` branch. If you also need to rebuild an in-progress branch, you can either push an empty commit to your branch, or find the branch on the "Build history" page and click the "Rebuild" button.

--- a/docs/development-workflows/configuring-site-settings.md
+++ b/docs/development-workflows/configuring-site-settings.md
@@ -1,0 +1,24 @@
+# Configuring Site Settings
+
+## Local Development
+
+Default Jekyll site settings can be found in `_config.yml`. Refer to [Jekyll documentation](https://jekyllrb.com/docs/configuration/options/) for more information about configuration options.
+
+To override settings in your lcoal environment, you can add a `_config.dev.yml` file to the root directory. Any settings in this file will override an equivalent setting in the base Jekyll `_config.yml` configuration. For example, you may want to configure Sass `style` to `expanded` to debug the non-minified styles, or temporarily disable non-English locales to improve rebuild times.
+
+## Live Site
+
+The Cloud.gov Pages administration dashboard allows us to override `_config.yml` settings for the live site and for preview branches.
+
+Before managing site settings, you will need to request access from one of the existing [Cloud.gov Pages organization managers](https://docs.google.com/document/d/1ZMpi7Gj-Og1dn-qUBfQHqLc1Im7rUzDmIxKn11DPJzk/edit#heading=h.80vseiuz6587). You will need to provide them with your email address and GitHub username.
+
+Once you have access to Cloud.gov Pages:
+
+1. [Sign in to Cloud.gov Pages](https://pages.cloud.gov/)
+2. After signing in, click the link for "identity-site" in the list of sites
+3. Click "Site settings" in the sidebar
+4. Expand "Advanced settings"
+5. Enter the configuration overrides under "Live site" or "Preview site", depending on where you want your configuration to apply
+6. Click "Save advanced settings"
+
+Saving the settings will automatically trigger a rebuild of the `main` branch. If you also need to rebuild an in-progress branch, you can either push an empty commit to your branch, or find the branch on the "Build history" page and click the "Rebuild" button.

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -2,7 +2,7 @@
 
 This guide is written in a "Choose your own adventure" style to quickly guide you to relevant information, in case of an active outage.
 
-For each outcome, you will need to [sign in to Cloud.gov Pages](https://pages.cloud.gov/) and [modify site settings](https://pages.cloud.gov/sites/85/settings). Configuration can be edited under "Advanced settings" ► "Live site" ► "Site configuration", either at the end of the configuration textarea, or replacing existing configuration values for the relevant setting names.
+For each outcome, you should modify site settings by following the instructions found in the [_Configuring Site Settings_ guide](./configuring-site-settings.md#live-site).
 
 **Is the contact form currently experiencing an unexpected outage?**
 


### PR DESCRIPTION
## 🛠 Summary of changes

Builds on #1098 to add a new guide for how to edit any site settings. There were fragmented references previously to local development settings and outage handling, but this wasn't broadly applicable, and missed a few steps (e.g. requesting access, rebuilding branches after saving changes).

Related Slack discussion (private channel): https://gsa-tts.slack.com/archives/C046YTLTK6U/p1686334353060939

## 📜 Testing Plan

1. Follow the guide and see if you can understand where to add settings