### PR TITLE
LG-10491 Update how-to-verify-your-identity with info for people under 18 years old

### DIFF
--- a/content/_help/verify-your-identity/how-to-verify-your-identity._en.md
+++ b/content/_help/verify-your-identity/how-to-verify-your-identity._en.md
@@ -10,7 +10,7 @@ redirect_from:
 
 Some government applications require identity verification. This additional layer of security requires you to prove you are you - and not someone pretending to be you.
 
-You will need to verify your identity and secure your account.
+If you are under 18 years of age, you may not be able to verify your identity for a Login.gov account. If you have trouble verifying your identity, please contact the partner agency to find out what you can do.
 
 ## Requirements for identity verification
 

--- a/content/_help/verify-your-identity/how-to-verify-your-identity._es.md
+++ b/content/_help/verify-your-identity/how-to-verify-your-identity._es.md
@@ -7,7 +7,7 @@ order: 1
 
 Algunas aplicaciones gubernamentales requieren verificación de identidad. Esta capa adicional de seguridad requiere que pruebes que eres tú y no alguien que finge ser tú.
 
-Necesitarás verificar tu identidad y asegurar tu cuenta.
+Si es menor de 18 años, es posible que no pueda verificar su identidad en su cuenta de Login.gov. Si tiene problemas para verificar su identidad, póngase en contacto con el organismo asociado para saber qué puede hacer.
 
 ## Requisitos para la verificación de identidad
 

--- a/content/_help/verify-your-identity/how-to-verify-your-identity._fr.md
+++ b/content/_help/verify-your-identity/how-to-verify-your-identity._fr.md
@@ -7,7 +7,7 @@ order: 1
 
 Certaines applications gouvernementales nécessitent une vérification d'identité. Ce niveau de sécurité supplémentaire exige que vous prouviez que vous êtes vous-même – et non quelqu'un qui se fait passer pour vous.
 
-Vous devrez vérifier votre identité et sécuriser votre compte.
+Si vous avez moins de 18 ans, il se peut que vous ne puissiez pas vérifier votre identité pour un compte Login.gov. Si vous ne parvenez pas à vérifier votre identité, merci de contacter l’agence partenaire pour savoir ce que vous pouvez faire.
 
 ## Exigences relatives à la vérification de l'identité
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-10491](https://cm-jira.usa.gov/browse/LG-10491)

## 🛠 Summary of changes

The sentences "If you are under 18 years of age, you may not be able to verify your identity for a Login.gov account. If you have trouble verifying your identity, please contact the partner agency to find out what you can do." replaces "You will need to verify your identity and secure your account." in the English, Spanish, and French versions of 5.4.1 How to Verify your identity.

## 📸 Screenshots

| English | Spanish | French |
| ----------- | ----------- | ------------- |
| ![Screenshot 2023-08-11 at 11 41 45 AM](https://github.com/18F/identity-site/assets/2381438/503828ba-5c51-412b-9a7e-08f45a0195b2) | ![Screenshot 2023-08-11 at 11 42 14 AM](https://github.com/18F/identity-site/assets/2381438/de112c44-f078-4241-8b84-99caf6eb641c) | ![Screenshot 2023-08-11 at 11 42 27 AM](https://github.com/18F/identity-site/assets/2381438/965ded21-339d-4569-8d76-5c8aca5a966c) |
