### PR TITLE
Create a script to download Touchpoint API results

### DIFF
--- a/scripts/TOUCHPOINTS.md
+++ b/scripts/TOUCHPOINTS.md
@@ -1,0 +1,33 @@
+*WHAT IS THIS?*
+This temporary script is meant as a stopgap to allow a person with a Touchpoint API Key to download results from a survey to their local device. The downloaded data can be used to for in-depth discovery of survey results.
+
+*HOW TO USE IT*
+In the _touchpoint.yml file, enter the form id you wish to retrieve results for as well as your API Key. Change the filename if you don't want to overwrite it.
+
+1. Modify _touchpoint.yml
+2. Run the script: ruby touchpoint.rb
+
+**_touchpoint.yml**
+form_id: The form you want results from
+api_key: Your API key
+start_date: Date starting of results you want
+end_date: Non-inclusive date
+filename: Target save name for csv file
+base_url: 'https://api.gsa.gov/analytics/touchpoints/v1/forms/'
+max_pages: Max number of pages to receive (# of calls to the API maximum)
+languages: The supported languages on the help site (en is assumed)
+
+*WHAT HAPPENS?*
+The script will call the API endpoint up to max_pages as defined in the config file. Each call to the endpoint will receive up to 500 individual results. These are converted into a csv entry in the file when saved.
+
+The end_date value is non-inclusive, so if you provide an end date, it actually stops at 11:59:50 the day prior. If you use the same start and end date, there will be no results.
+
+*COLUMNS*
+_id_: The response ID of the survey result.
+_date_: Date on which the result was submitted, the TIME has been removed to make it easier to create graphs in a spreadsheet.
+_referer_: The page or site that is associated with the help page.
+_user agent_: Visiting device.
+_page_: The help page that is the subject of the survey answer.
+_raw answer_: Untranslated response to the yes/no survey. Since mobile devices can translate on the fly, this value can vary wildly.
+_language_: This is scraped from the page and is relevant for comparing data for specifically supported languages (fr, en, es).
+_english answer_: Translated from the raw language (not all are captured) to yes/no. For those languages not specifically being translated, the value 'err' is used instead of yes or no.

--- a/scripts/_touchpoints.yml
+++ b/scripts/_touchpoints.yml
@@ -1,0 +1,10 @@
+form_id: 'xxxxxx'
+api_key: 'xxxxxx'
+start_date: '2023-09-07'
+end_date: '2023-09-08'
+filename: 'touchpoints.csv'
+base_url: 'https://api.gsa.gov/analytics/touchpoints/v1/forms/'
+max_pages: 500
+languages:
+  - es
+  - fr

--- a/scripts/touchpoints.rb
+++ b/scripts/touchpoints.rb
@@ -1,0 +1,96 @@
+require 'optparse'
+require 'rest-client'
+require 'json'
+require 'yaml'
+
+API_CONFIG = YAML.load_file('_touchpoints.yml')
+MAX_PAGES = API_CONFIG['max_pages']
+CSV_HEADER = "id, date, referer, user agent, page, raw answer, language, english answer\n"
+
+def parse_args
+   options = {}
+
+   options[:form_id]=API_CONFIG['form_id']
+   options[:api_key]=API_CONFIG['api_key']
+   options[:start_date]=API_CONFIG['start_date']
+   options[:end_date]=API_CONFIG['end_date']
+   options[:filename]=API_CONFIG['filename']
+   options[:base_url]=API_CONFIG['base_url']
+
+   options
+end
+
+def make_single_call(base_url, page_number, start_date, end_date, api_key)
+  begin
+    response = RestClient.get(
+      "#{base_url}#{page_number}&start_date=#{start_date}&end_date=#{end_date}",
+      { 'X-Api-Key' => api_key }
+    )
+    JSON.parse(response.body)
+  rescue RestClient::ExceptionWithResponse => e
+    puts "Error making API request: #{e.message}"
+    nil
+  end
+end
+
+def get_language(source)
+  match = API_CONFIG['languages'].find {|lang| source.include?("/#{lang}/")}
+  return match if match
+  return 'en'
+end
+
+def translate(response)
+  translation_dict = {
+    'Si' => 'yes', 'si' => 'yes', 'yes' => 'yes', 'Yes' => 'yes', 'Oui' => 'yes', 'no' => 'no', 'Non' => 'no',
+    'No' => 'no', '是的' => 'yes', '是' => 'yes', '否' => 'no', '不' => 'no', 'はい' => 'yes', '예' => 'yes',
+    '아니오' => 'no', 'បាទ' => 'yes', 'ไม่ใช่' => 'no', 'ใช่' => 'yes', 'না' => 'no', 'हां' => 'yes',
+    'नहीं' => 'no', 'نعم' => 'yes', 'لا' => 'no', 'خیر' => 'yes', 'بەڵێ' => 'yes', 'بله' => 'yes',
+    'أوي' => 'yes', 'Нет' => 'no', 'НЕТ' => 'no', 'Да' => 'yes', 'ДA' => 'yes', 'Ναι' => 'yes',
+    'Hayır' => 'no'
+  }
+  translation_dict[response] || 'err'
+end
+
+def process_data(form_id, api_key, start_date, end_date)
+  base_url = "#{API_CONFIG['base_url']}#{form_id}.json?size=500&page="
+  final_result = CSV_HEADER
+
+  (1..MAX_PAGES).each do |page|
+    result = make_single_call(base_url, page, start_date, end_date, api_key)
+
+    included = result['included'] || []
+    break if included.empty?
+
+    included.each do |data|
+      submission_id = data['id'].to_s
+      attrs = data['attributes']
+      user_agent = attrs['user_agent'].gsub(',', ' ')
+      language = get_language(attrs['page'])
+      translated_answer = translate(attrs['answer_01'].strip)
+      updated_at = attrs['updated_at'][0..9]
+      new_line = "#{submission_id},#{updated_at},#{attrs['referer']},#{user_agent},#{attrs['page']},\
+                  #{attrs['answer_01']},#{language},#{translated_answer}\n"
+      final_result += new_line
+    end
+
+    puts "Received page #{page}/#{MAX_PAGES}"
+  end
+
+  final_result
+end
+
+def save_data_to_csv(data, filename)
+  File.open(filename, 'w') { |file| file.write(data) }
+  puts "Data written to #{filename}"
+end
+
+def main
+  options = parse_args
+  data = process_data(options[:form_id], options[:api_key], options[:start_date], options[:end_date])
+  save_data_to_csv(data, options[:filename])
+end
+
+if __FILE__ == $PROGRAM_NAME
+  main
+end
+


### PR DESCRIPTION
This transient script is meant to alleviate issues with the Touchpoint dashboard, which is having difficulty displaying results for Login.gov IDP survey results.

## 🎫 Ticket
[LG-10566](https://cm-jira.usa.gov/browse/LG-10566)
