### PR TITLE
Add YAML normalization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,16 @@ jobs:
           name: Lint JavaScript
           command: make lint-js
 
+  lint-yaml:
+    docker:
+      - image: cimg/ruby:2.7-node
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Lint YAML
+          command: make lint-yaml
+
   typecheck-js:
     docker:
       - image: cimg/ruby:2.7-node

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ lint-assets:
 	npm run optimize-assets > /dev/null
 	git diff --quiet assets/img || (echo "Error: Optimize SVG images using 'npm run optimize-assets'"; exit 1)
 
-lint: lint-js lint-assets validate-lockfiles typecheck-js
+lint-yaml:
+	npm run normalize-yaml
+	(! git diff --name-only | grep ".*\.yml$$") || (echo "Error: Run 'make normalize_yaml' to normalize YAML"; exit 1)
+
+lint: lint-js lint-assets lint-yaml validate-lockfiles typecheck-js
 
 test: build
 	bundle exec rspec spec

--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -1,7 +1,7 @@
 accessible_labels:
+  footer_navigation: Footer navigation
   login_link_logo: Login.gov Homepage
   partners_link_logo: Login.gov Partners Homepage
-  footer_navigation: Footer navigation
   primary_navigation: Primary links
   secondary_navigation: Secondary links
 actions:
@@ -17,22 +17,22 @@ banner:
     learn: Learn how to create an account
     tagline: Your one account for government
   text:
-    official: An official website of the United States government
-    how: Here’s how you know
+    gov_description: A <strong>.gov</strong> website belongs to an official
+      government organization in the United States.
     gov_heading: Official websites use .gov
-    gov_description: A <strong>.gov</strong> website belongs to an official government organization in the United States.
+    how: Here’s how you know
+    official: An official website of the United States government
+    secure_description: 'A <strong>lock</strong> or <strong>https://</strong> means
+      you’ve safely connected to the .gov website. Share sensitive information
+      only on official, secure websites.'
     secure_heading: Secure .gov websites use HTTPS
-    secure_description: 'A <strong>lock</strong> or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.'
 contact_page:
+  call_us:
+    operating_hours: Operating hours are 24 hours a day, seven days a week.
+    title: Call us
   operating_hours: Operating hours are 24 hours a day, seven days a week.
   required: required
-  call_us:
-    title: Call us
-    operating_hours: Operating hours are 24 hours a day, seven days a week.
   support_request_form:
-    title: Submit a help ticket
-    other: Other
-    required_text: Required fields are marked with an asterisk
     agencies:
       'Central Intelligence Agency': Central Intelligence Agency
       'Consumer Financial Protection Bureau': Consumer Financial Protection Bureau
@@ -42,14 +42,14 @@ contact_page:
       'Department of Defense': Department of Defense
       'Department of Education': Department of Education
       'Department of Energy': Department of Energy
-      'Department of the Interior': Department of the Interior
       'Department of Labor': Department of Labor
       'Department of State': Department of State
-      'Department of Transportation': Department of Transportation
+      'Department of the Interior': Department of the Interior
       'Department of the Treasury': Department of the Treasury
+      'Department of Transportation': Department of Transportation
       'Department of Veterans Affairs': Department of Veterans Affairs
-      'DOI ePermits': DOI ePermits
       'DOD Moves.mil (Homes or Office)': DOD Move.mil (Homes or Office)
+      'DOI ePermits': DOI ePermits
       'DOL Foreign Labor Application Gateway (FLAG)': DOL Foreign Labor Application Gateway (FLAG)
       'DOT Delphi eInvoicing': DOT Delphi eInvoicing
       'DOT FMCSA (Motor Carrier Safety)': DOT FMCSA (Motor Carrier Safety)
@@ -79,30 +79,37 @@ contact_page:
       'Securities and Exchange Commission': Securities and Exchange Commission
       'Social Security Administration (SSA)': Social Security Administration (SSA)
       'Trusted Traveler Programs (Global Entry/Nexus/Sentri)': Trusted Traveler Programs (Global Entry/Nexus/Sentri)
-      'United States Forest Service': United States Forest Services
       'U.S. Agency for International Development': U.S. Agency for International Development
       'U.S. Department of Agriculture': U.S. Department of Agriculture
       'U.S. International Trade Commission': U.S. International Trade Commission
+      'United States Forest Service': United States Forest Services
       'USAJOBS': USAJOBS
     errors:
-      pii_found: For your privacy, do not submit sensitive information to this form. Our customer support agents can still assist you without this information.
       captcha_required: You must complete the spam prevention challenge.
+      pii_found: For your privacy, do not submit sensitive information to this form.
+        Our customer support agents can still assist you without this
+        information.
     form_helpers:
-      select_topic: '- Select a topic -'
-      select_issue: '- Select a specific issue -'
       select_agency: '- Agency you’re trying to access -'
+      select_issue: '- Select a specific issue -'
+      select_topic: '- Select a topic -'
     labels:
       agency_application: Partner Agency
       agency_application_all: All Applications
       agency_application_common: Common Applications
       agency_application_other: Other Applications
-      description: Provide more detail. If you need support, please describe the steps you took and the issues you encountered.
+      description: Provide more detail. If you need support, please describe the steps
+        you took and the issues you encountered.
       email: Email
       first_name: First name
       last_name: Last name
-      pii_warning: Do not include phone numbers, membership numbers, full names, birthdays, addresses, social security numbers, or other identifying information.
+      pii_warning: Do not include phone numbers, membership numbers, full names,
+        birthdays, addresses, social security numbers, or other identifying
+        information.
       subtopic: Issue
       topic: Topic
+    other: Other
+    required_text: Required fields are marked with an asterisk
     reset: Clear form
     submit: Submit
     subtopics:
@@ -112,37 +119,37 @@ contact_page:
       authentication_app: How do I change my authentication method?
       authentication_app_setup: How do I set up an authentication app?
       backup_codes: How do I use my backup codes to sign in?
-      blank_screen: I'm seeing an error/blank screen when creating my account
+      blank_screen: I’m seeing an error/blank screen when creating my account
       cant_proof_in_person: I could not verify my identity in person at the Post Office
       change_email: How do I change my email?
       change_password: How do I update my Login.gov password?
       change_phone_number: How do I change my phone number?
-      concerned_login_email: I'm concerned about the Login.gov email I received
+      concerned_login_email: I’m concerned about the Login.gov email I received
       delete_account: How do I delete my Login.gov account?
       device_notification: I have received an alert about a new sign in on my Login.gov account
       email_delivery_issue: I am not receiving the Login.gov confirmation email
       feedback: I have feedback about Login.gov
-      forgot_password: I forgot my Login.gov password and can't reset it
-      how_to_link: How do I link my partner agency account with Login.gov?
+      forgot_password: I forgot my Login.gov password and can’t reset it
       how_to_create_with_verification: How do I create a Login.gov account with identity verification?
+      how_to_link: How do I link my partner agency account with Login.gov?
       how_to_verify: How/why do I verify my identify?
+      interest_in_partnership: I’m interested in using Login.gov for my government agency
       international_number: I have an international number and am not receiving my security code
-      interest_in_partnership: I'm interested in using Login.gov for my government agency
       invalid_email: Login.gov is not accepting my email address. It says it is invalid
       invalid_otp: Login.gov says my security code is invalid
-      issue_with_partner_agency: I'm having an issue with this partner agency
-      issues_with_face_touch_unlock: I'm having issue with using face or touch unlock
-      letter_in_mail: I didn't get my letter by mail or it expired
+      issue_with_partner_agency: I’m having an issue with this partner agency
+      issues_with_face_touch_unlock: I’m having issue with using face or touch unlock
+      letter_in_mail: I didn’t get my letter by mail or it expired
       locked_out: I am locked out of my account
-      lost_access: I've lost access to my phone or email address
       lost_2fa_method: Lost two-factor authentication method
+      lost_access: I’ve lost access to my phone or email address
       multiple_otps: I am receiving many security codes when signing in
       new_account: My email/username and password are not working
       new_backup_codes: How do I get new backup codes?
+      new_device_notification: I’ve received a new device notification email
       new_personal_key: How do I get a new personal key?
-      new_device_notification: I've received a new device notification email
       no_otp_received: No OTP received
-      no_phone: I can't create my Login.gov account because I don't have a phone
+      no_phone: I can’t create my Login.gov account because I don’t have a phone
       none: '--None--'
       other: Other
       password_issue: Password issue
@@ -153,18 +160,19 @@ contact_page:
       piv_cac: I am having trouble using my PIV/CAC to sign in
       privacy_and_security: Privacy and security
       recover_account: How do I sign into my account if I dont have my phone or personal key?
+      remember_browser: I set up remember browser but I’m still receiving security codes
       remember_device_issue: How do I stop receiving security codes?
-      remember_browser: I set up remember browser but I'm still receiving security codes
-      security_question: How do you/How does Login.gov protect my privacy and security?
       security_code: I am not receiving the security code
       security_key: I am having trouble using my security key to sign in
-      seeing_errors: I'm seeing an error/blank screen when accessing Login.gov
+      security_question: How do you/How does Login.gov protect my privacy and security?
+      seeing_errors: I’m seeing an error/blank screen when accessing Login.gov
       service_quality: Service quality
-      site_navigation: I don't know where to go to create an account
+      site_navigation: I don’t know where to go to create an account
       state_issued_id_error: I got an error after uploading my state-issued ID
-      unwanted_otp: I am receiving security codes from Login.gov that I didn't request
+      unwanted_otp: I am receiving security codes from Login.gov that I didn’t request
       verify_identity_error: I got a failure trying to verify my identity
       wrong_account_update: Wrong account update
+    title: Submit a help ticket
     topics:
       changing_settings: Changing your Login.gov information
       creating_account: Create a Login.gov account
@@ -176,9 +184,9 @@ contact_page:
       signing_in: Signing in to your Login.gov account
       verifying_identity: Verifying your identity
 feedback_form:
-  'yes': 'Yes'
   'no': 'No'
   question: 'Was this article helpful?'
+  'yes': 'Yes'
 global:
   language: Language
   locales:
@@ -186,38 +194,61 @@ global:
     es: Español
     fr: Français
 help_page:
+  categories:
+    - description: Create your account. Learn about authentication options and more
+        account features.
+      image: /assets/img/help/get-started.svg
+      title: Get started with Login.gov
+      url: /help/get-started/overview/
+    - description: Forgot your password? Locked out of your account? We’ll help you
+        resolve access issues.
+      image: /assets/img/help/trouble-signing-in.svg
+      title: Trouble signing in?
+      url: /help/trouble-signing-in/overview/
+    - description: Change your account settings including your password, phone number,
+        email, and more.
+      image: /assets/img/help/manage-your-account.svg
+      title: Manage your account
+      url: /help/manage-your-account/overview/
+    - description: Get help with Trusted Traveler Programs (TTP) and SAM.gov.
+      image: /assets/img/help/help-specific-agencies.svg
+      title: Help with specific agencies
+      url: /help/specific-agencies/overview/
+    - description: Learn about options for verifying your identity.
+      image: /assets/img/help/verify-your-id.svg
+      title: Verify your identity
+      url: /help/verify-your-identity/overview/
   p_1: Browse common topics
   title: How can we help?
