### PR TITLE
Consistently use alert "component" partial

### DIFF
--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -1,7 +1,8 @@
 {% comment %}
 include
 - content
-- type (optional)
+- heading (optional)
+- type (optional, default "info")
 - role (optional)
 - id (optional)
 - class (optional)

--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -2,9 +2,21 @@
 include
 - content
 - type (optional)
+- role (optional)
+- id (optional)
+- class (optional)
+- hidden (optional)
 {% endcomment %}
-<div class="usa-alert usa-alert--{{ include.type | default: 'info' }}">
+<div
+  class="usa-alert usa-alert--{{ include.type | default: 'info' }} {{ include.class }}"
+  {% if include.id %}id="{{ include.id }}"{% endif %}
+  {% if include.role %}role="{{ include.role }}"{% endif %}
+  {% if include.hidden %}hidden{% endif %}
+>
   <div class="usa-alert__body">
+    {% if include.heading %}
+      <h2 class="usa-alert__heading">{{ include.heading }}</h2>
+    {% endif %}
     <p class="usa-alert__text">
       {{ include.content }}
     </p>

--- a/_includes/contact_form.html
+++ b/_includes/contact_form.html
@@ -530,16 +530,14 @@
       ' }}
     </div>
 
-    <div class="usa-alert usa-alert--warning display-none margin-bottom-4" id="pii-warning">
-      <div class="usa-alert__body">
-        <p
-          class="usa-alert__text"
-          id="pii-warning-message"
-          role="alert"
-          data-error="{{ site.data.[page.lang].settings.contact_page.support_request_form.errors.pii_found }}"
-        ></p>
-      </div>
-    </div>
+    {% assign pii_alert_content = site.data.[page.lang].settings.contact_page.support_request_form.errors.pii_found %}
+    {% include alert.html
+       content=pii_alert_content
+       type="warning"
+       id="pii-warning"
+       role="alert"
+       class="margin-bottom-4"
+       hidden="true" %}
 
     <textarea
       id="description"

--- a/_includes/country_support_table.html
+++ b/_includes/country_support_table.html
@@ -44,12 +44,11 @@ Should include these translations as includes:
       </tr>
     </tbody>
   </table>
-  <div hidden class="usa-alert usa-alert--error" role="alert">
-    <div class="usa-alert__body">
-      <h2 class="usa-alert__heading">{{ include.error_heading }}</h2>
-      <p class="usa-alert__text">
-        {{ include.error_body }}
-      </p>
-    </div>
-  </div>
+
+  {% include alert.html
+     type="error"
+     role="alert"
+     hidden="true"
+     heading=include.error_heading
+     content=include.error_body %}
 </div>

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -20,7 +20,6 @@ common_applications:
   {% include alert.html
      type="warning"
      id="contact-us-maintenance-alert"
-     class="display-none"
      hidden="true"
      content=maintenance_alert_content %}
 {% endif %}

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -11,29 +11,28 @@ common_applications:
 ---
 
 {% if site.contact_maintenance_start_time and site.contact_maintenance_end_time %}
-  <div id="contact-us-maintenance-alert" class="usa-alert usa-alert--warning" hidden>
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        {{ page.maintenance_window_content }}
-        {% if site.contact_maintenance_phone_available %}
-          {{ page.phone_available_content }}
-        {% endif %}
-      </p>
-    </div>
-  </div>
+  {% capture maintenance_alert_content %}
+    {{ page.maintenance_window_content }}
+    {% if site.contact_maintenance_phone_available %}
+      {{ page.phone_available_content }}
+    {% endif %}
+  {% endcapture %}
+  {% include alert.html
+     type="warning"
+     id="contact-us-maintenance-alert"
+     class="display-none"
+     hidden="true"
+     content=maintenance_alert_content %}
 {% endif %}
 
 {% if site.contact_unplanned_outage %}
