### PR TITLE
Remove contact form phone location option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,6 @@ contact_form_orgid: '00DU0000000Leux'
 # Contact page phone number enabled (overridden in Cloud.gov Pages)
 contact_phone_number_enabled: false
 contact_phone_number: ''
-contact_phone_number_location: 'bottom' # acceptable values are 'top' and 'bottom'
 
 # Contact page maintenance window
 contact_maintenance_start_time: null

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -45,19 +45,13 @@ common_applications:
 >
   {{ page.intro_content | markdownify }}
 
-  {% if site.contact_phone_number_enabled and site.contact_phone_number and
-    site.contact_phone_number_location == 'top' %}
+  {% if site.contact_phone_number_enabled and site.contact_phone_number %}
     {% include contact_phone.html %}
   {% endif %}
 
   <div class="desktop:grid-col-9">
     {% include contact_form.html common_applications=layout.common_applications %}
   </div>
-
-  {% if site.contact_phone_number_enabled and site.contact_phone_number and
-    site.contact_phone_number_location == 'bottom' %}
-    {% include contact_phone.html %}
-  {% endif %}
 </contact-us-form>
 
 <div class="page-content__section">{{ page.partner_content | markdownify }}</div>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an option to control whether the contact center phone number appears above or below the contact form.

This was previously used in early iterations as part of roll-out testing for the contact center phone number. Since this has now settled, it's not expected we would need to change this via configuration.

## 📜 Testing Plan

Enable phone number in local development:

```
# _config.dev.yml
contact_phone_number_enabled: true
contact_phone_number: '800-555-0100'
```

1. `make run`
2. Observe no errors in build
3. Visit http://localhost:4000/contact/
4. Observe phone number visible above contact form