-  categories:
-    - title: Get started with Login.gov
-      description: Create your account. Learn about authentication options and more account features.
-      url: /help/get-started/overview/
-      image: /assets/img/help/get-started.svg
-    - title: Trouble signing in?
-      description: Forgot your password? Locked out of your account? We'll help you resolve access issues.
-      url: /help/trouble-signing-in/overview/
-      image: /assets/img/help/trouble-signing-in.svg
-    - title: Manage your account
-      description: Change your account settings including your password, phone number, email, and more.
-      url: /help/manage-your-account/overview/
-      image: /assets/img/help/manage-your-account.svg
-    - title: Help with specific agencies
-      description: Get help with Trusted Traveler Programs (TTP) and SAM.gov.
-      url: /help/specific-agencies/overview/
-      image: /assets/img/help/help-specific-agencies.svg
-    - title: Verify your identity
-      description: Learn about options for verifying your identity.
-      url: /help/verify-your-identity/overview/
-      image: /assets/img/help/verify-your-id.svg
 help_subpages:
   get-started: Get started with Login.gov
-  trouble-signing-in: Trouble signing in?
   manage-your-account: Manage your account
   specific-agencies: Help with specific agencies
+  trouble-signing-in: Trouble signing in?
   verify-your-identity: Verify your identity
