### PR TITLE
9166: Load PO search default translations

### DIFF
--- a/_includes/components/post-office-search.html
+++ b/_includes/components/post-office-search.html
@@ -6,7 +6,7 @@
   ></div>
 
   {% assign timestamp = site.time | date: '%s' %}
-  {% assign uncached_translations_path = page.po_search_translations._idp_translations_file | append: '?ts=' | append: timestamp %}
+  {% assign uncached_translations_path = page.idp_translations_file | append: '?ts=' | append: timestamp %}
 
   <script src="{{uncached_translations_path | relative_url}}"></script>
   <script src="{{'/assets/js/post_office_search.js' | relative_url}}"></script>

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
@@ -3,8 +3,7 @@ title: Find a Participating Post Office to finish identity verification
 child: true
 order: 1
 permalink: /help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/
-po_search_translations:
-  _idp_translations_file: /assets/idp_translations/en.js
+idp_translations_file: /assets/idp_translations/en.js
 ---
 
 {% include components/post-office-search.html %}

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
@@ -3,8 +3,7 @@ title: Find a Participating Post Office to finish identity verification
 child: true
 order: 1
 permalink: /es/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/
-po_search_translations:
-  _idp_translations_file: /assets/idp_translations/es.js
+idp_translations_file: /assets/idp_translations/es.js
 ---
 
 {% include components/post-office-search.html %}

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
@@ -3,8 +3,7 @@ title: Find a Participating Post Office to finish identity verification
 child: true
 order: 1
 permalink: /fr/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/
-po_search_translations:
-  _idp_translations_file: /assets/idp_translations/fr.js
+idp_translations_file: /assets/idp_translations/fr.js
 ---
 
 {% include components/post-office-search.html %}


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-9166)

## 🛠 Summary of changes

PO search page loads in the local default IDP-supplied translation files. This PR depends on https://github.com/18F/identity-site/pull/1150.

Note we append `?ts=` plus the buildtime epoch timestamp to uncache for each build:

<img width="475" alt="image" src="https://github.com/18F/identity-site/assets/5004319/b191371f-530a-4190-970e-2a46973548e7">


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] [Check that timestamp is appended](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/wmg/9166-load-translations/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/)
