### PR TITLE
Added periods to "US" and made conform to Oxford comma usage.

### DIFF
--- a/content/_help/verify-your-identity/accepted-identification-documents._en.md
+++ b/content/_help/verify-your-identity/accepted-identification-documents._en.md
@@ -11,8 +11,8 @@ redirect_from:
   - /help/verify-your-identity/accepted-state-issued-identification/
   - /en/help/verify-your-identity/accepted-state-issued-identification/
 do_list: 
-  - "**Driver’s license** from all 50 states, the District of Columbia (DC), and other US territories (Guam, US Virgin Islands, American Samoa, Mariana Islands and Puerto Rico)."
-  - "**Non-driver’s license state-issued ID card.** This is an identity document issued by the state, the District of Columbia (DC), or US territory that asserts identity but does not give driving privileges."
+  - "**Driver’s license** from all 50 states, the District of Columbia (DC), and other U.S. territories (Guam, U.S. Virgin Islands, American Samoa, Mariana Islands, and Puerto Rico)."
+  - "**Non-driver’s license state-issued ID card.** This is an identity document issued by the state, the District of Columbia (DC), or U.S. territory that asserts identity but does not give driving privileges."
 dont_list:
   - You cannot pass identity verification if your ID is expired.
   - You cannot use extension documents in place of an unexpired&nbsp;ID.


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket.
[LG-12089](https://cm-jira.usa.gov/browse/LG-12089)

## 🛠 Summary of changes

Updated help center copy about what forms of ID we accept to conform to login.gov style guide.
Specifically:
- Changed "US" to "U.S."
- Added Oxford commas

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that the rendered help page is updated to use "U.S." and Oxford commas.

## 📸 Screenshots

| Before | After |
| ----------- | ----------- |
|![image](https://github.com/18F/identity-site/assets/101212334/8de9a8ef-b867-4ba6-92b3-589f24a6f0d7)| ![image](https://github.com/18F/identity-site/assets/101212334/130580f5-2758-4a97-a5d2-e88bac731afd) |

