### PR TITLE
Create new "Issues with Authentication Methods" page with translations

### DIFF
--- a/content/_help/trouble-signing-in/forgot-your-personal-key._en.md
+++ b/content/_help/trouble-signing-in/forgot-your-personal-key._en.md
@@ -3,7 +3,7 @@ layout: help
 title: Forgot your personal key
 category: trouble-signing-in
 permalink: /help/trouble-signing-in/forgot-your-personal-key/
-order: 3 
+order: 4
 redirect_from:
   - /en/help/trouble-signing-in/forgot-your-personal-key/
 ---

--- a/content/_help/trouble-signing-in/forgot-your-personal-key._es.md
+++ b/content/_help/trouble-signing-in/forgot-your-personal-key._es.md
@@ -3,7 +3,7 @@ layout: help
 title: Olvidaste tu clave personal 
 category: trouble-signing-in
 permalink: /es/help/trouble-signing-in/forgot-your-personal-key/
-order: 3 
+order: 4
 redirect_from:
   - /es/help/trouble-signing-in/forgot-your-personal-key/
 ---

--- a/content/_help/trouble-signing-in/forgot-your-personal-key._fr.md
+++ b/content/_help/trouble-signing-in/forgot-your-personal-key._fr.md
@@ -3,7 +3,7 @@ layout: help
 title: Vous avez oublié votre clé personnelle?
 category: trouble-signing-in
 permalink: /fr/help/trouble-signing-in/forgot-your-personal-key/