-  <div class="usa-alert usa-alert--warning">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        {{ page.unplanned_outage_content }}
-        {% if site.contact_unplanned_outage_phone_available %}
-          {{ page.phone_available_content }}
-        {% endif %}
-      </p>
-    </div>
-  </div>
+  {% capture outage_alert_content %}
+    {{ page.unplanned_outage_content }}
+    {% if site.contact_unplanned_outage_phone_available %}
+      {{ page.phone_available_content }}
+    {% endif %}
+  {% endcapture %}
+  {% include alert.html type="warning" content=outage_alert_content %}
 {% endif %}
 
 {{ page.help_center_content | markdownify }}

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -7,7 +7,6 @@ function verifyCanSubmitEntry() {
   const form = document.getElementById('contact-us-form');
   const error = document.getElementById('captcha-error-message');
   const piiError = document.getElementById('pii-warning');
-  const piiErrorText = document.getElementById('pii-warning-message');
   const descriptionInput = document.getElementById('description');
   let alreadyAttemptedSubmission = false;
   form.addEventListener('submit', (event) => {
@@ -19,17 +18,13 @@ function verifyCanSubmitEntry() {
     } else if (descriptionInput.value.match(/\d{4,}/) && !alreadyAttemptedSubmission) {
       alreadyAttemptedSubmission = true;
       event.preventDefault();
-      piiError.classList.remove('display-none');
-      piiErrorText.textContent = piiErrorText.dataset.error;
+      piiError.hidden = false;
     }
   });
 
   descriptionInput.addEventListener('change', (_) => {
     alreadyAttemptedSubmission = false;
-    if (piiErrorText.textContent) {
-      piiError.classList.add('display-none');
-      piiErrorText.textContent = '';
-    }
+    piiError.hidden = true;
   });
 }
 document.addEventListener('DOMContentLoaded', verifyCanSubmitEntry);

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._en.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._en.md
@@ -6,13 +6,12 @@ permalink: /help/trouble-signing-in/issues-with-authentication-methods/
 order: 3
 ---
 
-Depending on the authentication methods you’ve set up, you may still be able to access your Login.gov account. After you’re able to sign in, make sure you’ve set up more than one authentication method to avoid losing access to your account. 
+Depending on the authentication methods you’ve set up, you may still be able to access your Login.gov account. After you’re able to sign in, make sure you’ve set up more than one authentication method to avoid losing access to your account.
 
-<div class="usa-alert usa-alert--warning margin-bottom-4" role="status">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">If you cannot sign in with your only authentication method, you will have to delete your account and create a new account. Login.gov cannot unlock your account for you or sign in on your behalf.</p>
-  </div>
-</div>
+{% capture delete_account_alert_content %}
+If you cannot sign in with your only authentication method, you will have to delete your account and create a new account. Login.gov cannot unlock your account for you or sign in on your behalf.
+{% endcapture %}
+{% include alert.html type="warning" class="margin-bottom-4" content=delete_account_alert_content %}
 
 ## Face or touch unlock isn't working
 
@@ -31,11 +30,10 @@ We recommend you set up additional authentication methods in case you lose acces
 * Your code may not arrive immediately. Wait up to 10 minutes, or try the “Resend code” button to send your code again.
 * Make sure you’re not using a phone number with an extension, as Login.gov cannot send one-time codes to extensions.
 
-<div class="usa-alert usa-alert--info margin-bottom-4" role="status">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Only the newest one-time code you receive will work. If you request and receive multiple messages at the same time, you may need to try more than one code until one works.</p>
-  </div>
-</div>
+{% capture newest_otp_alert_content %}
+Only the newest one-time code you receive will work. If you request and receive multiple messages at the same time, you may need to try more than one code until one works.
+{% endcapture %}
+{% include alert.html class="margin-bottom-4" content=newest_otp_alert_content %}
 
 ## My authenticator app isn’t working
 

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._es.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._es.md
@@ -7,11 +7,10 @@ order: 3
 
 Dependiendo de los métodos de autenticación que haya configurado, es posible que aún pueda acceder a su cuenta de Login.gov. Una vez que pueda iniciar sesión, asegúrese de haber configurado más de un método de autenticación para evitar perder el acceso a su cuenta.
 
-<div class="usa-alert usa-alert--warning margin-bottom-4" role="status">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Si no puede iniciar sesión con su único método de autenticación, tendrá que eliminar su cuenta y crear una nueva. Login.gov no puede desbloquear su cuenta ni iniciar sesión en su nombre.</p>
-  </div>
-</div>
+{% capture delete_account_alert_content %}
+Si no puede iniciar sesión con su único método de autenticación, tendrá que eliminar su cuenta y crear una nueva. Login.gov no puede desbloquear su cuenta ni iniciar sesión en su nombre.
+{% endcapture %}
+{% include alert.html type="warning" class="margin-bottom-4" content=delete_account_alert_content %}
 
 ## El desbloqueo facial o táctil no funciona
 
@@ -30,11 +29,10 @@ Le recomendamos que configure métodos de autenticación adicionales por si pier
 * Es posible que su código no llegue inmediatamente. Espere hasta 10 minutos, o pruebe el botón "Reenviar código" para enviar su código de nuevo.
 * Asegúrese de que no está utilizando un número de teléfono con extensión, ya que Login.gov no puede enviar códigos de un solo uso a extensiones.
 
