### PR TITLE
Unskip valid headers test

### DIFF
--- a/spec/all_pages_spec.rb
+++ b/spec/all_pages_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'all pages' do
         end
       end
 
-      xit 'links to valid headings' do
+      it 'links to valid headings' do
         expect(doc).to link_to_valid_headers
       end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Unskips the test which asserts that all in-page links reference a valid heading by ID.

I noticed this as being skipped but it appears to pass as-is, and would be a useful test to enforce.

## 📜 Testing Plan

```
bundle exec jekyll build
rspec spec/all_pages_spec.rb
```