### PR TITLE
Bug Fix Contact Us form - Remove 'Other' Topic

### DIFF
--- a/_data/en/settings.yml
+++ b/_data/en/settings.yml
@@ -176,7 +176,7 @@ contact_page:
     topics:
       changing_settings: Changing your Login.gov information
       creating_account: Create a Login.gov account
-      feedback: Feedback for Login.gov
+      feedback: Feedback or other
       not_login_gov: Not Login.gov
       other: Other
       piv_cac: PIV/CAC issue

--- a/_data/es/settings.yml
+++ b/_data/es/settings.yml
@@ -191,7 +191,7 @@ contact_page:
     topics:
       changing_settings: Cambiar su información de Login.gov
       creating_account: Crear una cuenta de Login.gov
-      feedback: Comentarios para Login.gov
+      feedback: Comentarios o otro
       not_login_gov: No es Login.gov
       other: Otro
       piv_cac: Problema con CAC (tarjeta de acceso común) o PIV (verificación de

--- a/_data/fr/settings.yml
+++ b/_data/fr/settings.yml
@@ -189,7 +189,7 @@ contact_page:
     topics:
       changing_settings: Changer vos informations de Login.gov
       creating_account: Créer un compte Login.gov
-      feedback: Commentaires pour Login.gov
+      feedback: Commentaires ou autre
       not_login_gov: Pas Login.gov
       other: Autre
       piv_cac: Problème de PIV/CAC

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -292,10 +292,6 @@
         ),
       ],
     ),
-    new TopicEntry(
-      'Other',
-      '{{ site.data.[page.lang].settings.contact_page.support_request_form.topics.other | escape_quotes }}',
-    ),
   ];
 
   function remapvalues(frm) {


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

[LG-10067](https://cm-jira.usa.gov/browse/LG-10067)


## 🛠 Summary of changes

Removes from the topicMap array the Other Topic.

Other as a Topic has no subtopic Issue. 
Issue is a required field so when a user selects Other they cannot select an Issue and so cannot submit the form.

Relabel 'Feedback for Login.gov' to 'Feedback or other'

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|  |  |
-->

