### PR TITLE
Change SAM.gov link to bare path homepage

### DIFF
--- a/content/_help/specific-agencies/sam._en.md
+++ b/content/_help/specific-agencies/sam._en.md
@@ -32,14 +32,14 @@ Please do not send Login.gov sensitive data about yourself or SAM application.
 
 Login.gov can only answer questions about the sign-in process and creating a Login.gov account.
 
-Please contact [SAM.gov](https://sam.gov/SAM/pages/public/index.jsf) directly if you have questions regarding:
+Please contact [SAM.gov](https://sam.gov/) directly if you have questions regarding:
 
 * Application registration, eligibility, status or changes
 * Scheduling appointments
 * Entity registration status
 * Or other related concerns
 
-To make changes to your SAM.gov account profile, you will need to sign in at <https://www.sam.gov>.
+To make changes to your SAM.gov account profile, you will need to sign in at <https://sam.gov>.
 
 Contact the Federal Service Desk at 866-606-8220 (toll-free) or 334-206-7828 (internationally) for assistance, or submit your request via web form at [www.fsd.gov](https://www.fsd.gov/).
 

--- a/content/_help/specific-agencies/sam._es.md
+++ b/content/_help/specific-agencies/sam._es.md
@@ -31,13 +31,13 @@ Por favor, no envíes a Login.gov datos sensibles sobre ti o sobre tu solicitud 
 
 Login.gov solo puede responder preguntas sobre el proceso de inicio de sesión y sobre cómo crear una cuenta de Login.gov.
 
-Por favor, ponte en contacto directo con [SAM.gov](https://sam.gov/SAM/pages/public/index.jsf) si tienes alguna pregunta relacionada con:
+Por favor, ponte en contacto directo con [SAM.gov](https://sam.gov/) si tienes alguna pregunta relacionada con:
 * registro de solicitudes, elegibilidad, estado o cambios
 * programación de citas
 * estado del registro de entidades
 * u otros asuntos relacionados
 
-Para realizar cambios al perfil de tu cuenta de SAM.gov tendrás que iniciar sesión en <https://www.sam.gov>.
+Para realizar cambios al perfil de tu cuenta de SAM.gov tendrás que iniciar sesión en <https://sam.gov>.
 
 Ponte en contacto con el Federal Service Desk (Centro Federal de Atención al Usuario) al 866-606-8220 (llamada gratuita) o al 334-206-7828 (internacional) para recibir asistencia o envía tu solicitud a través de un formulario web en www.fsd.gov.
 

--- a/content/_help/specific-agencies/sam._fr.md
+++ b/content/_help/specific-agencies/sam._fr.md
@@ -31,13 +31,13 @@ Veuillez ne pas envoyer de données sensibles de Login.gov vous concernant ou co
 
 Login.gov peut uniquement répondre aux questions concernant le processus de connexion et la création d’un compte Login.gov.
 
-Veuillez contacter directement [SAM.gov](https://sam.gov/SAM/pages/public/index.jsf) si vous avez des questions à ce sujet :
+Veuillez contacter directement [SAM.gov](https://sam.gov/) si vous avez des questions à ce sujet :
 * Enregistrement de la demande, éligibilité, statut ou changements
 * Fixation des rendez-vous
 * Statut d’enregistrement de l’entité
 * Ou d’autres préoccupations connexes
 
-Pour apporter des modifications à votre profil de compte SAM.gov, vous devez vous connecter à <https://www.sam.gov>.
+Pour apporter des modifications à votre profil de compte SAM.gov, vous devez vous connecter à <https://sam.gov>.
 
 Contactez le Federal Service Desk au 866-606-8220 (frais de péage) ou au 334-206-7828 (international) pour obtenir de l’aide, ou soumettez votre demande via le formulaire web à [www.fsd.gov](https://www.fsd.gov/).
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates SAM.gov links to direct users to the root path homepage.

Why?

- It's where the user arrives by this link anyways
- May be remnant of the older site (redesigned in 2022)
- Hopefully resolves some intermittent build failures for the daily external link checker
- Changing from www.sam.gov to [sam.gov](https://sam.gov) skips a redirect hop, so the user arrives where they want without delay
  - `$ curl -I --silent https://www.sam.gov | grep Location:`
  - `Location: https://sam.gov/`

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1686398830922189

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-sam-gov-homepage/help/specific-agencies/sam/
2. Click either of the "SAM.gov" links
3. Observe that you arrive at the same place as the corresponding links on [the live site version of the page](https://login.gov/help/specific-agencies/sam/)