### PR TITLE
Add translations for title and add sidenav title for PO Search

### DIFF
--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
@@ -1,5 +1,6 @@
 ---
 title: Find a Participating Post Office to finish identity verification
+meta_title: Find a Participating Post Office
 child: true
 order: 1
 permalink: /help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
@@ -1,6 +1,6 @@
 ---
 title: Find a Participating Post Office to finish identity verification
-# meta_title: Find a Participating Post Office
+meta_title: Find a Participating Post Office
 child: true
 order: 1
 permalink: /help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._en.md
@@ -1,6 +1,6 @@
 ---
 title: Find a Participating Post Office to finish identity verification
-meta_title: Find a Participating Post Office
+# meta_title: Find a Participating Post Office
 child: true
 order: 1
 permalink: /help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
@@ -1,6 +1,6 @@
 ---
 title: Encuentra una oficina de correos participante para finalizar la verificación de identidad
-# meta_title: Encuentra una oficina de correos participante
+meta_title: Encuentra una oficina de correos participante
 child: true
 order: 1
 permalink: /es/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
@@ -1,6 +1,6 @@
 ---
 title: Encuentra una oficina de correos participante para finalizar la verificación de identidad
-meta_title: Encuentra una oficina de correos participante
+# meta_title: Encuentra una oficina de correos participante
 child: true
 order: 1
 permalink: /es/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._es.md
@@ -1,5 +1,6 @@
 ---
-title: Find a Participating Post Office to finish identity verification
+title: Encuentra una oficina de correos participante para finalizar la verificación de identidad
+meta_title: Encuentra una oficina de correos participante
 child: true
 order: 1
 permalink: /es/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
@@ -1,5 +1,6 @@
 ---
-title: Find a Participating Post Office to finish identity verification
+title: Trouver un bureau de poste participant pour terminer la vérification de l’identité
+meta_title: Trouver un bureau de poste participant
 child: true
 order: 1
 permalink: /fr/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
@@ -1,6 +1,6 @@
 ---
 title: Trouver un bureau de poste participant pour terminer la vérification de l’identité
-meta_title: Trouver un bureau de poste participant
+# meta_title: Trouver un bureau de poste participant
 child: true
 order: 1
 permalink: /fr/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
+++ b/content/_help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office._fr.md
@@ -1,6 +1,6 @@
 ---
 title: Trouver un bureau de poste participant pour terminer la vérification de l’identité
-# meta_title: Trouver un bureau de poste participant
+meta_title: Trouver un bureau de poste participant
 child: true
 order: 1
 permalink: /fr/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/

--- a/spec/e2e/post_office_search_spec.ts
+++ b/spec/e2e/post_office_search_spec.ts
@@ -23,7 +23,7 @@ describe('PO search page', () => {
       await goto('/help/verify-your-identity/overview/');
 
       const link = await page.waitForXPath(
-        '//a[contains(text(),"Find a Participating Post Office to finish identity verification")]',
+        '//a[contains(text(),"Find a Participating Post Office")]',
         { timeout: 1000 },
       );
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-11267](https://cm-jira.usa.gov/browse/LG-11267) Enable PO Search in the Help Center (While working on this ticket- I discovered we did not have translations for the title and we did not have a meta- title- aka side navigation). This view and the side navigation is currently turned off in production. I wanted to make this separate PR to handle these translations for preparation of enabling the flag that way that code is separate and isolated. 

## Translations
[Gengo]( https://gengo.com/c/job/details/91967897/)
[French](https://docs.google.com/document/d/13qxL_ws3Gdi-bg37YNQ1nRCgjnvBpl-H/edit?usp=drive_link&ouid=116141035080166034135&rtpof=true&sd=true)
[Spanish](https://docs.google.com/document/d/1zNEllAMmm-jvfA5f6Mazye7ihZMrsqOu/edit?usp=drive_link&ouid=116141035080166034135&rtpof=true&sd=true)

## 🛠 Summary of changes
1.  Add side navigation title (that is different than the page title) in English, Spanish, and French
2. Added Spanish and French translations for title on PO Search 

## 📜 Testing Plan
To test changes locally...
- [ ] Step 1: Open file `_config.yml`
- [ ] Step 2: Edit `exclude: true` to `exclude: false` on line 101. This will allow you to observe the side navigation text and test the link.  
- [ ] Step 3: Edit `show_po_search: true` so that you can see the PO Search form (and the title)
- [ ] Step 4: Visit url `http://localhost:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/` in English, Spanish, and French. Inspect the title and side nav title. Click around- check that the Find a Participating Post Office sidenav takes. you to the correct view and language (test for all languages).

## 📸 Screenshots

<img width="1500" alt="Screenshot 2023-10-27 at 11 04 53 AM" src="https://github.com/18F/identity-site/assets/125507397/40f81cda-69c3-460a-b5f3-a2fdf25ab80b">

<img width="1500" alt="Screenshot 2023-10-27 at 11 05 23 AM" src="https://github.com/18F/identity-site/assets/125507397/3221d328-a85a-4d36-bb72-2802d09401bf">

<img width="1501" alt="Screenshot 2023-10-27 at 11 05 40 AM" src="https://github.com/18F/identity-site/assets/125507397/aef9a5e7-21ca-4ae6-8e33-e41722d57250">



