### PR TITLE
Update outage runbook to cover phone-only outage

### DIFF
--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -4,16 +4,16 @@ This guide is written in a "Choose your own adventure" style to quickly guide yo
 
 For each outcome, you should modify site settings by following the instructions found in the [_Configuring Site Settings_ guide](./configuring-site-settings.md#live-site).
 
-**❓ Is the contact form currently experiencing an unexpected outage?**
+**Is the contact form currently experiencing an unexpected outage?**
 
 - If **YES**, the contact form is experiencing an unexpected outage:
-  - **❓ Is the phone line still available for support?**
+  - **Is the phone line still available for support?**
     - If **YES**, use the following configuration to hide the form and include an alert banner advising that the phone line is still available for support:
 
           contact_unplanned_outage: true
           contact_unplanned_outage_phone_available: true
     - If **NO**, the phone line is not available:
-      - **❓ Is the web-based contact form still available for support?**
+      - **Is the web-based contact form still available for support?**
         - If **YES**, use the following configuration to remove the phone number and keep the form:
 
               contact_phone_number_enabled: false
@@ -22,7 +22,7 @@ For each outcome, you should modify site settings by following the instructions 
               contact_unplanned_outage: true
               contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
-  - **❓ Will the phone line be available during the planned maintenance?**
+  - **Will the phone line be available during the planned maintenance?**
     - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
 
           contact_maintenance_start_time: 1970-01-01T00:00:00Z

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -13,7 +13,7 @@ For each outcome, you should modify site settings by following the instructions 
           contact_unplanned_outage: true
           contact_unplanned_outage_phone_available: true
     - If **NO**, the phone line is not available:
-      - **Is the contact form still available for support?**
+      - **Is the web-based contact form still available for support?**
         - If **YES**, use the following configuration to remove the phone number and keep the form:
 
               contact_phone_number_enabled: false

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -4,16 +4,16 @@ This guide is written in a "Choose your own adventure" style to quickly guide yo
 
 For each outcome, you should modify site settings by following the instructions found in the [_Configuring Site Settings_ guide](./configuring-site-settings.md#live-site).
 
-**Is the contact form currently experiencing an unexpected outage?**
+**❓ Is the contact form currently experiencing an unexpected outage?**
 
 - If **YES**, the contact form is experiencing an unexpected outage:
-  - **Is the phone line still available for support?**
+  - **❓ Is the phone line still available for support?**
     - If **YES**, use the following configuration to hide the form and include an alert banner advising that the phone line is still available for support:
 
           contact_unplanned_outage: true
           contact_unplanned_outage_phone_available: true
     - If **NO**, the phone line is not available:
-      - **Is the web-based contact form still available for support?**
+      - **❓ Is the web-based contact form still available for support?**
         - If **YES**, use the following configuration to remove the phone number and keep the form:
 
               contact_phone_number_enabled: false
@@ -22,7 +22,7 @@ For each outcome, you should modify site settings by following the instructions 
               contact_unplanned_outage: true
               contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
-  - **Will the phone line be available during the planned maintenance?**
+  - **❓ Will the phone line be available during the planned maintenance?**
     - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
 
           contact_maintenance_start_time: 1970-01-01T00:00:00Z

--- a/docs/development-workflows/contact-form-outages.md
+++ b/docs/development-workflows/contact-form-outages.md
@@ -7,17 +7,22 @@ For each outcome, you should modify site settings by following the instructions 
 **Is the contact form currently experiencing an unexpected outage?**
 
 - If **YES**, the contact form is experiencing an unexpected outage:
-  - Is the phone line still available for support?
-    - If **YES**, use the following configuration:
+  - **Is the phone line still available for support?**
+    - If **YES**, use the following configuration to hide the form and include an alert banner advising that the phone line is still available for support:
 
           contact_unplanned_outage: true
           contact_unplanned_outage_phone_available: true
-    - If **NO**, use the following configuration:
+    - If **NO**, the phone line is not available:
+      - **Is the contact form still available for support?**
+        - If **YES**, use the following configuration to remove the phone number and keep the form:
 
-          contact_unplanned_outage: true
-          contact_unplanned_outage_phone_available: false
+              contact_phone_number_enabled: false
+        - If **NO**, use the following configuration to hide the form and include an alert banner advising that support is currently unavailable:
+
+              contact_unplanned_outage: true
+              contact_unplanned_outage_phone_available: false
 - If **NO**, the contact form will be undergoing a planned maintenance in the future:
-  - Will the phone line be available during the planned maintenance?
+  - **Will the phone line be available during the planned maintenance?**
     - If **YES**, use the following configuration and replace start and end times with the relevant [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-formatted date strings:
 
           contact_maintenance_start_time: 1970-01-01T00:00:00Z


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the "Contact Form Outage" workflow guide to cover a scenario where only the phone line is experiencing an outage, but the online support form is still available.

**Why?**: In case of an outage affecting only the phone line where a user can still use the online support form, we can configure that only the phone number be removed from the page.

Preview: https://github.com/18F/identity-site/blob/aduth-outage-runbook-phone-only-outage/docs/development-workflows/contact-form-outages.md

Related:

- Example incident: https://status.login.gov/incidents/kypwq01dq7gs
- Slack discussion: https://gsa-tts.slack.com/archives/C20J64X6V/p1693396986141389

## 📜 Testing Plan

Try following the runbook and applying configuration in local environment, and verify the expected result.