-<div class="usa-alert usa-alert--info margin-bottom-4" role="status">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Solo funcionará el código de un solo uso más reciente que reciba. Si solicita y recibe varios mensajes al mismo tiempo, es posible que tenga que probar más de un código hasta que uno funcione.</p>
-  </div>
-</div>
+{% capture newest_otp_alert_content %}
+Solo funcionará el código de un solo uso más reciente que reciba. Si solicita y recibe varios mensajes al mismo tiempo, es posible que tenga que probar más de un código hasta que uno funcione.
+{% endcapture %}
+{% include alert.html class="margin-bottom-4" content=newest_otp_alert_content %}
 
 ## Mi aplicación de autenticación no funciona
 

--- a/content/_help/trouble-signing-in/issues-with-authentication-methods._fr.md
+++ b/content/_help/trouble-signing-in/issues-with-authentication-methods._fr.md
@@ -5,13 +5,12 @@ permalink: /fr/help/trouble-signing-in/issues-with-authentication-methods/
 order: 3
 ---
 
-En fonction des méthodes d’authentification que vous avez configurées, vous pourrez peut-être encore accéder à votre compte Login.gov. Une fois que vous avez pu vous connecter, assurez-vous d’avoir configuré plusieurs méthodes d’authentification pour éviter de perdre l’accès à votre compte. 
+En fonction des méthodes d’authentification que vous avez configurées, vous pourrez peut-être encore accéder à votre compte Login.gov. Une fois que vous avez pu vous connecter, assurez-vous d’avoir configuré plusieurs méthodes d’authentification pour éviter de perdre l’accès à votre compte.
 
-<div class="usa-alert usa-alert--warning margin-bottom-4" role="status">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Si vous ne pouvez pas vous connecter avec votre seule méthode d’authentification, vous devrez supprimer votre compte et en créer un nouveau. Login.gov ne peut pas déverrouiller votre compte pour vous ou vous connecter en votre nom.</p>
-  </div>
-</div>
+{% capture delete_account_alert_content %}
+Si vous ne pouvez pas vous connecter avec votre seule méthode d’authentification, vous devrez supprimer votre compte et en créer un nouveau. Login.gov ne peut pas déverrouiller votre compte pour vous ou vous connecter en votre nom.
+{% endcapture %}
+{% include alert.html type="warning" class="margin-bottom-4" content=delete_account_alert_content %}
 
 ## Le déverrouillage facial ou tactile ne fonctionne pas
 
@@ -30,11 +29,10 @@ Nous vous recommandons de configurer d'autres méthodes d'authentification au ca
 * Il se peut que votre code ne vous parvienne pas immédiatement. Attendez jusqu’à 10 minutes ou essayez le bouton « Renvoyer le code » pour envoyer à nouveau votre code.
 * Assurez-vous que vous n’utilisez pas un numéro de téléphone avec une extension, car Login.gov ne peut pas envoyer de codes à usage unique à des extensions.
 
-<div class="usa-alert usa-alert--info margin-bottom-4" role="status">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">Seul le code unique le plus récent que vous recevrez fonctionnera. Si vous demandez et recevez plusieurs messages en même temps, il se peut que vous deviez essayer plusieurs codes jusqu’à ce que l’un d’entre eux fonctionne.</p>
-  </div>
-</div>
+{% capture newest_otp_alert_content %}
+Seul le code unique le plus récent que vous recevrez fonctionnera. Si vous demandez et recevez plusieurs messages en même temps, il se peut que vous deviez essayer plusieurs codes jusqu’à ce que l’un d’entre eux fonctionne.
+{% endcapture %}
+{% include alert.html class="margin-bottom-4" content=newest_otp_alert_content %}
 
 ## Mon application d'authentification ne fonctionne pas
 


### PR DESCRIPTION
## 🛠 Summary of changes

Follow-up to: https://github.com/18F/identity-site/pull/1123#discussion_r1261691663

Refactors existing ad-hoc alert HTML to use the `alert.html` partial added in #1123.

This was slightly more complicated than initial expected, due to the various customizations we apply to alerts through attributes.

## 📜 Testing Plan

Verify no regressions in affected pages, including in Spanish and French locales:

- http://localhost:4000/contact/
  - Outage banner
     - Refer to https://github.com/18F/identity-site/blob/main/docs/development-workflows/contact-form-outages.md
  - PII banner (when submitting with 4 digits in comment field)
- http://localhost:4000/help/trouble-signing-in/issues-with-authentication-methods/
  - Note: Two alerts in this page
- http://localhost:4001/help/manage-your-account/international-phone-support/
  - Only shows when IdP unreachable, use `idp_base_url: http://localhost:3000` in `_config.dev.yml`