+identifier:
+  accessible_labels:
+    description: Agency description
+    gsa_link_logo: GSA homepage
+    identifier: Agency identifier
+    links: Important links
+    login_gov_logo: Login.gov logo
+    usa_gov: U.S. government information and services
+  disclaimer: An official website of the [General Services
+    Administration](https://www.gsa.gov)
+  links:
+    about_agency: About GSA
+    accessibility: Accessibility support
+    foia: FOIA requests
+    ig: Office of the Inspector General
+    no_fear_act: No FEAR Act data
+    performance: Performance reports
+    privacy: Privacy policy
+  usa_gov:
+    link: Visit USA.gov
+    text: Looking for U.S. government information and services?
 nav:
   about_us:
-    title: About us
     sections:
       - name: Our mission
         url: '#our-mission'
@@ -225,8 +256,8 @@ nav:
         url: '#our-vision'
       - name: About Login.gov
         url: '#about-logingov'
+    title: About us
   accessibility:
-    title: Accessibility statement
     sections:
       - name: Our Commitment
         url: '#our-commitment'
@@ -236,12 +267,13 @@ nav:
         url: '#evaluation'
       - name: Known limitations
         url: '#known-limitations'
+    title: Accessibility statement
   anchor_to_top: Back to top
   become_a_partner: Become a partner
   business_inquiries:
     title: Business inquiries
+  contact_login_gov: Contact Login.gov
   contact_us:
-    title: Contact us
     sections:
       - name: Find answers to commonly asked questions
         url: '#find-answers-to-commonly-asked-questions'
@@ -251,7 +283,7 @@ nav:
         url: '#partner-with-logingov'
       - name: Report an issue
         url: '#report-an-issue'
-  contact_login_gov: Contact Login.gov
+    title: Contact us
   create_an_account: Create an account
   developer_guide: Developer guide
   developers: developers
@@ -260,26 +292,24 @@ nav:
   groups:
     about_login_gov: About Login.gov
     agencies: For agencies
-    partners: For partners
     learn: Learn
+    partners: For partners
     support: Support
   help: Help
   help_center: Help center
   home: Home
   implementation: Implementation
   join_us:
-    title: Join us
     sections:
       - name: Open positions
         url: '#open-positions'
       - name: How to apply
         url: '#how-to-apply'
+    title: Join us
   menu: Menu
   overview: Overview
   playbook: Playbook
   policies:
-    title: Privacy & security
-    url: /policy/
     sections:
       - name: Our commitment to your privacy and security
         url: /policy/
@@ -293,6 +323,8 @@ nav:
         url: /policy/messaging-terms-and-conditions/
       - name: Rules of use
         url: /policy/rules-of-use/
+    title: Privacy & security
+    url: /policy/
   principles: Principles
   privacy_&_security: Privacy & security
   security: Security
@@ -303,17 +335,15 @@ nav:
   what_is_login_gov: What is Login.gov?
   who_uses_login_gov: Who uses Login.gov?
 policies:
-  title: Privacy & security
   sections:
     - name: Our commitment to your privacy and security
-      url: '/policy/'
       sublinks:
         - text: How we work with our partner agencies
           url: '#how-we-work-with-our-partner-agencies'
+      url: '/policy/'
     - name: How does it work?
       url: '/policy/how-does-it-work/'
     - name: Our privacy act statement
-      url: '/policy/our-privacy-act-statement/'
       sublinks:
         - text: The Authority - Who authorizes the collection of this data?
           url: '#authority'
@@ -329,37 +359,19 @@ policies:
           url: '#analytics'
         - text: Privacy Impact Assessment
           url: '#impact'
+      url: '/policy/our-privacy-act-statement/'
     - name: Our security practices
-      url: '/policy/our-security-practices/'
       sublinks:
         - text: Vulnerability disclosure policy
           url: '#vdp'
         - text: For more information
           url: '#more-info'
+      url: '/policy/our-security-practices/'
     - name: Messaging terms and conditions
-      url: '/policy/messaging-terms-and-conditions/'
       sublinks:
         - text: SMS terms and conditions
           url: '#terms'
+      url: '/policy/messaging-terms-and-conditions/'
     - name: Rules of use
       url: '/policy/rules-of-use/'
-identifier:
-  accessible_labels:
-    description: Agency description
-    identifier: Agency identifier
-    links: Important links
-    login_gov_logo: Login.gov logo
-    gsa_link_logo: GSA homepage
-    usa_gov: U.S. government information and services
-  disclaimer: An official website of the [General Services Administration](https://www.gsa.gov)
-  links:
-    about_agency: About GSA
-    accessibility: Accessibility support
-    foia: FOIA requests
-    ig: Office of the Inspector General
-    no_fear_act: No FEAR Act data
-    performance: Performance reports
-    privacy: Privacy policy
-  usa_gov:
-    text: Looking for U.S. government information and services?
-    link: Visit USA.gov
+  title: Privacy & security

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -1,7 +1,7 @@
 accessible_labels:
-  login_link_logo:  Página de inicio de Login.gov
-  partners_link_logo: Página de inicio Login.gov Partners
   footer_navigation: Navegación de pie de página
+  login_link_logo: Página de inicio de Login.gov
+  partners_link_logo: Página de inicio Login.gov Partners
   primary_navigation: Enlaces primarios
   secondary_navigation: Enlaces secundarios
 actions:
@@ -10,29 +10,32 @@ banner:
   already-have-an-account:
     learn_more: Obtenga más información sobre cómo crear una cuenta
     one_account: Login.gov es su cuenta única para el gobierno
-    sign_in: Inicie sesión para administrar su cuenta y actualizar su información personal o las opciones de seguridad
+    sign_in: Inicie sesión para administrar su cuenta y actualizar su información
+      personal o las opciones de seguridad
     text: ¿Ya tiene una cuenta?
   one-account-for-govt:
     create: Crea una cuenta
     learn: Aprender a crear una cuenta
     tagline: Su única cuenta para el gobierno
   text:
-    official: Un sitio web oficial del gobierno de los Estados Unidos
-    how: Así es como sabes
+    gov_description: Un sitio web .gov pertenece a una organización oficial del
+      Gobierno de Estados Unidos.
     gov_heading: Los sitios web oficiales usan .gov
-    gov_description: Un sitio web .gov pertenece a una organización oficial del Gobierno de Estados Unidos.
+    how: Así es como sabes
+    official: Un sitio web oficial del gobierno de los Estados Unidos
+    secure_description: 'Un <strong>candado</strong> o <strong>https://</strong>
+      significa que usted se conectó de forma segura a un sitio web .gov.
+      Comparta información sensible sólo en sitios web oficiales y seguros.'
     secure_heading: os sitios web seguros .gov usan HTTPS
-    secure_description: 'Un <strong>candado</strong> o <strong>https://</strong> significa que usted se conectó de forma segura a un sitio web .gov. Comparta información sensible sólo en sitios web oficiales y seguros.'
 contact_page:
-  operating_hours: 'El horario de servicio es el siguiente: las 24 horas del día, los siete días de la semana.'
-  required: requerido
   call_us:
+    operating_hours: 'El horario de servicio es el siguiente: las 24 horas del día,
+      los siete días de la semana.'
     title: Llámenos
-    operating_hours: 'El horario de servicio es el siguiente: las 24 horas del día, los siete días de la semana.'
+  operating_hours: 'El horario de servicio es el siguiente: las 24 horas del día,
+    los siete días de la semana.'
+  required: requerido
   support_request_form:
-    title: Enviar un tíquet de ayuda
-    other: Otro
-    required_text: Los campos obligatorios están marcados con un asterisco
     agencies:
       'Central Intelligence Agency': Agence centrale de renseignement
       'Consumer Financial Protection Bureau': Oficina para la Protección Financiera del Consumidor
@@ -42,20 +45,24 @@ contact_page:
       'Department of Defense': Departamento de Defensa
       'Department of Education': Departamento de Educación
       'Department of Energy': Departamento de Energía
-      'Department of the Interior': Departamento del Interior
       'Department of Labor': Departamento del Trabajo
       'Department of State': Departamento de Estado
-      'Department of Transportation': Departamento de Transporte
+      'Department of the Interior': Departamento del Interior
       'Department of the Treasury': Departamento del Tesoro
-      'DOD Moves.mil (Homes or Office)': DOD Move.mil (Hogares u oficinas)
+      'Department of Transportation': Departamento de Transporte
       'Department of Veterans Affairs': Departamento de Asuntos de los Veteranos
+      'DOD Moves.mil (Homes or Office)': DOD Move.mil (Hogares u oficinas)
       'DOI ePermits': Permisos electrónicos del Departamento del Interior (DOI)
-      'DOL Foreign Labor Application Gateway (FLAG)': Portal de solicitud de mano de obra extranjera (FLAG) del Departamento del Trabajo (DOL)
+      'DOL Foreign Labor Application Gateway (FLAG)': Portal de solicitud de mano de
+        obra extranjera (FLAG) del Departamento del Trabajo (DOL)
       'DOT Delphi eInvoicing': Facturación electrónica en Delphi del Departamento de Transporte (DOT)
       'DOT FMCSA (Motor Carrier Safety)': FMCSA del Departamento de Transporte (Seguridad de Autotransportes)
-      'DOT National Registry of Certified Medical Examiners': Registro Nacional de Examinadores Médicos Certificados del Departamento de Transporte
+      'DOT National Registry of Certified Medical Examiners': Registro Nacional de
+        Examinadores Médicos Certificados del Departamento de Transporte
       'Environmental Protection Agency': Agencia de Protección Ambiental
-      'FDIC Resolution Request Management Portal': Portal de administración de resoluciones de solicitudes de la Corporación Federal de Seguro de Depósitos (FDIC)
+      'FDIC Resolution Request Management Portal': Portal de administración de
+        resoluciones de solicitudes de la Corporación Federal de Seguro de
+        Depósitos (FDIC)
       'FEMA Disaster Assistance': Asistencia de FEMA en caso de catástrofe
       'General Services Administration': Administración de Servicios Generales
       'GSA Sam.gov': GSA SAM.gov
@@ -75,36 +82,43 @@ contact_page:
       'PBGC-MyPBA': 'PBGC - MyPBA'
       'Peace Corps': Cuerpo de Paz
       'Railroad Retirement Board': Junta de Jubilación del Ferrocarril
-      'Securities and Exchange Commision': Comisión de Bolsa y Valores
       'SBA DLAP': SBA DLAP
+      'Securities and Exchange Commision': Comisión de Bolsa y Valores
       'Securities and Exchange Commission': Comisión de Bolsa y Valores
       'Social Security Administration (SSA)': Administración del Seguro Social (SSA, por su siglas en inglés)
       'Trusted Traveler Programs (Global Entry/Nexus/Sentri)': Programas de Viajero de Confianza (Global Entry/Nexus/Sentri)
       'U.S. Agency for International Development': Agencia de los Estados Unidos para el Desarrollo Internacional
       'U.S. Department of Agriculture': Departamento de Agricultura de los Estados Unidos
-      'United States Forest Service': Servicio Forestal de los Estados Unidos
       'U.S. International Trade Commission': Comisión Internacional de Comercio de los Estados Unidos
+      'United States Forest Service': Servicio Forestal de los Estados Unidos
       'USAJOBS': USAJOBS
     errors:
-      pii_found: Por su privacidad, no envíe información confidencial en este formulario. Nuestros agentes de atención al cliente pueden atenderle igualmente sin esta información.
       captcha_required: Debes superar el desafío de prevención de spam.
+      pii_found: Por su privacidad, no envíe información confidencial en este
+        formulario. Nuestros agentes de atención al cliente pueden atenderle
+        igualmente sin esta información.
     form_helpers:
-      select_topic: '- Seleccione un tema -'
-      select_issue: '- Seleccione un problema específico -'
       select_agency: '- Seleccione Agencia a la que intenta acceder-'
+      select_issue: '- Seleccione un problema específico -'
+      select_topic: '- Seleccione un tema -'
     labels:
       agency_application: Aplicación de agencia
       agency_application_all: Todas las aplicaciones
       agency_application_common: Aplicaciones comunes
       agency_application_other: Otras aplicaciones
-      description: Proporcione más detalles. Si necesita ayuda, por favor describa los pasos que dio y los problemas que encontró.
+      description: Proporcione más detalles. Si necesita ayuda, por favor describa los
+        pasos que dio y los problemas que encontró.
       email: Correo electrónico
       first_name: Nombre
       last_name: Apellido
-      pii_warning: 'No incluya números de teléfono, números de socio, nombres completos, cumpleaños, direcciones, números de la seguridad social u otros datos identificativos.'
+      optional: opcional
+      pii_warning: 'No incluya números de teléfono, números de socio, nombres
+        completos, cumpleaños, direcciones, números de la seguridad social u
+        otros datos identificativos.'
       subtopic: Subtema del problema
       topic: Tema del problema
-      optional: opcional
+    other: Otro
+    required_text: Los campos obligatorios están marcados con un asterisco
     reset: Limpiar formulario
     submit: Enviar
     subtopics:
@@ -121,23 +135,25 @@ contact_page:
       change_phone_number: ¿Cómo cambio mi número de teléfono?
       concerned_login_email: Estoy preocupado por el correo electrónico de Login.gov que he recibido
       delete_account: ¿Cómo elimino mi cuenta de Login.gov?
-      device_notification: He recibido una alerta sobre un nuevo inicio de sesión en mi cuenta de Login.gov
-      feedback: Tengo comentarios sobre Login.gov
+      device_notification: He recibido una alerta sobre un nuevo inicio de sesión en
+        mi cuenta de Login.gov
       email_delivery_issue: No recibo el correo electrónico de confirmación de Login.gov
+      feedback: Tengo comentarios sobre Login.gov
       forgot_password: Olvidé mi contraseña de Login.gov y no puedo restablecerla
-      how_to_link: ¿Cómo puedo vincular la cuenta de mi agencia asociada con Login.gov?
       how_to_create_with_verification: ¿Cómo puedo crear una cuenta en Login.gov con verificación de identidad?
+      how_to_link: ¿Cómo puedo vincular la cuenta de mi agencia asociada con Login.gov?
       how_to_verify: ¿Cómo/por qué verifico mi identidad?
       interest_in_partnership: Estoy interesado en utilizar Login.gov para mi agencia gubernamental
       international_number: Tengo un número internacional y no recibo mi código de seguridad
-      invalid_email: Login.gov no acepta mi dirección de correo electrónico. Dice que no es válido
+      invalid_email: Login.gov no acepta mi dirección de correo electrónico. Dice que
+        no es válido
       invalid_otp: Login.gov dice que mi código de seguridad no es válido
       issue_with_partner_agency: Tengo un problema con esta agencia asociada
       issues_with_face_touch_unlock: Tengo problemas con el uso del desbloqueo facial o táctil
       letter_in_mail: No he recibido mi carta por correo o ha caducado
       locked_out: Estoy bloqueado en mi cuenta
-      lost_access: He perdido el acceso a mi teléfono o dirección de correo electrónico
       lost_2fa_method: Método autenticación de dos factores perdido
+      lost_access: He perdido el acceso a mi teléfono o dirección de correo electrónico
       multiple_otps: Recibo códigos de seguridad de Login.gov que no he solicitado
       new_account: Mi correo electrónico/nombre de usuario y contraseña no funcionan
       new_backup_codes: ¿Cómo consigo nuevos códigos de copia de seguridad?
@@ -149,39 +165,44 @@ contact_page:
       other: Otro
       password_issue: Problema con la contraseña
       personal_key: Mi clave personal no funciona
+      personal_key_notification: He recibido una alerta sobre un nuevo inicio de
+        sesión en mi cuenta de Login.gov
       personal_key_setup: Configuración de la clave personal
-      personal_key_notification: He recibido una alerta sobre un nuevo inicio de sesión en mi cuenta de Login.gov
       phone_number_failure: He recibido un fallo después de introducir mi número de teléfono
       piv_cac: Tengo problemas para usar mi PIV/CAC para iniciar sesión
       privacy_and_security: Privacidad y seguridad
-      recover_account: ¿Cómo puedo entrar en mi cuenta si no tengo mi teléfono o mi clave personal?
+      recover_account: ¿Cómo puedo entrar en mi cuenta si no tengo mi teléfono o mi
+        clave personal?
+      remember_browser: He configurado el navegador para recordar, pero sigo
+        recibiendo códigos de seguridad
       remember_device_issue: ¿Cómo puedo dejar de recibir los códigos de seguridad?
-      remember_browser: He configurado el navegador para recordar, pero sigo recibiendo códigos de seguridad
-      security_question: ¿Cómo protege Login.gov mi privacidad y seguridad?
       security_code: No recibo el código de seguridad
       security_key: Tengo problemas para usar mi clave de seguridad para iniciar sesión
+      security_question: ¿Cómo protege Login.gov mi privacidad y seguridad?
       seeing_errors: Veo una pantalla de error/en blanco cuando accedo a Login.gov
       service_quality: Calidad del servicio
       site_navigation: No sé dónde ir para crear una cuenta
-      state_issued_id_error: Tengo un error después de subir mi documento de identidad emitido por el estado
+      state_issued_id_error: Tengo un error después de subir mi documento de identidad
+        emitido por el estado
       unwanted_otp: Recibo muchos códigos de seguridad al iniciar sesión
       verify_identity_error: He recibido un fallo al intentar verificar mi identidad
       wrong_account_update: Actualización de la cuenta errónea
+    title: Enviar un tíquet de ayuda
     topics:
       changing_settings: Cambiar su información de Login.gov
       creating_account: Crear una cuenta de Login.gov
       feedback: Comentarios para Login.gov
       not_login_gov: No es Login.gov
       other: Otro
-      piv_cac: Problema con CAC (tarjeta de acceso común) o PIV (verificación de identidad
-        personal)
+      piv_cac: Problema con CAC (tarjeta de acceso común) o PIV (verificación de
+        identidad personal)
       security_codes: Códigos de seguridad de Login.gov
       signing_in: Iniciar sesión en su cuenta de Login.gov
       verifying_identity: Verificar su identidad
 feedback_form:
-  'yes': 'Si'
   'no': 'No'
   question: ¿Te resultó útil este artículo?
+  'yes': 'Si'
 footer:
   gsa: Administración General de Servicios de EE. UU.
 global:
@@ -191,38 +212,61 @@ global:
     es: Español
     fr: Français
 help_page:
+  categories:
+    - description: Cree su cuenta. Conozca las opciones de autenticación y más
+        características de la cuenta.
+      image: /assets/img/help/get-started.svg
+      title: Empiece con Login.gov
+      url: /es/help/get-started/overview/
+    - description: ¿Olvidó su contraseña? ¿Se bloqueó su cuenta? Le ayudaremos a
+        solucionar los problemas de acceso.
+      image: /assets/img/help/trouble-signing-in.svg
+      title: ¿Tiene problemas para iniciar sesión?
+      url: /es/help/trouble-signing-in/overview/
+    - description: Cambia la configuración de la cuenta, incluida la contraseña, el
+        teléfono, el correo electrónico y más.
+      image: /assets/img/help/manage-your-account.svg
+      title: Administrar su cuenta
+      url: /es/help/manage-your-account/overview/
+    - description: Obtenga ayuda con Trusted Traveler Programs (TTP), SAM.gov.
+      image: /assets/img/help/help-specific-agencies.svg
+      title: Asistencia de agencias específicas
+      url: /es/help/specific-agencies/overview/
+    - description: Aprenda sobre las opciones para verificar su identidad.
+      image: /assets/img/help/verify-your-id.svg
+      title: Verifique su identidad
+      url: /es/help/verify-your-identity/overview/
   p_1: Explore los temas comunes
   title: ¿Cómo podemos ayudar?
-  categories:
-    - title: Empiece con Login.gov
-      description: Cree su cuenta. Conozca las opciones de autenticación y más características de la cuenta.
-      url: /es/help/get-started/overview/
-      image: /assets/img/help/get-started.svg
-    - title: ¿Tiene problemas para iniciar sesión?
-      description: ¿Olvidó su contraseña? ¿Se bloqueó su cuenta? Le ayudaremos a solucionar los problemas de acceso.
-      url: /es/help/trouble-signing-in/overview/
-      image: /assets/img/help/trouble-signing-in.svg
-    - title: Administrar su cuenta
-      description: Cambia la configuración de la cuenta, incluida la contraseña, el teléfono, el correo electrónico y más.
-      url: /es/help/manage-your-account/overview/
-      image: /assets/img/help/manage-your-account.svg
-    - title: Asistencia de agencias específicas
-      description: Obtenga ayuda con Trusted Traveler Programs (TTP), SAM.gov.
-      url: /es/help/specific-agencies/overview/
-      image: /assets/img/help/help-specific-agencies.svg
-    - title: Verifique su identidad
-      description: Aprenda sobre las opciones para verificar su identidad.
-      url: /es/help/verify-your-identity/overview/
-      image: /assets/img/help/verify-your-id.svg
 help_subpages:
   get-started: Empiece con Login.gov
-  trouble-signing-in: ¿Tiene problemas para iniciar sesión?
   manage-your-account: Administrar su cuenta
   specific-agencies: Ayuda con agencias específicas
+  trouble-signing-in: ¿Tiene problemas para iniciar sesión?
   verify-your-identity: Verificación de identidad
+identifier:
+  accessible_labels:
+    description: Descripción de la agencia
+    gsa_link_logo: Página de inicio de GSA
+    identifier: Identificador de la agencia
+    links: Enlaces importantes
+    login_gov_logo: Logotipo de Login.gov
+    usa_gov: Información y servicios del Gobierno de EE. UU.
+  disclaimer: Un sitio web oficial de [General Services
+    Administration](https://www.gsa.gov)
+  links:
+    about_agency: Acerca de GSA
+    accessibility: Soporte de accesibilidad
+    foia: Solicitud a través de FOIA
+    ig: Oficina del Inspector General
+    no_fear_act: Datos de la ley No FEAR
+    performance: Informes de desempeño
+    privacy: Política de privacidad
+  usa_gov:
+    link: Visite USAGov en Español
+    text: ¿Necesita información y servicios del Gobierno?
 nav:
   about_us:
-    title: Acerca de nosotros
     sections:
       - name: Nuestra misión
         url: '#nuestra-misión'
@@ -230,8 +274,8 @@ nav:
         url: '#nuestra-visión'
       - name: Acerca de Login.gov
         url: '#acerca-de-logingov'
+    title: Acerca de nosotros
   accessibility:
-    title: Accesibilidad
     sections:
       - name: Nuestro compromiso
         url: '#nuestro-compromiso'
@@ -241,12 +285,14 @@ nav:
         url: '#evaluación'
       - name: Limitaciones conocidas
         url: '#limitaciones-conocidas'
+    title: Accesibilidad
   anchor_to_top: Volver arriba
   become_a_partner: Convertirse en un compañero
   business_inquiries:
     title: Business inquiries
+
+  contact_login_gov: Póngase en contacto con Login.gov
   contact_us:
-    title: Contacta con nosotros
     sections:
       - name: Encuentra las respuestas a las preguntas más frecuentes
         url: '#encuentra-las-respuestas-a-las-preguntas-más-frecuentes'
@@ -256,8 +302,7 @@ nav:
         url: '#asociarse-con-logingov'
       - name: Reportar un problema
         url: '#reportar-un-problema'
-
-  contact_login_gov: Póngase en contacto con Login.gov
+    title: Contacta con nosotros
   create_an_account: Crea una cuenta
   developer_guide: Guía para desarrolladores
   developers: Desarrolladores
@@ -266,26 +311,24 @@ nav:
   groups:
     about_login_gov: About Login.gov # partners site does not require translations
     agencies: Para agencias
-    partners: For partners # partners site does not require translations
     learn: Aprender
+    partners: For partners # partners site does not require translations
     support: Apoyo
   help: Ayuda
   help_center: Centro de ayuda
   home: Inicio
   implementation: Implementación
   join_us:
-    title: Únete a nuestro equipo
     sections:
       - name: Posiciones abiertas
         url: '#posiciones-abiertas'
       - name: Cómo aplicar
         url: '#cómo-aplicar'
+    title: Únete a nuestro equipo
   menu: Menú
   overview: Resumen
   playbook: Manual
   policies:
-    title: Privacidad y seguridad
-    url: /es/policy/
     sections:
       - name: Nuestro compromiso con su privacidad y seguridad
         url: /es/policy/
@@ -299,6 +342,8 @@ nav:
         url: /es/policy/messaging-terms-and-conditions/
       - name: Reglas de uso
         url: /es/policy/rules-of-use/
+    title: Privacidad y seguridad
+    url: /es/policy/
   principles: Principios
   privacy_&_security: Privacidad y seguridad
   security: Seguridad
@@ -309,17 +354,15 @@ nav:
   what_is_login_gov: ¿Qué es Login.gov?
   who_uses_login_gov: ¿Quién usa Login.gov?
 policies:
-  title: Privacidad y seguridad
   sections:
     - name: Nuestro compromiso con su privacidad y seguridad
-      url: '/policy/'
       sublinks:
         - text: Cómo trabajamos con nuestras agencias asociadas
           url: '#how-we-work-with-our-partner-agencies'
+      url: '/policy/'
     - name: ¿Cómo funciona?
       url: '/policy/how-does-it-work/'
     - name: Nuestra declaración de la ley de privacidad
-      url: '/policy/our-privacy-act-statement/'
       sublinks:
         - text: La Autoridad - ¿Quién autoriza la recopilación de estos datos?
           url: '#authority'
@@ -335,37 +378,19 @@ policies:
           url: '#analytics'
         - text: Evaluación del impacto en la privacidad
           url: '#impact'
+      url: '/policy/our-privacy-act-statement/'
     - name: Nuestras prácticas de seguridad
-      url: '/policy/our-security-practices/'
       sublinks:
         - text: Política de divulgación de vulnerabilidades
           url: '#vdp'
         - text: Para más información
           url: '#more-info'
+      url: '/policy/our-security-practices/'
     - name: Términos y condiciones de mensajería
-      url: '/policy/messaging-terms-and-conditions/'
       sublinks:
         - text: Términos y condiciones de SMS
           url: '#terms'
+      url: '/policy/messaging-terms-and-conditions/'
     - name: Reglas de uso
       url: '/policy/rules-of-use/'
-identifier:
-  accessible_labels:
-    description: Descripción de la agencia
-    identifier: Identificador de la agencia
-    links: Enlaces importantes
-    login_gov_logo: Logotipo de Login.gov
-    gsa_link_logo: Página de inicio de GSA
-    usa_gov: Información y servicios del Gobierno de EE. UU.
-  disclaimer: Un sitio web oficial de [General Services Administration](https://www.gsa.gov)
-  links:
-    about_agency: Acerca de GSA
-    accessibility: Soporte de accesibilidad
-    foia: Solicitud a través de FOIA
-    ig: Oficina del Inspector General
-    no_fear_act: Datos de la ley No FEAR
-    performance: Informes de desempeño
-    privacy: Política de privacidad
-  usa_gov:
-    text: ¿Necesita información y servicios del Gobierno?
-    link: Visite USAGov en Español
+  title: Privacidad y seguridad

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -1,38 +1,40 @@
 accessible_labels:
-  login_link_logo:  Page d'accueil de Login.gov
-  partners_link_logo: Page d'accueil de Login.gov Partners
   footer_navigation: Navigation en bas de page
+  login_link_logo: Page d’accueil de Login.gov
+  partners_link_logo: Page d’accueil de Login.gov Partners
   primary_navigation: Liens primaires
-  secondary_navigation: Liens secondaires 
+  secondary_navigation: Liens secondaires
 actions:
   search: Chercher
 banner:
   already-have-an-account:
-    learn_more: En savoir plus concernant la création d'un compte
+    learn_more: En savoir plus concernant la création d’un compte
     one_account: Login.gov est votre compte unique pour les services gouvernementaux
-    sign_in: Connectez-vous pour gérer votre compte et mettre à jour vos informations personnelles ou vos options de sécurité
-    text: Vous disposez déjà d'un compte?
+    sign_in: Connectez-vous pour gérer votre compte et mettre à jour vos
+      informations personnelles ou vos options de sécurité
+    text: Vous disposez déjà d’un compte?
   one-account-for-govt:
     create: Créer un compte
     learn: Apprendre à créer un compte
     tagline: Votre seul compte pour le gouvernement
   text:
-    official: Un site officiel du gouvernement américain
-    how: Voici comment vous savez
+    gov_description: Un site Web .gov appartient à une organisation gouvernementale
+      officielle des États-Unis.
     gov_heading: Les sites Web officiels utilisent .gov
-    gov_description: Un site Web .gov appartient à une organisation gouvernementale officielle des États-Unis.
+    how: Voici comment vous savez
+    official: Un site officiel du gouvernement américain
+    secure_description: 'Un <strong>verrou</strong> ou <strong>https://</strong>
+      signifie que vous êtes connecté en toute sécurité au site Web .gov.
+      Partagez des informations sensibles uniquement sur des sites Web officiels
+      et sécurisés.'
     secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
-    secure_description: 'Un <strong>verrou</strong> ou <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez des informations sensibles uniquement sur des sites Web officiels et sécurisés.'
 contact_page:
-  operating_hours: Les heures d'ouverture sont de 24 heures par jour, sept jours par semaine.
-  required: obligatoire
   call_us:
+    operating_hours: Les heures d’ouverture sont de 24 heures par jour, sept jours par semaine.
     title: Appelez-nous
-    operating_hours: Les heures d'ouverture sont de 24 heures par jour, sept jours par semaine.
+  operating_hours: Les heures d’ouverture sont de 24 heures par jour, sept jours par semaine.
+  required: obligatoire
   support_request_form:
-    title: Soumettre un ticket d'assistance
-    other: Other
-    required_text: Les champs obligatoires sont marqués d'un astérisque
     agencies:
       'Central Intelligence Agency': Agence centrale de renseignement
       'Consumer Financial Protection Bureau': Bureau financier de la protection des consommateurs
@@ -40,21 +42,21 @@ contact_page:
       'Customs and Border Protection ROAM': ROAM des douanes et de la protection des frontières
       'Department of Commerce': Département du Commerce
       'Department of Defense': Département de la Défense
-      'Department of Education': Département de l'Éducation
-      'Department of Energy': Département de l'Energie
+      'Department of Education': Département de l’Éducation
+      'Department of Energy': Département de l’Energie
       'Department of Labor': Département du Travail
       'Department of State': Département d’État
-      'Department of the Interior': Département de l'Intérieur
+      'Department of the Interior': Département de l’Intérieur
       'Department of the Treasury': Département du Trésor
       'Department of Transportation': Département des Transports
       'Department of Veterans Affairs': Ministère des Anciens Combattants
       'DOD Moves.mil (Homes or Office)': Move.mil de DOD (Résidences ou bureaux)
       'DOI ePermits': DOI ePermits
       'DOL Foreign Labor Application Gateway (FLAG)': DOL Foreign Labor Application Gateway (FLAG)
-      'DOT FMCSA (Motor Carrier Safety)': FMCSA du Département des transports (Sécurité des transporteurs routiers)
       'DOT Delphi eInvoicing': DOT Delphi eInvoicing
+      'DOT FMCSA (Motor Carrier Safety)': FMCSA du Département des transports (Sécurité des transporteurs routiers)
       'DOT National Registry of Certified Medical Examiners': Registre national des médecins agréés du Département des transports
-      'Environmental Protection Agency': Agence de protection de l'environnement
+      'Environmental Protection Agency': Agence de protection de l’environnement
       'FDIC Resolution Request Management Portal': FDIC demande un portail de gestion des résolutions
       'FEMA Disaster Assistance': Assistance FEMA en cas de catastrophe
       'General Services Administration': Administration des services généraux
@@ -63,10 +65,10 @@ contact_page:
       'HHS Grants.gov': HHS Grants.gov
       'HHS National Institutes of Health (NIH)': HHS Institut national de la santé (NIH)
       'Housing and Urban Development': Logement et développement urbain
-      'Internal Revenue Service (IRS)': L'Internal Revenue Service (IRS)
+      'Internal Revenue Service (IRS)': L’Internal Revenue Service (IRS)
       'Library of Congress': Bibliothèque du Congrès
       'myTreasury': myTreasury
-      'National Aeronautics and Space Administration': Administration Nationale de l'Espace et de l'Aéronautique
+      'National Aeronautics and Space Administration': Administration Nationale de l’Espace et de l’Aéronautique
       'National Archives and Records Administration (NARA)': Archives nationales et administration des documents (NARA)
       'National Labor Relations Board': Commission nationale des relations de travail
       'OPM Employee Express': OPM Employé Express
@@ -80,92 +82,110 @@ contact_page:
       'Social Security Administration (SSA)': Administration de la sécurité sociale (SSA)
       'Trusted Traveler Programs (Global Entry/Nexus/Sentri)': Programmes pour voyageurs de confiance (Global Entry/Nexus/Sentri)
       'U.S. Agency for International Development': Agence américaine pour le développement international
-      'U.S. Department of Agriculture': Département de l'agriculture des États-Unis
-      'United States Forest Service': Service forestier des États-Unis
+      'U.S. Department of Agriculture': Département de l’agriculture des États-Unis
       'U.S. International Trade Commission': Commission du commerce international des États-Unis
+      'United States Forest Service': Service forestier des États-Unis
       'USAJOBS': USAJOBS
     errors:
-      pii_found: Pour le respect de votre vie privée, ne soumettez pas d'informations sensibles dans ce formulaire. Nos agents du service clientèle peuvent toujours vous aider sans ces informations.
       captcha_required: Vous devez relever le défi de la prévention du pourriel.
+      pii_found: Pour le respect de votre vie privée, ne soumettez pas d’informations
+        sensibles dans ce formulaire. Nos agents du service clientèle peuvent
+        toujours vous aider sans ces informations.
     form_helpers:
-      select_topic: '- Sélectionnez un sujet -'
+      select_agency: '- Sélectionnez Agence à laquelle vous essayez d’accéder -'
       select_issue: '- Sélectionnez une question spécifique -'
-      select_agency: "- Sélectionnez Agence à laquelle vous essayez d'accéder -"
+      select_topic: '- Sélectionnez un sujet -'
     labels:
       agency_application: Demande à une agence
       agency_application_all: Toutes les applications
       agency_application_common: Applications courantes
       agency_application_other: Autres applications
-      description: Fournissez plus de détails. Si vous avez besoin d'aide, veuillez décrire les mesures que vous avez suivies et les problèmes que vous avez rencontrés.
+      description: Fournissez plus de détails. Si vous avez besoin d’aide, veuillez
+        décrire les mesures que vous avez suivies et les problèmes que vous avez
+        rencontrés.
       email: E-mail
       first_name: Prénom
       last_name: Nom
-      pii_warning: N’incluez pas les numéros de téléphone, les numéros de membre, les noms complets, les anniversaires, les adresses, les numéros de sécurité sociale ou toute autre information permettant d’identifier les personnes.
+      optional: optionnel
+      pii_warning: N’incluez pas les numéros de téléphone, les numéros de membre, les
+        noms complets, les anniversaires, les adresses, les numéros de sécurité
+        sociale ou toute autre information permettant d’identifier les
+        personnes.
       subtopic: Thème de la question
       topic: Thème de la question
-      optional: optionnel
+    other: Other
+    required_text: Les champs obligatoires sont marqués d’un astérisque
     reset: Formulaire clair
     submit: Soumettre
     subtopics:
       account_locked: Mon compte est bloqué pendant 24 heures
       add_family_member: Comment puis-je ajouter un membre de ma famille à mon compte Login.gov?
-      agency_app: Problème avec l'appli de l'agence
-      authentication_app: J'ai une application d'authentification mais elle ne fonctionne pas
-      authentication_app_setup: Comment configurer une application d'authentification?
+      agency_app: Problème avec l’appli de l’agence
+      authentication_app: J’ai une application d’authentification mais elle ne fonctionne pas
+      authentication_app_setup: Comment configurer une application d’authentification?
       backup_codes: Comment utiliser mes codes de sauvegarde pour me connecter?
       blank_screen: Je vois une erreur/un écran vide lors de la création de mon compte
-      cant_proof_in_person: Je n'ai pas pu vérifier mon identité en personne au bureau de poste.
+      cant_proof_in_person: Je n’ai pas pu vérifier mon identité en personne au bureau de poste.
       change_email: Comment puis-je modifier mon adresse courriel?
       change_password: Comment puis-je mettre à jour mon mot de passe Login.gov?
       change_phone_number: Comment modifier mon numéro de téléphone?
-      concerned_login_email: Je suis préoccupé par le courriel que j'ai reçu de Login.gov
+      concerned_login_email: Je suis préoccupé par le courriel que j’ai reçu de Login.gov
       delete_account: Comment supprimer mon compte Login.gov?
-      device_notification: J'ai reçu une alerte concernant une nouvelle ouverture de session sur mon compte Login.gov
+      device_notification: J’ai reçu une alerte concernant une nouvelle ouverture de
+        session sur mon compte Login.gov
       email_delivery_issue: Je ne reçois pas le courriel de confirmation de Login.gov
-      feedback: J'ai des commentaires à propos de Login.gov
-      forgot_password: J'ai oublié mon mot de passe Login.gov et je ne peux pas le réinitialiser
+      feedback: J’ai des commentaires à propos de Login.gov
+      forgot_password: J’ai oublié mon mot de passe Login.gov et je ne peux pas le réinitialiser
+      how_to_create_with_verification: Comment puis-je créer un compte Login.gov avec vérification d’identité?
       how_to_link: Comment puis-je lier le compte de mon agence partenaire avec Login.gov?
-      how_to_create_with_verification: Comment puis-je créer un compte Login.gov avec vérification d'identité?
       how_to_verify: Comment/pourquoi dois-je vérifier mon identité?
-      international_number: J'ai un numéro international et je ne reçois pas mon code de sécurité
-      interest_in_partnership: Je suis intéressé par l'utilisation de Login.gov pour mon agence gouvernementale
-      invalid_email: Login.gov n'accepte pas mon adresse courriel. Il est indiqué qu'elle n'est pas valide
-      invalid_otp: Login.gov indique que mon code de sécurité n'est pas valide
-      issue_with_partner_agency: J'ai un problème avec cette agence partenaire
-      issues_with_face_touch_unlock: J'ai un problème avec le déverrouillage facial ou tactile
-      letter_in_mail: Je n'ai pas reçu ma lettre par la poste ou elle a expiré
+      interest_in_partnership: Je suis intéressé par l’utilisation de Login.gov pour
+        mon agence gouvernementale
+      international_number: J’ai un numéro international et je ne reçois pas mon code de sécurité
+      invalid_email: Login.gov n’accepte pas mon adresse courriel. Il est indiqué
+        qu’elle n’est pas valide
+      invalid_otp: Login.gov indique que mon code de sécurité n’est pas valide
+      issue_with_partner_agency: J’ai un problème avec cette agence partenaire
+      issues_with_face_touch_unlock: J’ai un problème avec le déverrouillage facial ou tactile
+      letter_in_mail: Je n’ai pas reçu ma lettre par la poste ou elle a expiré
       locked_out: Je suis bloqué sur mon compte
-      lost_access: J'ai perdu l'accès à mon téléphone ou à mon adresse électronique
       lost_2fa_method: Authentification à deux facteurs perdue
-      multiple_otps: Je reçois de nombreux codes de sécurité lors de l'ouverture de session
-      new_account: Mon courriel/nom d'utilisateur et mon mot de passe ne fonctionnent pas
+      lost_access: J’ai perdu l’accès à mon téléphone ou à mon adresse électronique
+      multiple_otps: Je reçois de nombreux codes de sécurité lors de l’ouverture de session
+      new_account: Mon courriel/nom d’utilisateur et mon mot de passe ne fonctionnent pas
       new_backup_codes: Comment obtenir de nouveaux codes de sauvegarde?
+      new_device_notification: J’ai reçu une notification par adresse électronique d’un nouvel appareil
       new_personal_key: Comment obtenir une nouvelle clé personnelle?
-      new_device_notification: J'ai reçu une notification par adresse électronique d'un nouvel appareil
       no_otp_received: Aucun OTP reçu
-      no_phone: Je ne peux pas créer mon compte Login.gov parce que je n'ai pas de téléphone.
+      no_phone: Je ne peux pas créer mon compte Login.gov parce que je n’ai pas de
+        téléphone.
       none: '--Aucun--'
       other: Autre
       password_issue: Problème de mot de passe
       personal_key: Ma clé personnelle ne fonctionne pas
+      personal_key_notification: J’ai reçu une alerte concernant l’utilisation de ma
+        clé personnelle pour me connecter
       personal_key_setup: Configuration de la clé personnelle
-      personal_key_notification: J'ai reçu une alerte concernant l'utilisation de ma clé personnelle pour me connecter
-      phone_number_failure: J'ai reçu un message d'erreur après avoir entré mon numéro de téléphone
-      piv_cac: J'ai des difficultés à utiliser mon PIV/CAC pour me connecter
+      phone_number_failure: J’ai reçu un message d’erreur après avoir entré mon numéro de téléphone
+      piv_cac: J’ai des difficultés à utiliser mon PIV/CAC pour me connecter
       privacy_and_security: Confidentialité et sécurité
-      recover_account: Comment puis-je me connecter à mon compte si je n'ai pas mon téléphone ou ma clé personnelle?
-      remember_browser: J’ai configuré mon navigateur, mais je reçois toujours des codes de sécurité
-      security_question: Comment protégez-vous/comment Login.gov protège-t-il ma vie privée et ma sécurité?
+      recover_account: Comment puis-je me connecter à mon compte si je n’ai pas mon
+        téléphone ou ma clé personnelle?
+      remember_browser: J’ai configuré mon navigateur, mais je reçois toujours des
+        codes de sécurité
       remember_device_issue: Comment puis-je cesser de recevoir des codes de sécurité?
       security_code: Je ne reçois pas le code de sécurité
-      security_key: J'ai des difficultés à utiliser ma clé de sécurité pour me connecter
-      seeing_errors: Je vois une erreur/un écran vide lorsque j'accède à Login.gov
+      security_key: J’ai des difficultés à utiliser ma clé de sécurité pour me connecter
+      security_question: Comment protégez-vous/comment Login.gov protège-t-il ma vie
+        privée et ma sécurité?
+      seeing_errors: Je vois une erreur/un écran vide lorsque j’accède à Login.gov
       service_quality: Qualité du service
       site_navigation: Je ne sais pas où aller pour créer un compte
-      state_issued_id_error: J'ai eu une erreur après avoir téléchargé mon identifiant d'état
-      unwanted_otp: Je reçois des codes de sécurité de Login.gov que je n'ai pas demandés
-      verify_identity_error: J'ai reçu un message d'erreur en essayant de vérifier mon identité
+      state_issued_id_error: J’ai eu une erreur après avoir téléchargé mon identifiant d’état
+      unwanted_otp: Je reçois des codes de sécurité de Login.gov que je n’ai pas demandés
+      verify_identity_error: J’ai reçu un message d’erreur en essayant de vérifier mon identité
       wrong_account_update: Mise à jour de compte erronée
+    title: Soumettre un ticket d’assistance
     topics:
       changing_settings: Changer vos informations de Login.gov
       creating_account: Créer un compte Login.gov
@@ -177,9 +197,9 @@ contact_page:
       signing_in: Se connecter à votre compte Login.gov
       verifying_identity: Vérifier votre identité
 feedback_form:
-  'yes': 'Oui'
   'no': 'Non'
   question: Cet article vous a-t-il été utile?
+  'yes': 'Oui'
 footer:
   gsa: Administration des services généraux des États-Unis
 global:
@@ -189,38 +209,61 @@ global:
     es: Español
     fr: Français
 help_page:
+  categories:
+    - description: Créez votre compte. Découvrez les options d’authentification et
+        d’autres caractéristiques du compte.
+      image: /assets/img/help/get-started.svg
+      title: Commencez avec Login.gov
+      url: /fr/help/get-started/overview/
+    - description: Vous avez oublié votre mot de passe ? Votre compte est bloqué ?
+        Nous vous aiderons à résoudre vos problèmes d’accès.
+      image: /assets/img/help/trouble-signing-in.svg
+      title: Des problèmes pour vous connecter?
+      url: /fr/help/trouble-signing-in/overview/
+    - description: Modifiez les paramètres de votre compte, notamment votre mot de
+        passe, votre numéro de téléphone, votre adresse électronique, etc.
+      image: /assets/img/help/manage-your-account.svg
+      title: Gérez votre compte
+      url: /fr/help/manage-your-account/overview/
+    - description: Obtenez de l’aide avec Trusted Traveler Programs (TTP), SAM.gov.
+      image: /assets/img/help/help-specific-agencies.svg
+      title: Assistance auprès des agences spécifiques
+      url: /fr/help/specific-agencies/overview/
+    - description: Découvrez les différentes options de vérification de votre identité.
+      image: /assets/img/help/verify-your-id.svg
+      title: Vérifiez votre identité
+      url: /fr/help/verify-your-identity/overview/
   p_1: Parcourir les sujets communs
   title: Comment pouvons nous aider?
-  categories:
-    - title: Commencez avec Login.gov
-      description: Créez votre compte. Découvrez les options d'authentification et d'autres caractéristiques du compte.
-      url: /fr/help/get-started/overview/
-      image: /assets/img/help/get-started.svg
-    - title: Des problèmes pour vous connecter?
-      description: Vous avez oublié votre mot de passe ? Votre compte est bloqué ? Nous vous aiderons à résoudre vos problèmes d'accès.
-      url: /fr/help/trouble-signing-in/overview/
-      image: /assets/img/help/trouble-signing-in.svg
-    - title: Gérez votre compte
-      description: Modifiez les paramètres de votre compte, notamment votre mot de passe, votre numéro de téléphone, votre adresse électronique, etc.
-      url: /fr/help/manage-your-account/overview/
-      image: /assets/img/help/manage-your-account.svg
-    - title: Assistance auprès des agences spécifiques
-      description: Obtenez de l'aide avec Trusted Traveler Programs (TTP), SAM.gov.
-      url: /fr/help/specific-agencies/overview/
-      image: /assets/img/help/help-specific-agencies.svg
-    - title: Vérifiez votre identité
-      description: Découvrez les différentes options de vérification de votre identité.
-      url: /fr/help/verify-your-identity/overview/
-      image: /assets/img/help/verify-your-id.svg
 help_subpages:
   get-started: Commencez avec Login.gov
-  trouble-signing-in: Des problèmes pour vous connecter?
   manage-your-account: Gérez votre compte
   specific-agencies: Aide aux agences spécifiques
+  trouble-signing-in: Des problèmes pour vous connecter?
   verify-your-identity: Vérifiez votre identité
+identifier:
+  accessible_labels:
+    description: Descriptif de l’agence
+    gsa_link_logo: Page d’accueil de GSA
+    identifier: Identifiant de l’agence
+    links: Liens importants
+    login_gov_logo: Login.gov logo
+    usa_gov: Informations et services du gouvernement américain
+  disclaimer: Un site Web officiel de [General Services
+    Administration](https://www.gsa.gov)
+  links:
+    about_agency: À propos de GSA
+    accessibility: Support de l’accessibilité
+    foia: Demandes FOIA
+    ig: Bureau de l’inspecteur général
+    no_fear_act: Données No FEAR Act
+    performance: Rapports de performances
+    privacy: Politique de confidentialité
+  usa_gov:
+    link: Visitez USA.gov
+    text: Vous recherchez des informations et des services du gouvernement américain?
 nav:
   about_us:
-    title: À propos de nous
     sections:
       - name: Notre mission
         url: '#notre-mission'
@@ -228,8 +271,8 @@ nav:
         url: '#notre-vision'
       - name: À propos de Login.gov
         url: '#à-propos-de-logingov'
+    title: À propos de nous
   accessibility:
-    title: Accessibilité
     sections:
       - name: Notre engagement
         url: '#notre-engagement'
@@ -239,12 +282,13 @@ nav:
         url: '#évaluation'
       - name: Limites connues
         url: '#limites-connues'
+    title: Accessibilité
   anchor_to_top: Retour au sommet
   become_a_partner: Devenir un partenaire
   business_inquiries:
     title: Business inquiries
+  contact_login_gov: Contactez Login.gov
   contact_us:
-    title: Nous contacter
     sections:
       - name: Trouver des réponses aux questions les plus fréquemment posées
         url: '#trouver-des-réponses-aux-questions-les-plus-fréquemment-posées'
@@ -254,7 +298,7 @@ nav:
         url: '#partenaire-avec-logingov'
       - name: Signaler un problème
         url: '#signaler-un-problème'
-  contact_login_gov: Contactez Login.gov
+    title: Nous contacter
   create_an_account: Créer un compte
   developer_guide: Guide du développeur
   developers: Développeurs
@@ -263,26 +307,24 @@ nav:
   groups:
     about_login_gov: About Login.gov # partners site does not require translations
     agencies: Pour les agences
-    partners: For partners # partners site does not require translations
     learn: Apprendre
+    partners: For partners # partners site does not require translations
     support: Soutien
   help: Aide
-  help_center: Centre d'aide
+  help_center: Centre d’aide
   home: Accueil
   implementation: Mise en œuvre
   join_us:
-    title: Rejoignez nous
     sections:
       - name: Postes ouverts
         url: '#postes-ouverts'
-      - name: Comment s'inscrire
+      - name: Comment s’inscrire
         url: '#comment-sinscrire'
+    title: Rejoignez nous
   menu: Menu
   overview: Aperçu
   playbook: Guide de mise en œuvre
   policies:
-    title: Confidentialité et sécurité
-    url: /fr/policy/
     sections:
       - name: Notre engagement envers votre confidentialité et votre sécurité
         url: /fr/policy/
@@ -294,8 +336,10 @@ nav:
         url: /fr/policy/our-security-practices/
       - name: Termes et conditions de la messagerie
         url: /fr/policy/messaging-terms-and-conditions/
-      - name: Règles d'utilisation
+      - name: Règles d’utilisation
         url: /fr/policy/rules-of-use/
+    title: Confidentialité et sécurité
+    url: /fr/policy/
   principles: Principes
   privacy_&_security: Confidentialité et sécurité
   security: Sécurité
@@ -303,10 +347,45 @@ nav:
   sign_in: 'Connectez-vous avec'
   skip_nav: Passer au contenu principal
   system_status: État du système Login.gov
-  what_is_login_gov: Qu'est-ce que Login.gov?
+  what_is_login_gov: Qu’est-ce que Login.gov?
   who_uses_login_gov: Qui utilise Login.gov?
 policies:
-  title: Confidentialité et sécurité
+  heading_1: Les principes du guide de mise en œuvre de l’identité
+  heading_2: Axé sur les besoins des utilisateurs
+  heading_3: Être transparent sur le fonctionnement
+  heading_4: Bâtir un produit flexible
+  heading_5: Utiliser des pratiques de confidentialité modernes
+  heading_6: Créer des systèmes de sécurité réactifs
+  p_1: |-
+    Résoudre des problèmes réels pour les utilisateurs potentiels doit être l’objectif principal de tout système et est doublement important dans la construction d’un système de gestion d’identité. Tout au long de ce guide, vous constaterez à quel point les besoins des utilisateurs constituent un principe directeur pour chaque prise de décision.
+
+    Une des premières étapes que vous devez effectuer est d’identifier vos utilisateurs principaux. Pour Login.gov, nous avons identifié deux groupes comme étant nos utilisateurs principaux: le public et les experts en technologie faisant partie des agences gouvernementales. L’objectif pour le système en soi est de fournir de l’assistance et de répondre aux besoins du public. En bref, nous souhaitons nous assurer que notre système rend les gens à l’aise avec la connexion aux services gouvernementaux. Le public doit avoir confiance que Login.gov se comporte comme prévu et qu’il ne les décevra pas. Le système doit aussi aborder l’expérience entière des utilisateurs alors qu’ils tentent d’accomplir leurs objectifs. Parce que la vérification de l’identité et l’authentification sont technologiquement complexes, il est probable que même les personnes les plus aguérries en ce qui a trait aux technologies peuvent rester piégées si leur téléphone est perdu ou si un système comporte des erreurs. Alors, en soutien à la mission de chaque agence, les architectes et les concepteurs des systèmes de gestion de l’identité doivent anticiper les points probables de friction afin que les utilisateurs ne perdent pas leur accès aux services et aux avantages.
+
+    Les agences doivent identifier la portion du public qu’elles desservent et comment les services peuvent être bâtis pour répondre spécifiquement à leurs besoins. Ceci aidera les équipes d’intégration des agences à comprendre ce dont ils ont besoin si elles décident de mettre en œuvre la plate-forme Login.gov ou tout autre système de gestion d’identité du consommateur.
+
+    Enfin, vous devez constamment tester les designs et outils au moment où ils sont prêts à être partagés et ensuite ajuster votre projet en fonction de ce que vous avez appris. Dans certains cas, nous apprenons que les meilleures pratiques actuelles ne sont pas adéquates. Et dans ces cas, nous sommes poussés à essayer de nouvelles façons de donner aux utilisateurs la meilleure expérience possible. Ce processus implique plus de tests, l’éducation des utilisateurs et une volonté à itérer.
+
+    Il existe un nombre de méthodes de conception spécifiques que nous mettons en pratique pour demeurer axés sur l’utilisateur et vous pouvez lire au sujet de tous ces processus et les utiliser en passant en revue le [18F Design Methods](https://methods.18f.gov/).
+  p_2: |-
+    [Travailler de façon transparente](https://playbook.cio.gov/#play13) et créer un système transparent devrait être la façon dont toute agence travaille pour bâtir ou mettre en œuvre un système de gestion d’identité. Pour exécuter ce principe avec Login.gov, nous bâtissons la plate-méthode de manière à ce que les parties intéressées puisse nous conseiller sur les meilleures pratiques afin que nous demeurions responsables envers le public et envers nos partenaires de toutes les agences gouvernementales. De plus, cela signifie qu’un système qui indique aux utilisateurs ce qu’il fait de leur information dans le but de créer une responsabilisation et établir une confiance. Nous impliquons les utilisateurs et autres parties intéressées par le biais de notre [référentiel GitHub](https://github.com/18F/identity-idp) et travaillons à la création de forums publics où les utilisateurs peuvent discuter de notre travail.
+
+    Afin de rendre un système de gestion d’identité transparent pour les utilisateurs finaux, le système doit inclure des fonctionnalités qui éduquent les gens sur la façon dont le système fonctionne, pourquoi il fonctionne de cette façon et de quelle manière ils peuvent contrôler ce qui advient de leurs données. Vous devriez aussi informer les utilisateurs de l’information qui est requise par une agence pour la connexion à un service. Il est aussi important d’informer les utilisateurs de quelle information vos systèmes stockeront et si toute donnée est partagée avec les autres agences. Si les gens qui utilisent le système ne sont pas à l’aise avec le partage d’information, ils ne doivent pas être obligés de participer.
+
+    Login.gov travaille pour mettre en œuvre toutes ces fonctionnalités ayant pour but d’améliorer la transparence. De plus, pour aider les gens à comprendre tout le processus, nous créons une politique de confidentialité qui explique comment les données sont partagées et ce que signifie de choisir l’option de retrait.
+  p_3: |-
+    La technologie et les normes pour de la vérification d’identité peuvent changer rapidement. La gestion de l’identité du consommateur doit s’adapter rapidement aux normes changeantes et réagir aux nouvelles menaces à la sécurité. Afin de rendre l’adaptation aux nouvelles politiques et aux capacités possible, il s’agit d’une bonne pratique de bâtir des produits en utilisant des méthodes agiles qui tiennent compte des versions changeantes. En d’autres termes, planifier les modifications pour aider votre service d’identité à être aussi à jour et conforme que possible aux normes et politiques actuelles.
+
+    Nous adhérons à ce principe pour chaque aspect des projets qui construisent Login.gov.
+
+    [Lisez ce guide](https://pages.18f.gov/agile/index.html) des principes et pratiques agiles élaborés par l’équipe 18F pour en savoir plus sur ce que signifie de travailler de façon agile.
+  p_4: |-
+    Les systèmes de gestion d’identité stockent l’information personnelle sur les utilisateurs afin que les gens n’aient pas à répéter sans cesse les processus de vérification et d’authentification. Toutefois, recueillir et stocker de l’information personnelle sou;ève des questions éthiques et légales que les concepteurs de systèmes et les développeurs doivent considérer. Souvent, ce qui vient d’abord à l’esprit sont les questions techniques sur la sécurité : la protection de l’information contre les usages non autorisés et illégaux. Toutefois, nous devons aussi nous préoccuper des usages autorisés et légaux de l’information personnelle qui violent les attentes des utilisateurs en matière de confidentialité. Les utilisateurs de Login.gov doivent être assurés que nous gérons leur information personnelle de façon respectueuse et appropriée.
+
+    La première étape est de recueillir seulement l’information dont vous avez absolument besoin. Et c’est ce que fait Login.gov. La vérification d’identité à assurance élevée pour les tâches sensibles requiert une collecte d’information exhaustive. Cependant, de nombreuses activités ne requièrent pas des niveaux élevés d’assurance (NEA) et Login.gov prend en charge différents LOA afin que les agences puissent clairement délimiter leurs utilisateurs qui ont besoin d’un niveau de sécurité plus bas de ceux qui ont des besoins plus sensibles tout en assurant l’utilisabilité et la sécurité des données. Minimiser la quantité d’information recueillie et stockée ne réduit pas seulement les risques liés à la sécurité; cela réduit aussi pour les utilisateurs les craintes liées à la réutilisation et la divulgation.
+
+    La prochaine étape est de donner aux utilisateurs autant de contrôle que possible sur l’information qui est partagée. Nous croyons fermement que les gens possèdent leurs propres données, pas nous, et nous agirons toujours en conséquence. Si les utilisateurs ne sont pas à l’aise avec les demandes de données pour l’utilisation du système, ils doivent savoir qu’ils n’ont pas à s’inscrire et qu’il existe d’autres moyens d’atteindre leurs objectifs.
+
+    Au fur et à mesure que nous faisons la conception de Login.gov, nous travaillons également à éduquer les utilisateurs pour les aider à sécuriser leurs propres données. Nous souhaitons que les gens comprennent pourquoi nous devons demander certains types d’information, comme les numéros de sécurité sociale, et comment nous les utilisons.
   sections:
     - link:
         text: Notre engagement envers votre confidentialité et votre sécurité
@@ -321,15 +400,17 @@ policies:
         text: Notre déclaration de confidentialité
         url: '/policy/our-privacy-act-statement/'
       sublinks:
-        - text: L'Autorité - Qui autorise la collecte de ces données?
+        - text: L’Autorité - Qui autorise la collecte de ces données?
           url: '#authority'
         - text: The Purpose - Pourquoi avons-nous besoin de vos informations?
           url: '#purpose'
-        - text: Usages courants - Avec qui les informations sont-elles communément partagées?
+        - text: Usages courants - Avec qui les informations sont-elles communément
+            partagées?
           url: '#routine-uses'
-        - text: Consentement - Comment pouvez-vous contrôler quelles informations sont partagées?
+        - text: Consentement - Comment pouvez-vous contrôler quelles informations sont
+            partagées?
           url: '#consent'
-        - text: Records - Où trouver plus d'informations?
+        - text: Records - Où trouver plus d’informations?
           url: '#records'
         - text: Analyse du site Web
           url: '#analytics'
@@ -341,7 +422,7 @@ policies:
       sublinks:
         - text: Politique de divulgation des vulnérabilités
           url: '#vdp'
-        - text: Pour plus d'informations
+        - text: Pour plus d’informations
           url: '#more-info'
     - link:
         text: Termes et conditions de la messagerie
@@ -350,44 +431,9 @@ policies:
         - text: Termes et conditions SMS
           url: '#terms'
     - link:
-        text: Règles d'utilisation
+        text: Règles d’utilisation
         url: '/policy/rules-of-use/'
-  heading_1: Les principes du guide de mise en œuvre de l'identité
-  heading_2: Axé sur les besoins des utilisateurs
-  heading_3: Être transparent sur le fonctionnement
-  heading_4: Bâtir un produit flexible
-  heading_5: Utiliser des pratiques de confidentialité modernes
-  heading_6: Créer des systèmes de sécurité réactifs
-  p_1: |-
-    Résoudre des problèmes réels pour les utilisateurs potentiels doit être l'objectif principal de tout système et est doublement important dans la construction d'un système de gestion d'identité. Tout au long de ce guide, vous constaterez à quel point les besoins des utilisateurs constituent un principe directeur pour chaque prise de décision.
-
-    Une des premières étapes que vous devez effectuer est d'identifier vos utilisateurs principaux. Pour Login.gov, nous avons identifié deux groupes comme étant nos utilisateurs principaux: le public et les experts en technologie faisant partie des agences gouvernementales. L'objectif pour le système en soi est de fournir de l'assistance et de répondre aux besoins du public. En bref, nous souhaitons nous assurer que notre système rend les gens à l'aise avec la connexion aux services gouvernementaux. Le public doit avoir confiance que Login.gov se comporte comme prévu et qu'il ne les décevra pas. Le système doit aussi aborder l'expérience entière des utilisateurs alors qu'ils tentent d'accomplir leurs objectifs. Parce que la vérification de l'identité et l'authentification sont technologiquement complexes, il est probable que même les personnes les plus aguérries en ce qui a trait aux technologies peuvent rester piégées si leur téléphone est perdu ou si un système comporte des erreurs. Alors, en soutien à la mission de chaque agence, les architectes et les concepteurs des systèmes de gestion de l'identité doivent anticiper les points probables de friction afin que les utilisateurs ne perdent pas leur accès aux services et aux avantages.
-
-    Les agences doivent identifier la portion du public qu'elles desservent et comment les services peuvent être bâtis pour répondre spécifiquement à leurs besoins. Ceci aidera les équipes d'intégration des agences à comprendre ce dont ils ont besoin si elles décident de mettre en œuvre la plate-forme Login.gov ou tout autre système de gestion d'identité du consommateur.
-
-    Enfin, vous devez constamment tester les designs et outils au moment où ils sont prêts à être partagés et ensuite ajuster votre projet en fonction de ce que vous avez appris. Dans certains cas, nous apprenons que les meilleures pratiques actuelles ne sont pas adéquates. Et dans ces cas, nous sommes poussés à essayer de nouvelles façons de donner aux utilisateurs la meilleure expérience possible. Ce processus implique plus de tests, l'éducation des utilisateurs et une volonté à itérer.
-
-    Il existe un nombre de méthodes de conception spécifiques que nous mettons en pratique pour demeurer axés sur l'utilisateur et vous pouvez lire au sujet de tous ces processus et les utiliser en passant en revue le [18F Design Methods](https://methods.18f.gov/).
-  p_2: |-
-    [Travailler de façon transparente](https://playbook.cio.gov/#play13) et créer un système transparent devrait être la façon dont toute agence travaille pour bâtir ou mettre en œuvre un système de gestion d'identité. Pour exécuter ce principe avec Login.gov, nous bâtissons la plate-méthode de manière à ce que les parties intéressées puisse nous conseiller sur les meilleures pratiques afin que nous demeurions responsables envers le public et envers nos partenaires de toutes les agences gouvernementales. De plus, cela signifie qu'un système qui indique aux utilisateurs ce qu'il fait de leur information dans le but de créer une responsabilisation et établir une confiance. Nous impliquons les utilisateurs et autres parties intéressées par le biais de notre [référentiel GitHub](https://github.com/18F/identity-idp) et travaillons à la création de forums publics où les utilisateurs peuvent discuter de notre travail.
-
-    Afin de rendre un système de gestion d'identité transparent pour les utilisateurs finaux, le système doit inclure des fonctionnalités qui éduquent les gens sur la façon dont le système fonctionne, pourquoi il fonctionne de cette façon et de quelle manière ils peuvent contrôler ce qui advient de leurs données. Vous devriez aussi informer les utilisateurs de l'information qui est requise par une agence pour la connexion à un service. Il est aussi important d'informer les utilisateurs de quelle information vos systèmes stockeront et si toute donnée est partagée avec les autres agences. Si les gens qui utilisent le système ne sont pas à l'aise avec le partage d'information, ils ne doivent pas être obligés de participer.
-
-    Login.gov travaille pour mettre en œuvre toutes ces fonctionnalités ayant pour but d'améliorer la transparence. De plus, pour aider les gens à comprendre tout le processus, nous créons une politique de confidentialité qui explique comment les données sont partagées et ce que signifie de choisir l'option de retrait.
-  p_3: |-
-    La technologie et les normes pour de la vérification d'identité peuvent changer rapidement. La gestion de l'identité du consommateur doit s'adapter rapidement aux normes changeantes et réagir aux nouvelles menaces à la sécurité. Afin de rendre l'adaptation aux nouvelles politiques et aux capacités possible, il s'agit d'une bonne pratique de bâtir des produits en utilisant des méthodes agiles qui tiennent compte des versions changeantes. En d'autres termes, planifier les modifications pour aider votre service d'identité à être aussi à jour et conforme que possible aux normes et politiques actuelles.
-
-    Nous adhérons à ce principe pour chaque aspect des projets qui construisent Login.gov.
-
-    [Lisez ce guide](https://pages.18f.gov/agile/index.html) des principes et pratiques agiles élaborés par l'équipe 18F pour en savoir plus sur ce que signifie de travailler de façon agile.
-  p_4: |-
-    Les systèmes de gestion d'identité stockent l'information personnelle sur les utilisateurs afin que les gens n'aient pas à répéter sans cesse les processus de vérification et d'authentification. Toutefois, recueillir et stocker de l'information personnelle sou;ève des questions éthiques et légales que les concepteurs de systèmes et les développeurs doivent considérer. Souvent, ce qui vient d'abord à l'esprit sont les questions techniques sur la sécurité : la protection de l'information contre les usages non autorisés et illégaux. Toutefois, nous devons aussi nous préoccuper des usages autorisés et légaux de l'information personnelle qui violent les attentes des utilisateurs en matière de confidentialité. Les utilisateurs de Login.gov doivent être assurés que nous gérons leur information personnelle de façon respectueuse et appropriée.
-
-    La première étape est de recueillir seulement l'information dont vous avez absolument besoin. Et c'est ce que fait Login.gov. La vérification d'identité à assurance élevée pour les tâches sensibles requiert une collecte d'information exhaustive. Cependant, de nombreuses activités ne requièrent pas des niveaux élevés d'assurance (NEA) et Login.gov prend en charge différents LOA afin que les agences puissent clairement délimiter leurs utilisateurs qui ont besoin d'un niveau de sécurité plus bas de ceux qui ont des besoins plus sensibles tout en assurant l'utilisabilité et la sécurité des données. Minimiser la quantité d'information recueillie et stockée ne réduit pas seulement les risques liés à la sécurité; cela réduit aussi pour les utilisateurs les craintes liées à la réutilisation et la divulgation.
-
-    La prochaine étape est de donner aux utilisateurs autant de contrôle que possible sur l'information qui est partagée. Nous croyons fermement que les gens possèdent leurs propres données, pas nous, et nous agirons toujours en conséquence. Si les utilisateurs ne sont pas à l'aise avec les demandes de données pour l'utilisation du système, ils doivent savoir qu'ils n'ont pas à s'inscrire et qu'il existe d'autres moyens d'atteindre leurs objectifs.
-
-    Au fur et à mesure que nous faisons la conception de Login.gov, nous travaillons également à éduquer les utilisateurs pour les aider à sécuriser leurs propres données. Nous souhaitons que les gens comprennent pourquoi nous devons demander certains types d'information, comme les numéros de sécurité sociale, et comment nous les utilisons.
+  title: Confidentialité et sécurité
   ul_1:
     li_1: Identifier vos auditoires potentiels
     li_2: Comprendre les expériences de connexion et identifier les besoins de vos
@@ -396,10 +442,12 @@ policies:
     li_4: Tester votre produit pour identifier les points morts ou les domaines qui
       nécessitent une amélioration
     li_5: Lorsque les meilleures pratiques actuelles ne sont pas assez bonnes pour
-      vos utilisateurs, testez de nouvelles solutions et aidez à guider l'adoption.
+      vos utilisateurs, testez de nouvelles solutions et aidez à guider
+      l’adoption.
   ul_2:
     li_1: Impliquez des experts, des intervenants et le public tôt et souvent
-    li_2: Expliquez comment et pourquoi vous recueillez, partagez et stockez des données
+    li_2: Expliquez comment et pourquoi vous recueillez, partagez et stockez des
+      données
     li_3: Créez une politique de confidentialité à laquelle tous peuvent accéder et
       que tous peuvent comprendre
     li_4: Créez une politique de confidentialité inclusive et informative
@@ -407,44 +455,25 @@ policies:
     li_1: Développer le produit en sprints et évaluer son efficacité après chaque
       sprint
     li_2: Communiquer continuellement avec les parties prenantes et les experts afin
-      d'évaluer les besoins et les mesures de succès
+      d’évaluer les besoins et les mesures de succès
     li_3: Tester votre produit auprès des utilisateurs de façon continuelle au fur
-      et à mesure que vous ajoutez de nouvelles fonctionnalités et raffinez les fonctionnalités
-      existantes
-    li_4: Définir ce qu'un produit minimal viable est pour vos besoins de gestion
-      d'identité
+      et à mesure que vous ajoutez de nouvelles fonctionnalités et raffinez les
+      fonctionnalités existantes
+    li_4: Définir ce qu’un produit minimal viable est pour vos besoins de gestion
+      d’identité
     li_5: Planifier une évolution basée sur une technologie et des normes changeantes
   ul_4:
-    li_1: Stockez aussi peu de renseignements permettant d'identifier une personne
+    li_1: Stockez aussi peu de renseignements permettant d’identifier une personne
       que possible
-    li_2: Donnez au utilisateurs les moyens d'atteindre leurs objectifs
+    li_2: Donnez au utilisateurs les moyens d’atteindre leurs objectifs
     li_3: Donnez aux utilisateurs le contrôle de leurs données
   ul_5:
-    li_1: Identifier les meilleures pratiques de l'industrie et s'y conformer
+    li_1: Identifier les meilleures pratiques de l’industrie et s’y conformer
     li_2: Se conformer aux règlementations fédérales comme FISMA et FedRamp
-    li_3: Mettre en place des systèmes pour effectuer une surveillance et une détection
-      de la fraude
-    li_4: Utiliser des techniques modernes de chiffrement dans toute la pile technologique
+    li_3: Mettre en place des systèmes pour effectuer une surveillance et une
+      détection de la fraude
+    li_4: Utiliser des techniques modernes de chiffrement dans toute la pile
+      technologique
     li_5: Stocker seulement la quantité minimale nécessaire de données
-    li_6: Aider les utilisateurs à comprendre les mesures de sécurité qu'ils doivent
+    li_6: Aider les utilisateurs à comprendre les mesures de sécurité qu’ils doivent
       effectuer
-identifier:
-  accessible_labels:
-    description: Descriptif de l'agence
-    identifier: Identifiant de l'agence
-    links: Liens importants
-    login_gov_logo: Login.gov logo
-    gsa_link_logo: Page d'accueil de GSA
-    usa_gov: Informations et services du gouvernement américain
-  disclaimer: Un site Web officiel de [General Services Administration](https://www.gsa.gov)
-  links:
-    about_agency: À propos de GSA
-    accessibility: Support de l'accessibilité
-    foia: Demandes FOIA
-    ig: Bureau de l'inspecteur général
-    no_fear_act: Données No FEAR Act
-    performance: Rapports de performances
-    privacy: Politique de confidentialité
-  usa_gov:
-    text: Vous recherchez des informations et des services du gouvernement américain?
-    link: Visitez USA.gov

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -5,23 +5,22 @@ default:
       developer_guide: 'https://developers.login.gov'
     learn:
       about_us: '$LOCALE_BASE_URL/about-us/'
-      join_us: "$LOCALE_BASE_URL/join/"
-      policies: '$LOCALE_BASE_URL/policy/'
       accessibility: '$LOCALE_BASE_URL/accessibility/'
+      join_us: '$LOCALE_BASE_URL/join/'
+      policies: '$LOCALE_BASE_URL/policy/'
     support:
-      help_center: '$LOCALE_BASE_URL/help/'
       contact_us: '$LOCALE_BASE_URL/contact/'
+      help_center: '$LOCALE_BASE_URL/help/'
 partners:
   footer:
-    partners:
-      get_started: '$BASE_URL/partners/get-started/'
-      developer_guide: 'https://developers.login.gov'
-      security_experience: '$BASE_URL/partners/security-experience/'
     about_login_gov:
-      what_is_login_gov: '$BASE_URL/about-us/'
-      policies: '$BASE_URL/policy/'
       accessibility: '$BASE_URL/accessibility/'
+      policies: '$BASE_URL/policy/'
+      what_is_login_gov: '$BASE_URL/about-us/'
+    partners:
+      developer_guide: 'https://developers.login.gov'
+      get_started: '$BASE_URL/partners/get-started/'
+      security_experience: '$BASE_URL/partners/security-experience/'
     support:
-      faq: '$BASE_URL/partners/faq/'
       business_inquiries: '$BASE_URL/partners/business-inquiries/'
-
+      faq: '$BASE_URL/partners/faq/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@18f/eslint-plugin-identity": "^2.0.0",
+        "@18f/identity-normalize-yaml": "^1.0.0",
         "@axe-core/puppeteer": "^4.5.1",
         "@babel/eslint-plugin": "^7.14.5",
         "@types/jest": "^29.2.6",
@@ -116,6 +117,22 @@
       "engines": {
         "node": ">=12",
         "npm": ">6"
+      }
+    },
+    "node_modules/@18f/identity-normalize-yaml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-normalize-yaml/-/identity-normalize-yaml-1.0.0.tgz",
+      "integrity": "sha512-69kNtqKRhaLxvTTntQJPRva5ccbV6YJBMgZaThITOAqoq8ZrE0TrT+D9aahehcG1b51sGCm8iIkIcM4g5rIyzw==",
+      "dev": true,
+      "dependencies": {
+        "smartquotes": "^2.3.2",
+        "yaml": "^2.3.1"
+      },
+      "bin": {
+        "normalize-yaml": "cli.js"
+      },
+      "peerDependencies": {
+        "prettier": "*"
       }
     },
     "node_modules/@aduth/is-dependency": {
@@ -10996,6 +11013,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/smartquotes": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/smartquotes/-/smartquotes-2.3.2.tgz",
+      "integrity": "sha512-0R6YJ5hLpDH4mZR7N5eZ12oCMLspvGOHL9A9SEm2e3b/CQmQidekW4SWSKEmor/3x6m3NCBBEqLzikcZC9VJNQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -12490,6 +12516,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -12591,6 +12626,16 @@
       "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
       "requires": {
         "@uswds/uswds": "^3.4.1"
+      }
+    },
+    "@18f/identity-normalize-yaml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-normalize-yaml/-/identity-normalize-yaml-1.0.0.tgz",
+      "integrity": "sha512-69kNtqKRhaLxvTTntQJPRva5ccbV6YJBMgZaThITOAqoq8ZrE0TrT+D9aahehcG1b51sGCm8iIkIcM4g5rIyzw==",
+      "dev": true,
+      "requires": {
+        "smartquotes": "^2.3.2",
+        "yaml": "^2.3.1"
       }
     },
     "@aduth/is-dependency": {
@@ -20738,6 +20783,12 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "smartquotes": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/smartquotes/-/smartquotes-2.3.2.tgz",
+      "integrity": "sha512-0R6YJ5hLpDH4mZR7N5eZ12oCMLspvGOHL9A9SEm2e3b/CQmQidekW4SWSKEmor/3x6m3NCBBEqLzikcZC9VJNQ==",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -21867,6 +21918,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "keywords": [],
   "devDependencies": {
     "@18f/eslint-plugin-identity": "^2.0.0",
+    "@18f/identity-normalize-yaml": "^1.0.0",
     "@axe-core/puppeteer": "^4.5.1",
     "@babel/eslint-plugin": "^7.14.5",
     "@types/jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "concurrently \"npm:build:*\"",
     "watch": "concurrently \"npm:watch:*\"",
     "pages": "npm run build",
+    "normalize-yaml": "find _data -name '*.yml' | xargs npm exec normalize-yaml",
     "optimize-assets": "svgo -r -f assets/img",
     "lint": "eslint .",
     "typecheck": "tsc",


### PR DESCRIPTION
## 🛠 Summary of changes

Adds an enforces YAML normalization, using the `@18f/identity-normalize-yaml` package published from `identity-idp` in https://github.com/18F/identity-idp/pull/8654.

**Why?**

- Improved typography using punctuation formatters
   - Also resolves some existing inconsistency where we previously used smart quotes in some places, either due to Jekyll's built-in smart quotes handling or where content was copied from some other source
- Consistency of content formatting in YAML files
   - Improved readability by enforced key alphabetization

## 📜 Testing Plan

```
make lint_yaml
```

Ensure no regressions in displayed content in [preview site](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-normalize-yaml/).