### PR TITLE
LG-10350: Filter search collection for Help & Partners

### DIFF
--- a/_includes/header--help.html
+++ b/_includes/header--help.html
@@ -97,7 +97,7 @@
         {% include language_picker.html dropdown=true id="dropdown" %}
       </div>
 
-      {% include search.html id="header-nav" %}
+      {% include search.html id="header-nav" collection="8801" %}
 
       <div class="desktop:display-none margin-top-3">
         {% include language_picker.html id="mobile-list" %}

--- a/_includes/help/nav_sidenav.html
+++ b/_includes/help/nav_sidenav.html
@@ -1,4 +1,4 @@
-{% include search.html id="sidenav" %}
+{% include search.html id="sidenav" collection="8801" %}
 <nav class="margin-y-4 sidenav position-sticky pin-top" aria-label="{{ site.data.[page.lang].settings.accessible_labels.secondary_navigation }}">
   <ul class="usa-accordion usa-sidenav">
     {% for subpage in site.help_pages %}

--- a/_includes/hero--search.html
+++ b/_includes/hero--search.html
@@ -1,6 +1,6 @@
 <section class="usa-section--dark hero hero--search">
   <div class="container display-flex flex-column flex-justify-center text-center">
     <h1 class="hero__title">{{ site.data.[page.lang].settings.help_page.title }}</h1>
-    <div class="hero__description">{% include search.html size="big" id="help-hero" %}</div>
+    <div class="hero__description">{% include search.html collection=include.collection size="big" id="help-hero" %}</div>
   </div>
 </section>

--- a/_includes/partners/header.html
+++ b/_includes/partners/header.html
@@ -23,7 +23,7 @@
         </a>
       </div>
 
-      <div class="display-none desktop:display-block">{% include search.html id="desktop" %}</div>
+      <div class="display-none desktop:display-block">{% include search.html id="desktop" collection="8803" %}</div>
 
       <button class="usa-menu-btn">Menu</button>
     </div>
@@ -97,7 +97,7 @@
           {{ site.data.[page.lang].settings.nav.business_inquiries.title }}
         </a>
 
-        <div class="desktop:display-none">{% include search.html id="mobile" %}</div>
+        <div class="desktop:display-none">{% include search.html id="mobile" collection="8803" %}</div>
       </div>
     </nav>
   </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,12 +1,20 @@
+{% if include.collection %}
+  {% assign action = "https://search.usa.gov/search/docs" %}
+{% else %}
+  {% assign action = "https://search.usa.gov/search" %}
+{% endif %}
 <form
   accept-charset="UTF-8"
-  action="https://search.usa.gov/search"
+  action="{{ action }}"
   class="usa-search{% if include.size %} usa-search--{{ include.size }}{% endif %} display-flex flex-justify-center"
   method="get"
   role="search"
 >
   <input name="utf8" type="hidden" value="&#x2713;" />
   <input name="affiliate" type="hidden" value="login.gov" />
+  {% if include.collection %}
+    <input name="dc" type="hidden" value="{{ include.collection }}" />
+  {% endif %}
   <label class="usa-sr-only" for="search-field-{{ include.id }}"
     >{{ site.data.[page.lang].settings.actions.search }}</label
   >

--- a/_layouts/help_landing.html
+++ b/_layouts/help_landing.html
@@ -8,7 +8,7 @@ body:
   {% include banner.html %}
   {% include header--help.html %}
   {% if page.hero == true %}
-    {% include hero--search.html %}
+    {% include hero--search.html collection="8801" %}
   {% endif %}
 </header>
 <main id="main-content">{{ content }}</main>


### PR DESCRIPTION
## 🎫 Ticket

[LG-10350](https://cm-jira.usa.gov/browse/LG-10350)

## 🛠 Summary of changes

Updates searches performed in Help Center and Partners site to filter automatically to results for "Login.gov account help" and "For partners" Search.gov collections respectively.

Reference:

- https://search.gov/admin-center/activate/code.html#option-1-limit-to-collections
- https://search.usa.gov/sites/8022/collections

## 📜 Testing Plan

1. Go to http://localhost:4000
2. Search for something
3. Navigate to a different page
4. Try mobile searching too

Expect that search results are filtered based on where you search from:

- Help landing page or article? Filters to "Login.gov account help"
- Partner site? Filters to "For partners"
- Neither of the above? Shows "Everything" results
