### PR TITLE
Rename post_office_search to TSX

### DIFF
--- a/assets/js/post_office_search.tsx
+++ b/assets/js/post_office_search.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+// @ts-ignore
 import AddressSearch from '@18f/identity-address-search';
 
-const elem = document.getElementById('post-office-search');
+const elem = document.getElementById('post-office-search')!;
 const root = createRoot(elem);
 const { addressSearchUrl, locationsSearchUrl } = elem.dataset;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "@axe-core/puppeteer": "^4.5.1",
         "@babel/eslint-plugin": "^7.14.5",
         "@types/jest": "^29.2.6",
+        "@types/react": "^18.2.21",
+        "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
         "eslint": "^8.31.0",
@@ -2778,6 +2780,38 @@
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
@@ -4878,6 +4912,12 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
     "node_modules/damerau-levenshtein": {
@@ -14896,6 +14936,38 @@
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "dev": true
+    },
     "@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
@@ -16453,6 +16525,12 @@
           "dev": true
         }
       }
+    },
+    "csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@axe-core/puppeteer": "^4.5.1",
     "@babel/eslint-plugin": "^7.14.5",
     "@types/jest": "^29.2.6",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
     "eslint": "^8.31.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "strict": true,
     "moduleResolution": "node",
-    "noEmit": true
+    "noEmit": true,
+    "jsx": "preserve",
+    "allowSyntheticDefaultImports": true
   },
   "include": ["./spec", "./assets/js"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ const { NODE_ENV = 'production' } = process.env;
 
 module.exports = /** @type {import('webpack').Configuration} */ ({
   mode: NODE_ENV,
-
   entry: {
     main: './assets/js/main.js',
     contact: './assets/js/contact.js',
@@ -11,11 +10,9 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     partners_contact: './assets/js/partners/contact.js',
     touchpoints_translations: './assets/js/touchpoints_translations.js',
     country_support: './assets/js/country_support.js',
-    post_office_search: './assets/js/post_office_search.js',
+    post_office_search: './assets/js/post_office_search.tsx',
   },
-
   target: ['web'],
-
   output: {
     filename: '[name].js',
     path: `${__dirname}/_site/assets/js`,
@@ -23,7 +20,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
   module: {
     rules: [
       {
-        test: /\.[jt]s$/,
+        test: /\.[jt]sx?$/,
         exclude: /node_modules/,
         use: ['babel-loader'],
       },


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Post Office Search script to use TSX, including required changes to Webpack and TypeScript configurations.

**Why?**

- All of our new scripts should be written in TypeScript
- So that we have the capability of using JSX/TSX file extensions
- So a developer knows to expect JSX syntax

Continues: https://github.com/18F/identity-site/pull/1156#discussion_r1312226619

## 📜 Testing Plan

```
npm run build:js && npm run typecheck
```