### PR TITLE
Add updated Google Analytics 4 tag for DAP

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,9 @@ contact_maintenance_phone_available: true
 contact_unplanned_outage: false
 contact_unplanned_outage_phone_available: false
 
+# Digital Analytics Program (DAP)
+dap_measurement_id: null
+
 # Used to load country code support
 idp_base_url: https://secure.login.gov
 # for local development:

--- a/_includes/dap.html
+++ b/_includes/dap.html
@@ -1,7 +1,10 @@
-<!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-<script
-  async
-  type="text/javascript"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS"
-  id="_fed_an_ua_tag"
-></script>
+{% if site.dap_measurement_id %}
+  <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.dap_measurement_id }}"></script>
+  <script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', '{{ site.dap_measurement_id }}');
+  </script>
+{% endif %}


### PR DESCRIPTION
## 🛠 Summary of changes

As part of the DAP program's migration to Google Analytics 4, we need to update our tracking tags.

The code changes here assume a configurable measurement ID, which will be assigned in production prior to launch.

## 📜 Testing Plan

Configure a local measurement ID, either using a real value or a fake one like "G-XXXXXXXXXX".

```
# _config.dev.yml
dap_measurement_id: 'G-XXXXXXXXXX'
```

1. Go to http://localhost:4000/
2. Open developer tools
3. Observe no CSP errors in console
4. Observe network collection traffic for analytics in Network tab