### PR TITLE
Replace broken link to No Fear Act footer resource

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,7 +39,7 @@
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="https://www.gsa.gov/about-us/organization/office-of-civil-rights/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
+            <a href="https://www.gsa.gov/reference/civil-rights-programs/the-no-fear-act"
               class="usa-identifier__required-link usa-link">
               {{ site.data.[page.lang].settings.identifier.links.no_fear_act }}
             </a>

--- a/_includes/partners/footer.html
+++ b/_includes/partners/footer.html
@@ -39,7 +39,7 @@
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="https://www.gsa.gov/about-us/organization/office-of-civil-rights/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
+            <a href="https://www.gsa.gov/reference/civil-rights-programs/the-no-fear-act"
               class="usa-identifier__required-link usa-link">
               {{ site.data.[page.lang].settings.identifier.links.no_fear_act }}
             </a>


### PR DESCRIPTION
## 🛠 Summary of changes

Replaces the footer link for "No Fear Act", which currently 404's, with its equivalent replacement.

See Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1707134895579009

## 📜 Testing Plan

1. Go to https://federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5.sites.pages.cloud.gov/preview/18f/identity-site/aduth-no-fear-act-url/
2. Click "No Fear Act data" in the footer
3. Observe that you're taken to a resource for "Notification and Federal Employee Antidiscrimination and Retaliation Act of 2002: Equal Employment Opportunity No FEAR Act Posting"