### PR TITLE
Bump versions of address search and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@18f/identity-address-search": "^2.2.0",
+        "@18f/identity-address-search": "^3.0.0",
         "@18f/identity-build-sass": "^1.3.0",
-        "@18f/identity-components": "^1.0.0",
+        "@18f/identity-components": "^2.0.0",
         "@18f/identity-design-system": "^7.1.0",
         "@18f/identity-i18n": "^1.0.1",
         "@babel/core": "^7.12.9",
@@ -105,14 +105,15 @@
       }
     },
     "node_modules/@18f/identity-address-search": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-2.2.0.tgz",
-      "integrity": "sha512-e9x+NWIR/PUAVzYH2Lons6zIuU5lw8tsB7J5xwFx6PkIlmFIsDEYqr5Qao+7O6PZgXqwVDv543RJIU2Xt2nDgg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-3.0.0.tgz",
+      "integrity": "sha512-QUrcQuGsvwGhzMO3wTIJGhX7vKde4bBi4IwvwFeUaxX/LDKs6NYpvfPUdTQza+ASKQmVwOJ7NWUjF74nO4DJOw==",
       "dependencies": {
         "focus-trap": "^6.7.1",
         "swr": "^2.0.0"
       },
       "peerDependencies": {
+        "@18f/identity-i18n": ">=1",
         "react": ">=17"
       }
     },
@@ -133,13 +134,14 @@
       }
     },
     "node_modules/@18f/identity-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-components/-/identity-components-1.0.0.tgz",
-      "integrity": "sha512-J6s8boC/GgMFFc3PRcUfwc5qQbZc09xxgbvcrZMkLlVN7EJEw7azFolnMfFZHE0IVvMr4pLKlMTge465BrZ7zA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-components/-/identity-components-2.0.0.tgz",
+      "integrity": "sha512-NDy2QdyS9XCy3Usss4c7wmfMZdv1mCAGCvaD8XMSQQu4nJbukluOxCZYqnFacYXsRpjrH63iAxBTMN+EGQPQGw==",
       "dependencies": {
         "focus-trap": "^6.7.1"
       },
       "peerDependencies": {
+        "@18f/identity-i18n": ">=1",
         "react": ">=17",
         "react-dom": ">=17"
       }
@@ -13388,9 +13390,9 @@
       }
     },
     "@18f/identity-address-search": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-2.2.0.tgz",
-      "integrity": "sha512-e9x+NWIR/PUAVzYH2Lons6zIuU5lw8tsB7J5xwFx6PkIlmFIsDEYqr5Qao+7O6PZgXqwVDv543RJIU2Xt2nDgg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-address-search/-/identity-address-search-3.0.0.tgz",
+      "integrity": "sha512-QUrcQuGsvwGhzMO3wTIJGhX7vKde4bBi4IwvwFeUaxX/LDKs6NYpvfPUdTQza+ASKQmVwOJ7NWUjF74nO4DJOw==",
       "requires": {
         "focus-trap": "^6.7.1",
         "swr": "^2.0.0"
@@ -13410,9 +13412,9 @@
       }
     },
     "@18f/identity-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-components/-/identity-components-1.0.0.tgz",
-      "integrity": "sha512-J6s8boC/GgMFFc3PRcUfwc5qQbZc09xxgbvcrZMkLlVN7EJEw7azFolnMfFZHE0IVvMr4pLKlMTge465BrZ7zA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-components/-/identity-components-2.0.0.tgz",
+      "integrity": "sha512-NDy2QdyS9XCy3Usss4c7wmfMZdv1mCAGCvaD8XMSQQu4nJbukluOxCZYqnFacYXsRpjrH63iAxBTMN+EGQPQGw==",
       "requires": {
         "focus-trap": "^6.7.1"
       }

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "vnu-jar": "^21.10.12"
   },
   "dependencies": {
-    "@18f/identity-address-search": "^2.2.0",
+    "@18f/identity-address-search": "^3.0.0",
     "@18f/identity-build-sass": "^1.3.0",
     "@18f/identity-design-system": "^7.1.0",
     "@18f/identity-i18n": "^1.0.1",
-    "@18f/identity-components": "^1.0.0",
+    "@18f/identity-components": "^2.0.0",
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.22.5",


### PR DESCRIPTION
## 🎫 [Ticket](https://cm-jira.usa.gov/browse/LG-11001)

## 🛠 Summary of changes

Bump newly-published packages from https://github.com/18F/identity-idp/pull/9257

## 📜 Testing Plan
- [x] Install locally, `make run`, and check that `class i18n` only appears in _site/assets/js/post_office_search.js once
