### PR TITLE
LG-11861 Fix Spacing In PO Search Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Then, start identity-site server locally:
 ``
 make run
 ```
+
 You can then view the site in your browser at http://localhost:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/.
 
 To run specs:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ make run
 
 You can then view the site in your browser at http://localhost:4000 .
 
+To get mock data for Post Office Search:
+
+Update identity-idp config/application.yml with:
+
+```
+in_person_public_address_search_enabled: true
+```
+
+Then, start identity-idp server locally:
+
+```
+make run
+```
+
+Next update identity-site _config.yml with:
+
+```
+po_search_locations_search_url: http://xxx.x.x.x:3000/api/usps_locations
+where xxx.x.x.x is the remote IP address in identity-idp
+```
+
+Then, start identity-site server locally:
+
+``
+make run
+```
+You can then view the site in your browser at http://localhost:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/.
+
 To run specs:
 
 ```

--- a/_includes/components/post-office-search.html
+++ b/_includes/components/post-office-search.html
@@ -1,5 +1,6 @@
 <div
   id="post-office-search"
+  class="find-a-participating-post-office"
   data-address-search-url="{{ site.po_search_address_search_url }}"
   data-locations-search-url="{{ site.po_search_locations_search_url }}"
 ></div>

--- a/_sass/_index.scss
+++ b/_sass/_index.scss
@@ -4,10 +4,11 @@
 @forward 'mixins/all';
 @forward 'components/all';
 
+@forward 'pages/create_an_account';
+@forward 'pages/find_a_participating_post_office';
 @forward 'pages/home';
+@forward 'pages/not_found';
+@forward 'pages/partners';
+@forward 'pages/policy';
 @forward 'pages/what_is_login';
 @forward 'pages/who_uses_login';
-@forward 'pages/create_an_account';
-@forward 'pages/not_found';
-@forward 'pages/policy';
-@forward 'pages/partners';

--- a/_sass/pages/_find_a_participating_post_office.scss
+++ b/_sass/pages/_find_a_participating_post_office.scss
@@ -1,37 +1,35 @@
 @use '../variables' as *;
 
-.help-article {
-    .find-a-participating-post-office {
-        .usa-collection {
-            list-style: none;
-            font-size: 1rem;
-            padding-left: 0rem;
-        }
-    
-        .usa-collection li {
-            border-bottom: $border-style;
-        }
-    
-        .usa-collection__body {
-            margin: 24px 0px;
-            line-height: 1.5rem;
-            font-size: 1rem;
-        }
-    
-        .usa-collection__heading {
-            line-height: 1.68rem;
-            font-size: 1.125rem;
-        }
-    
-        .usa-collection__body h4 {
-            margin-top: 0.5rem;
-            line-height: 1.5rem;
-            font-size: 1rem;
-            font-weight: bold;
-        }
-    
-        .usa-collection__body h4 ~ div {
-            margin-top: 0rem;
-        }
+.find-a-participating-post-office {
+    .usa-collection {
+        list-style: none;
+        font-size: 1rem;
+        padding-left: 0rem;
+    }
+
+    .usa-collection li {
+        border-bottom: $border-style;
+    }
+
+    .usa-collection__body {
+        margin: 24px 0px;
+        line-height: 1.5rem;
+        font-size: 1rem;
+    }
+
+    .usa-collection__heading {
+        line-height: 1.68rem;
+        font-size: 1.125rem;
+    }
+
+    .usa-collection__body h4 {
+        margin-top: 0.5rem;
+        line-height: 1.5rem;
+        font-size: 1rem;
+        font-weight: bold;
+    }
+
+    .usa-collection__body h4 ~ div {
+        margin-top: 0rem;
     }
 }

--- a/_sass/pages/_find_a_participating_post_office.scss
+++ b/_sass/pages/_find_a_participating_post_office.scss
@@ -1,0 +1,35 @@
+@use '../variables' as *;
+
+.help-article {
+    .usa-collection {
+        list-style: none;
+        font-size: 1rem;
+        padding-left: 0rem;
+    }
+
+    .usa-collection li {
+        border-bottom: $border-style;
+    }
+
+    .usa-collection__body {
+        margin: 24px 0px;
+        line-height: 1.5rem;
+        font-size: 1rem;
+    }
+
+    .usa-collection__heading {
+        line-height: 1.68rem;
+        font-size: 1.125rem;
+    }
+
+    .usa-collection__body h4 {
+        margin-top: 0.5rem;
+        line-height: 1.5rem;
+        font-size: 1rem;
+        font-weight: bold;
+    }
+
+    .usa-collection__body h4 ~ div {
+        margin-top: 0rem;
+    }
+}

--- a/_sass/pages/_find_a_participating_post_office.scss
+++ b/_sass/pages/_find_a_participating_post_office.scss
@@ -1,35 +1,37 @@
 @use '../variables' as *;
 
 .help-article {
-    .usa-collection {
-        list-style: none;
-        font-size: 1rem;
-        padding-left: 0rem;
-    }
-
-    .usa-collection li {
-        border-bottom: $border-style;
-    }
-
-    .usa-collection__body {
-        margin: 24px 0px;
-        line-height: 1.5rem;
-        font-size: 1rem;
-    }
-
-    .usa-collection__heading {
-        line-height: 1.68rem;
-        font-size: 1.125rem;
-    }
-
-    .usa-collection__body h4 {
-        margin-top: 0.5rem;
-        line-height: 1.5rem;
-        font-size: 1rem;
-        font-weight: bold;
-    }
-
-    .usa-collection__body h4 ~ div {
-        margin-top: 0rem;
+    .find-a-participating-post-office {
+        .usa-collection {
+            list-style: none;
+            font-size: 1rem;
+            padding-left: 0rem;
+        }
+    
+        .usa-collection li {
+            border-bottom: $border-style;
+        }
+    
+        .usa-collection__body {
+            margin: 24px 0px;
+            line-height: 1.5rem;
+            font-size: 1rem;
+        }
+    
+        .usa-collection__heading {
+            line-height: 1.68rem;
+            font-size: 1.125rem;
+        }
+    
+        .usa-collection__body h4 {
+            margin-top: 0.5rem;
+            line-height: 1.5rem;
+            font-size: 1rem;
+            font-weight: bold;
+        }
+    
+        .usa-collection__body h4 ~ div {
+            margin-top: 0rem;
+        }
     }
 }


### PR DESCRIPTION
## 🎫 Ticket
[LG-11861 ](https://cm-jira.usa.gov/browse/LG-11861) Implementation: Fix spacing in the PO Search results

## 🛠 Summary of changes

- Add documentation on how to get mock data for PO Search buildings locally
- Create css stylesheet for Find a Participating Post Office
- Alpha order and add new style sheet into index.scss file

## 📜 Testing Plan
**Locally**
- [ ] Step 1 Read and follow the instructions "To get mock data for Post Office Search" in the README. Confirm instructions work and are accurate.
- [ ] Step 2 Perform a Post Office Search to get mock data back. Ensure style in [FIGMA](https://www.figma.com/file/I0SvsdxBvxtVvb7sPw3FSY/LG-8944%3A-PO-Search-in-the-Help-Center?type=design&node-id=115-2019&mode=design&t=Gv4Q5QEpLCBv6XLK-0) has been implemented.

**Review App**
- [ ] Step 1 Visit the review app [here](https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/gyamada/LG-11861-fix-spacing-in-po-search-results-v2/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/). Perform a Post Office Search to get mock data back. Ensure style in [FIGMA](https://www.figma.com/file/I0SvsdxBvxtVvb7sPw3FSY/LG-8944%3A-PO-Search-in-the-Help-Center?type=design&node-id=115-2019&mode=design&t=Gv4Q5QEpLCBv6XLK-0) has been implemented.

## 📸 Screenshots

![Screenshot 2024-01-08 at 10 29 20 AM](https://github.com/18F/identity-site/assets/125507397/f7dd7de9-dd3b-43c2-ad2c-583804644a8b)

