### PR TITLE
LG-11977: Add American Samoa to updated forms of ID partners site

### DIFF
--- a/content/_partners/faq._en.md
+++ b/content/_partners/faq._en.md
@@ -92,7 +92,7 @@ logistics_accordion:
         content: >-
             At this time, only the following state-issued identification is accepted: 
     
-            - Driver’s license from all 50 states, the District of Columbia (DC), and other U.S. territories (Guam, U.S. Virgin Islands, Mariana Islands and Puerto Rico)
+            - Driver’s license from all 50 states, the District of Columbia (DC), and other U.S. territories (American Samoa, Guam, U.S. Virgin Islands, Mariana Islands and Puerto Rico)
 
             - A non-driver’s license state-issued ID card
               - This is an identity document issued by the state/U.S. territory that asserts identity but does not give driving privileges.


### PR DESCRIPTION
## 🎫 Ticket

[LG-11977](https://cm-jira.usa.gov/browse/LG-11977)

## 🛠 Summary of changes

Add American Samoa on the login.gov partners site for accepted forms of Id.


## 📜 Testing Plan



- [ ] Got to /partners/faq 
- [ ] Under logistics -> _What forms of identification can Login.gov accept for identity proofing?_ confirm American Samoa is listed.



## 📸 Screenshots

If relevant, include a screenshot or screen capture of the changes.

| Before | After |
| ----------- | ----------- |
|<img width="824" alt="Screenshot 2024-01-24 at 11 35 51 AM" src="https://github.com/18F/identity-site/assets/1034049/c17bdf2f-48d3-4603-bf64-de4bed4dc819"> |  <img width="846" alt="Screenshot 2024-01-24 at 11 31 22 AM" src="https://github.com/18F/identity-site/assets/1034049/3b50751d-baf3-4798-8cc8-22c3d3761e61">|



