### PR TITLE
update pr template with ticket link pre-populated

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 ## 🎫 Ticket
 
 Link to the relevant ticket.
+[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
 -->
 
 <!--


### PR DESCRIPTION
This PR has a pre-populated link for tickets like we do in the `identity-idp` repo.