-order: 3 
+order: 4
 redirect_from:
   - /fr/help/trouble-signing-in/forgot-your-personal-key/
 ---

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._en.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._en.md
@@ -1,0 +1,60 @@
+---
+layout: help
+title: Issues with authentication methods
+category: trouble-signing-in
+permalink: /help/trouble-signing-in/issues-with-authentication-methods/
+order: 3
+---
+
+Depending on the authentication methods you’ve set up, you may still be able to access your Login.gov account. After you’re able to sign in, make sure you’ve set up more than one authentication method to avoid losing access to your account. 
+
+<div class="usa-alert usa-alert--warning margin-bottom-4" role="status">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">If you cannot sign in with your only authentication method, you will have to delete your account and create a new account. Login.gov cannot unlock your account for you or sign in on your behalf.</p>
+  </div>
+</div>
+
+## Face or touch unlock isn't working
+
+Unless your device and browser supports cloud sync, face or touch unlock only works on the same device and browser where you set it up. You can only use face or touch unlock on multiple devices if they support cloud sync.
+
+* If you set up face or touch unlock on a device that doesn’t support cloud sync, try using the same device and browser to unlock your account. If you no longer have access to them, you will need to use another authentication method.
+* If you set up face or touch unlock on a device that was signed into a cloud service such as iCloud or your Google Account, you may be able to sign in on any other device as long as it’s also signed into that cloud service.
+* If you set up face or touch unlock on another device, but don’t see face or touch unlock when signing into Login.gov, your current device does not support face or touch unlock. Try using the same device and browser you used to set it up.
+
+We recommend you set up additional authentication methods in case you lose access to a device that supports face or touch unlock.
+
+## I'm not receiving a text or phone call
+
+* If you have a landline phone, choose to receive your one-time code by phone call instead of a text message. You’ll receive a voicemail if you can’t answer the call.
+* If you have a mobile phone, make sure airplane mode is off.
+* Your code may not arrive immediately. Wait up to 10 minutes, or try the “Resend code” button to send your code again.
+* Make sure you’re not using a phone number with an extension, as Login.gov cannot send one-time codes to extensions.
+
+<div class="usa-alert usa-alert--info margin-bottom-4" role="status">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Only the newest one-time code you receive will work. If you request and receive multiple messages at the same time, you may need to try more than one code until one works.</p>
+  </div>
+</div>
+
+## My authenticator app isn’t working
+
+* The time may not be correctly synced between your device and your authenticator app. Make sure your device’s time is correct by using a page like [time.gov](https://www.time.gov/).
+
+    * If you use Google Authenticator, you may need to sync the time manually. [Follow Google’s instructions to sync your time](https://support.google.com/accounts/answer/185834?hl=en).
+
+## My backup code doesn’t work
+
+* Make sure you’re using a backup code that you haven’t used yet. When you use all ten backup codes, we will provide you a new list of backup codes.
+
+## My security key or phone was lost or stolen
+
+* If you are able to regain access to your phone’s original phone number, do so first and then request a one-time code. You should still receive the code, even if you’re using a new device and SIM card.
+* If you’ve lost your security key, you will have to use a different authentication method or delete your account if you have no other authentication method, unless you have already set up a backup.
+
+## My PIV/CAC card isn’t working
+* Login.gov may be missing an issuing certificate for your card. [Contact Login.gov support for additional help.](https://login.gov/contact/)
+
+## Related articles
+
+* [Authentication options](/help/get-started/authentication-options/)

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._en.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._en.md
@@ -16,7 +16,7 @@ Depending on the authentication methods you’ve set up, you may still be able t
 
 ## Face or touch unlock isn't working
 
-Unless your device and browser supports cloud sync, face or touch unlock only works on the same device and browser where you set it up. You can only use face or touch unlock on multiple devices if they support cloud sync.
+If your device and browser supports cloud sync, you can use face or touch unlock on multiple devices. Otherwise, face or touch unlock only works on the same device and browser where you set it up.
 
 * If you set up face or touch unlock on a device that doesn’t support cloud sync, try using the same device and browser to unlock your account. If you no longer have access to them, you will need to use another authentication method.
 * If you set up face or touch unlock on a device that was signed into a cloud service such as iCloud or your Google Account, you may be able to sign in on any other device as long as it’s also signed into that cloud service.

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._es.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._es.md
@@ -1,0 +1,59 @@
+---
+title: Problemas con los métodos de autenticación
+category: trouble-signing-in
+permalink: /es/help/trouble-signing-in/issues-with-authentication-methods/
+order: 3
+---
+
+Dependiendo de los métodos de autenticación que haya configurado, es posible que aún pueda acceder a su cuenta de Login.gov. Una vez que pueda iniciar sesión, asegúrese de haber configurado más de un método de autenticación para evitar perder el acceso a su cuenta.
+
+<div class="usa-alert usa-alert--warning margin-bottom-4" role="status">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Si no puede iniciar sesión con su único método de autenticación, tendrá que eliminar su cuenta y crear una nueva. Login.gov no puede desbloquear su cuenta ni iniciar sesión en su nombre.</p>
+  </div>
+</div>
+
+## El desbloqueo facial o táctil no funciona
+
+A menos que su dispositivo y navegador sean compatibles con la sincronización en la nube, el desbloqueo facial o táctil solo funciona en el mismo dispositivo y navegador donde lo configuró. Solo puede utilizar el desbloqueo facial o táctil en varios dispositivos si son compatibles con la sincronización en la nube. Consulte el artículo de ayuda sobre el desbloqueo facial o táctil para obtener más información.
+
+* Si configura el desbloqueo facial o táctil en un dispositivo que no admite la sincronización en la nube, intente utilizar el mismo dispositivo y navegador para desbloquear su cuenta. Si ya no tiene acceso a ellos, deberá utilizar otro método de autenticación.
+* Si configuró el desbloqueo facial o táctil en un dispositivo que había accedido a un servicio en la nube como iCloud o su cuenta de Google, es posible que pueda acceder en cualquier otro dispositivo siempre que también haya accedido a ese servicio en la nube.
+* Si configura el desbloqueo facial o táctil en otro dispositivo, pero no ve el desbloqueo facial o táctil al acceder a Login.gov, su dispositivo actual no es compatible con el desbloqueo facial o táctil. Intente utilizar el mismo dispositivo y navegador que utilizó para configurarlo.
+
+Le recomendamos que configure métodos de autenticación adicionales por si pierde el acceso a un dispositivo compatible con el desbloqueo facial o táctil.
+
+## No recibo mensajes de texto ni llamadas telefónicas
+
+* Si tiene un teléfono fijo, elija recibir su código de un solo uso mediante una llamada telefónica en lugar de un mensaje de texto. Recibirá un mensaje de voz si no puedes contestar la llamada.
+* Si tiene un teléfono móvil, asegúrese de que el modo avión está desactivado.
+* Es posible que su código no llegue inmediatamente. Espere hasta 10 minutos, o pruebe el botón "Reenviar código" para enviar su código de nuevo.
+* Asegúrese de que no está utilizando un número de teléfono con extensión, ya que Login.gov no puede enviar códigos de un solo uso a extensiones.
+
+<div class="usa-alert usa-alert--info margin-bottom-4" role="status">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Solo funcionará el código de un solo uso más reciente que reciba. Si solicita y recibe varios mensajes al mismo tiempo, es posible que tenga que probar más de un código hasta que uno funcione.</p>
+  </div>
+</div>
+
+## Mi aplicación de autenticación no funciona
+
+* Es posible que la hora no esté correctamente sincronizada entre su dispositivo y su aplicación de autenticación. Asegúrese de que la hora de su dispositivo sea correcta utilizando una página como [time.gov](https://www.time.gov/).
+
+    * Si utiliza Google Authenticator, es posible que tenga que sincronizar la hora manualmente. [Siga las instrucciones de Google para sincronizar la hora](https://support.google.com/accounts/answer/185834?hl=es).
+
+## Mi código de recuperación no funciona
+
+* Asegúrese de que está utilizando un código de recuperación que aún no ha utilizado. Cuando utilice los diez códigos de recuperación, le proporcionaremos una nueva lista de códigos.
+
+## He perdido o me han robado la clave de seguridad o el teléfono
+
+* Si puede volver a acceder al número de teléfono original de su teléfono, hágalo primero y luego solicite un código de un solo uso. Debería recibir el código aunque utilice un dispositivo y una tarjeta SIM nuevas.
+* Si ha perdido su clave de seguridad, tendrá que utilizar un método de autenticación diferente o eliminar su cuenta si no dispone de otro método de autenticación, a menos que ya haya configurado una copia de seguridad.
+
+## Mi tarjeta PIV/CAC no funciona
+* Login.gov puede no disponer de un certificado de emisión para su tarjeta. [Póngase en contacto con el servicio de asistencia de Login.gov para obtener más ayuda](https://login.gov/contact/).
+
+## Artículos relacionados
+
+* [Opciones de autenticacións](/es/help/get-started/authentication-options/)

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._fr.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._fr.md
@@ -1,0 +1,59 @@
+---
+title: Problèmes liés aux méthodes d’authentification
+category: trouble-signing-in
+permalink: /fr/help/trouble-signing-in/issues-with-authentication-methods/
+order: 3
+---
+
+En fonction des méthodes d’authentification que vous avez configurées, vous pourrez peut-être encore accéder à votre compte Login.gov. Une fois que vous avez pu vous connecter, assurez-vous d’avoir configuré plusieurs méthodes d’authentification pour éviter de perdre l’accès à votre compte. 
+
+<div class="usa-alert usa-alert--warning margin-bottom-4" role="status">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Si vous ne pouvez pas vous connecter avec votre seule méthode d’authentification, vous devrez supprimer votre compte et en créer un nouveau. Login.gov ne peut pas déverrouiller votre compte pour vous ou vous connecter en votre nom.</p>
+  </div>
+</div>
+
+## Le déverrouillage facial ou tactile ne fonctionne pas
+
+À moins que votre appareil et votre navigateur ne prennent en charge la synchronisation avec le nuage, le déverrouillage facial ou tactile ne fonctionne que sur l'appareil et le navigateur où vous l'avez configuré. Vous ne pouvez utiliser le déverrouillage facial ou tactile sur plusieurs appareils que s'ils prennent en charge la synchronisation avec le nuage. Pour plus d'informations, consultez l'article d'aide sur le déverrouillage facial ou tactile.
+
+* Si vous avez configuré le déverrouillage facial ou tactile sur un appareil qui ne prend pas en charge la synchronisation avec le nuage, essayez d'utiliser le même appareil et le même navigateur pour déverrouiller votre compte. Si vous n'y avez plus accès, vous devrez utiliser une autre méthode d'authentification.
+* Si vous avez configuré le déverrouillage facial ou tactile sur un appareil connecté à un service en nuage tel qu'iCloud ou votre compte Google, vous pourrez peut-être vous connecter sur n'importe quel autre appareil, à condition qu'il soit également connecté à ce service en nuage.
+* Si vous avez configuré le déverrouillage facial ou tactile sur un autre appareil, mais que vous ne voyez pas le déverrouillage facial ou tactile lorsque vous vous connectez à Login.gov, c'est que votre appareil actuel ne prend pas en charge le déverrouillage facial ou tactile. Essayez d'utiliser le même appareil et le même navigateur que ceux que vous avez utilisés pour la configuration.
+
+Nous vous recommandons de configurer d'autres méthodes d'authentification au cas où vous perdriez l'accès à un appareil prenant en charge le déverrouillage facial ou tactile.
+
+## Je ne reçois pas de texte ou d’appel téléphonique
+
+* Si vous avez un téléphone fixe, choisissez de recevoir votre code à usage unique par appel téléphonique plutôt que par message texte. Vous recevrez un message vocal si vous ne pouvez pas répondre à l’appel.
+* Si vous avez un téléphone portable, assurez-vous que le mode avion est désactivé.
+* Il se peut que votre code ne vous parvienne pas immédiatement. Attendez jusqu’à 10 minutes ou essayez le bouton « Renvoyer le code » pour envoyer à nouveau votre code.
+* Assurez-vous que vous n’utilisez pas un numéro de téléphone avec une extension, car Login.gov ne peut pas envoyer de codes à usage unique à des extensions.
+
+<div class="usa-alert usa-alert--info margin-bottom-4" role="status">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Seul le code unique le plus récent que vous recevrez fonctionnera. Si vous demandez et recevez plusieurs messages en même temps, il se peut que vous deviez essayer plusieurs codes jusqu’à ce que l’un d’entre eux fonctionne.</p>
+  </div>
+</div>
+
+## Mon application d'authentification ne fonctionne pas
+
+* Il se peut que l’heure ne soit pas correctement synchronisée entre votre appareil et votre application d’authentification. Assurez-vous que l’heure de votre appareil est correcte en utilisant une page comme [time.gov](https://www.time.gov/).
+
+    * Si vous utilisez Google Authenticator, vous devrez peut-être synchroniser l’heure manuellement. [Suivez les instructions de Google pour synchroniser votre heure.](https://support.google.com/accounts/answer/185834?hl=fr).
+
+## Mon code de sauvegarde ne fonctionne pas
+
+* Assurez-vous d’utiliser un code de sauvegarde que vous n’avez pas encore utilisé. Lorsque vous aurez utilisé les dix codes de sauvegarde, nous vous fournirons une nouvelle liste de codes de sauvegarde.
+
+## Ma clé de sécurité ou mon téléphone ont été perdus ou volés
+
+* Si vous parvenez à retrouver le numéro de téléphone d’origine de votre téléphone, commencez par le faire, puis demandez un code à usage unique. Vous devriez toujours recevoir le code, même si vous utilisez un nouvel appareil et une nouvelle carte SIM.
+* Si vous avez perdu votre clé de sécurité, vous devrez utiliser une autre méthode d’authentification ou supprimer votre compte si vous n’avez pas d’autre méthode d’authentification, à moins que vous n’ayez déjà mis en place une sauvegarde.
+
+## Ma carte PIV/CAC ne fonctionne pas
+* Il se peut qu’il manque à Login.gov un certificat d’émission pour votre carte. Contactez le service d’assistance de Login.gov pour obtenir de l’aide supplémentaire.
+
+## Articles connexes
+
+* [Authentication options](/fr/help/get-started/authentication-options/)


### PR DESCRIPTION
## 🎫 Ticket

[LG-10168](https://cm-jira.usa.gov/browse/LG-10168), an implementation of [LG-9890](https://cm-jira.usa.gov/browse/LG-9890)

## 🛠 Summary of changes

Per [LG-9890](https://cm-jira.usa.gov/browse/LG-9890), Team Katherine developed a troubleshooting article to support face/touch unlock, "Issues with authentication methods," which also covers common non-FT MFA troubleshooting problems identified by Dylan Bowling and Rachel Houghton from the support team.

This article has been created in markdown for EN, ES and FR and assigned an order of 3 in the taxonomy. The previous order 3 article, "Forgot your personal key," has been moved to order 4.

Since this article contains information valuable even for people who are already using face/touch unlock from the previous launch, this can be merged even prior to the phase 1 relaunch of face/touch unlock.

## 📜 Testing Plan

- [ ] Ensure "Issues with authentication methods" accurately displays as the "order 3" item in the list followed by "Forgot your personal key" ("order 4").
- [ ] Ensure no display bugs.
- [ ] Ensure consistency in display between en, fr, es pages.