### PR TITLE
LG-10861: Use New Version of identity-design-system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@18f/identity-address-search": "^1.0.5",
         "@18f/identity-build-sass": "^1.3.0",
-        "@18f/identity-design-system": "^7.0.1",
+        "@18f/identity-design-system": "^7.1.0",
         "@babel/core": "^7.12.9",
         "@babel/preset-env": "^7.12.7",
         "@babel/preset-typescript": "^7.18.6",
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@18f/identity-design-system": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz",
-      "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.1.0.tgz",
+      "integrity": "sha512-/DChj/p9hju15HMQCtukId2POIhHo25SjZzKh11bklkTICLOBEpPc1GRIkWUIDv5WU/N5DtX1saFafqs+HKnEA==",
       "dependencies": {
         "@uswds/uswds": "^3.4.1"
       },
@@ -12729,9 +12729,9 @@
       }
     },
     "@18f/identity-design-system": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz",
-      "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.1.0.tgz",
+      "integrity": "sha512-/DChj/p9hju15HMQCtukId2POIhHo25SjZzKh11bklkTICLOBEpPc1GRIkWUIDv5WU/N5DtX1saFafqs+HKnEA==",
       "requires": {
         "@uswds/uswds": "^3.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@18f/identity-address-search": "^1.0.5",
     "@18f/identity-build-sass": "^1.3.0",
-    "@18f/identity-design-system": "^7.0.1",
+    "@18f/identity-design-system": "^7.1.0",
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-typescript": "^7.18.6",


### PR DESCRIPTION
## 🎫 Ticket

https://cm-jira.usa.gov/browse/LG-10861

## 🛠 Summary of changes

This PR bumps the version of the identity-design-system to 7.1.0. As of 08/28/2023 that release doesn't exist yet. [This PR](https://github.com/18F/identity-design-system/pull/371) captures the work to create the release.

## 📜 Testing Plan

- [ ] Scan the preview site (in the github `pages/build` action. Does anything look obviously broken?
    - It's pretty unlikely that there's anything broken, but it's definitely worth looking through the preview.


