### PR TITLE
Avoid internal linking to legacy URLs

### DIFF
--- a/content/_landing/create_an_account._en.md
+++ b/content/_landing/create_an_account._en.md
@@ -20,7 +20,7 @@ steps:
     * Passwords must be at least 12 characters and should not include commonly used words or phrases.
   step3: >
     ## 3. One or more [authentication
-    methods](/help/authentication-methods/which-authentication-method-should-i-use/)
+    methods](/help/get-started/authentication-options/)
     such as:
 
 

--- a/content/_landing/create_an_account._es.md
+++ b/content/_landing/create_an_account._es.md
@@ -19,7 +19,7 @@ steps:
     * Las contraseñas deben tener al menos 12 caracteres y no deben incluir palabras o frases de uso común.
   step3: >-
     ## 3. Uno o más [métodos de
-    autenticación](/es/help/authentication-methods/which-authentication-method-should-i-use/)
+    autenticación](/es/help/get-started/authentication-options/)
     como:
 
 

--- a/content/_landing/create_an_account._fr.md
+++ b/content/_landing/create_an_account._fr.md
@@ -19,7 +19,7 @@ steps:
     * Les mots de passe doivent être composés d'au moins 12 caractères et ne doivent pas inclure des mots ou des phrases couramment utilisés.
   step3: >
     ## 3. Une ou plusieurs [méthodes
-    d'authentification](/fr/help/authentication-methods/which-authentication-method-should-i-use/)
+    d'authentification](/fr/help/get-started/authentication-options/)
     telles que:
 
     * __Plus sécurisé__

--- a/content/_landing/what_is_login._en.md
+++ b/content/_landing/what_is_login._en.md
@@ -29,7 +29,7 @@ component:
     ## Secure and private access for the public
 
 
-    Login.gov uses [the highest standards of security](/security/) to keep your information safe including identity verification and [two-factor authentication](/help/authentication-methods/which-authentication-method-should-i-use/).
+    Login.gov uses [the highest standards of security](/policy/our-security-practices/) to keep your information safe including identity verification and [two-factor authentication](/help/get-started/authentication-options/).
 
 
     Login.gov is provided by [Technology Transformation Services (TTS)](https://www.gsa.gov/tts).

--- a/content/_landing/what_is_login._es.md
+++ b/content/_landing/what_is_login._es.md
@@ -28,7 +28,7 @@ component:
     ## Acceso seguro y privado para el público
 
 
-    Login.gov utiliza [los más altos estándares de seguridad](/es/security/) para mantener segura su información, incluida la verificación de identidad y [autenticación de dos factores](/es/help/authentication-methods/which-authentication-method-should-i-use/).
+    Login.gov utiliza [los más altos estándares de seguridad](/es/policy/our-security-practices/) para mantener segura su información, incluida la verificación de identidad y [autenticación de dos factores](/es/help/get-started/authentication-options/).
 
 
     Login.gov es proporcionado por [Technology Transformation Services (TTS)](https://www.gsa.gov/tts).

--- a/content/_landing/what_is_login._fr.md
+++ b/content/_landing/what_is_login._fr.md
@@ -28,7 +28,7 @@ component:
     ## Accès sécurisé et privé pour le public
 
 
-    Login.gov utilise [les normes de sécurité les plus élevées](/fr/security/) pour protéger vos informations, y compris la vérification d’identité et [l’authentification à deux facteurs](/fr/help/authentication-methods/which-authentication-method-should-i-use/).
+    Login.gov utilise [les normes de sécurité les plus élevées](/fr/policy/our-security-practices/) pour protéger vos informations, y compris la vérification d’identité et [l’authentification à deux facteurs](/fr/help/get-started/authentication-options/).
 
 
     Login.gov est fourni par [Technology Transformation Services (TTS)](https://www.gsa.gov/tts).

--- a/content/_landing/who_uses_login._en.md
+++ b/content/_landing/who_uses_login._en.md
@@ -17,7 +17,7 @@ component:
     * Paycheck Protection Program (Small Business Administration)
     * Disaster Loan Applications Program (Small Business Administration)
   col2: >-
-    Login.gov adheres to the latest [security standards](/security/)
+    Login.gov adheres to the latest [security standards](/policy/our-security-practices/)
     established by top security organizations such as the [National Institute of
     Standards and Technology](https://www.nist.gov/), the [Cybersecurity
     National Action

--- a/content/_landing/who_uses_login._es.md
+++ b/content/_landing/who_uses_login._es.md
@@ -20,7 +20,7 @@ component:
     * Programa de solicitudes de préstamos por desastre (Administración de pequeñas empresas)
   col2: >-
     Login.gov se adhiere a los últimos [estándares de
-    seguridad](/es/security/) establecidos por las principales
+    seguridad](/es/policy/our-security-practices/) establecidos por las principales
     organizaciones de seguridad como el [Instituto Nacional de Estándares y
     Tecnología](https://www.nist.gov/), el [Plan de Acción Nacional de
     Ciberseguridad](https://www.hsdl.org/c/cybersecurity-national-action-plan/)

--- a/content/_landing/who_uses_login._fr.md
+++ b/content/_landing/who_uses_login._fr.md
@@ -19,7 +19,7 @@ component:
 
     * Programme de demandes de prêts en cas de catastrophe (Small Business Administration)
   col2: >-
-    Login.gov adhère aux dernières [normes de sécurité](/fr/security/)
+    Login.gov adhère aux dernières [normes de sécurité](/fr/policy/our-security-practices/)
     établies par des organisations de sécurité de premier plan telles que le
     [National Institute of Standards and Technology](https://www.nist.gov/), le
     [Cybersecurity National Action

--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -18,6 +18,8 @@ def get_locale(path)
 end
 
 RSpec.describe 'all pages' do
+  let(:old_paths) { YAML.load_file('OLD_URLS.yml').map { |url| URI(url).path } }
+
   files = Dir.glob('**/*.html', base: SITE_ROOT)
   files.reject! { |path| admin_page?(path) || redirect_page?(path) }
   files.sort.each do |path|
@@ -37,13 +39,14 @@ RSpec.describe 'all pages' do
         expect(doc).to properly_escape_html
       end
 
-      it 'links consistently' do
+      it 'links as HTTPS to valid page' do
         aggregate_failures do
           doc.css('a').each do |a|
             next if a[:href].start_with?('#')
             uri = URI(a[:href])
             next if external_link?(uri)
             expect(uri).to be_https_scheme, "expected https, got:\n\n#{a.to_html}"
+            expect(old_paths).not_to include(uri.path)
           end
         end
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates and adds enforcement that we don't internally link to "old" URLs.

**Why?**

- So that our links always direct to the most up-to-date content
- To avoid an extra redirect hop for users who follow these links

## 📜 Testing Plan

Ensure that the affected content still links to the expected page.