### PR TITLE
Add Custom Style to Fix Margin

### DIFF
--- a/_sass/components/_icon-list.scss
+++ b/_sass/components/_icon-list.scss
@@ -1,6 +1,5 @@
 ul.usa-icon-list {
     .page-content__prose & {
         padding-left: 0;
-        margin-top: 0;
     }
 }

--- a/_sass/components/_image-example.scss
+++ b/_sass/components/_image-example.scss
@@ -1,0 +1,3 @@
+.usa-image-example__figcaption {
+    margin-top: 0;
+}

--- a/_sass/components/_image-example.scss
+++ b/_sass/components/_image-example.scss
@@ -1,3 +1,4 @@
+// Remove after: https://cm-jira.usa.gov/browse/LG-11013
 .usa-image-example__figcaption {
     margin-top: 0;
 }

--- a/_sass/components/all.scss
+++ b/_sass/components/all.scss
@@ -7,6 +7,7 @@
 @forward 'header';
 @forward 'hero';
 @forward 'icon-list';
+@forward 'image-example';
 @forward 'language-picker';
 @forward 'layout';
 @forward 'list';


### PR DESCRIPTION
## 🎫 Ticket

This is a followup to the various help center work in [this epic](https://cm-jira.usa.gov/browse/LG-10667). Most specifically it's a followup to [this ticket](https://cm-jira.usa.gov/browse/LG-10527) and this [thread](https://gsa-tts.slack.com/archives/C056RD1NEHW/p1694548172264059?thread_ts=1694465060.661489&cid=C056RD1NEHW).

## 🛠 Summary of changes

This PR changes the margin on two pages so the spacing looks correct. There's a followup ticket ([LG-11013](https://cm-jira.usa.gov/browse/LG-11013)) for cleaning up these styles in the design system.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Observe the margins looks correct on these pages above the icon lists (checkmarks and "x"s)
    - [ ] http://localhost:4000/help/verify-your-identity/how-to-add-images-of-your-state-issued-id/
    - [ ] http://localhost:4000/help/verify-your-identity/accepted-identification-documents/

![Screenshot 2023-09-14 at 09 46 28](https://github.com/18F/identity-site/assets/6818839/fdc6f0fa-e9c1-4fd5-86d5-9d5710e7d33b)
![Screenshot 2023-09-14 at 09 46 20](https://github.com/18F/identity-site/assets/6818839/d358738c-e15d-45a7-ae0d-ee246d23f89b)


