### PR TITLE
Run accessibility page tests concurrently

### DIFF
--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -1,6 +1,6 @@
 import { AxePuppeteer } from '@axe-core/puppeteer';
 import { toHaveNoViolations } from 'jest-axe';
-import { page, goto } from './support/browser';
+import { page as globalPage, goto } from './support/browser';
 import { getCandidateLinks, toNotHaveTargetBlank } from './support/target-blank';
 
 expect.extend(toHaveNoViolations);
@@ -27,22 +27,12 @@ describe('accessibility', () => {
 
   for (const [label, viewport] of Object.entries(viewports)) {
     describe(`${label} viewport`, () => {
-      /** @type {import('puppeteer').Viewport} */
-      let originalViewport;
-
-      beforeAll(async () => {
-        originalViewport = page.viewport();
-        await page.setViewport(viewport);
-      });
-
-      afterAll(async () => {
-        await page.setViewport(originalViewport);
-      });
-
-      test.each(paths)(
+      test.concurrent.each(paths)(
         '%s',
         async (path) => {
-          await goto(path);
+          const page = await global.browser.newPage();
+          await page.setViewport(viewport);
+          await page.goto(new URL(path, process.env.ROOT_URL).toString());
           const runner = new AxePuppeteer(page).disableRules('frame-tested').disableFrame('*');
 
           const results = await runner.analyze();
@@ -59,10 +49,10 @@ describe('accessibility', () => {
   describe('"Back to top" link', () => {
     it('resets focus to the beginning of content', async () => {
       await goto('/about-us/');
-      const backToTopLinkHandle = await page.$('.page-content__prose .anchor-to-top');
+      const backToTopLinkHandle = await globalPage.$('.page-content__prose .anchor-to-top');
       await backToTopLinkHandle.click();
-      await page.keyboard.press('Tab');
-      const isFocusBeforeBackToTop = await page.evaluate(
+      await globalPage.keyboard.press('Tab');
+      const isFocusBeforeBackToTop = await globalPage.evaluate(
         (backToTopLink) =>
           backToTopLink.compareDocumentPosition(document.activeElement) ===
           Node.DOCUMENT_POSITION_PRECEDING,

--- a/spec/e2e/accessibility_spec.js
+++ b/spec/e2e/accessibility_spec.js
@@ -40,6 +40,7 @@ describe('accessibility', () => {
 
           const links = await getCandidateLinks(page);
           links.forEach((a) => expect(a).toNotHaveTargetBlank());
+          await page.close();
         },
         TEST_TIMEOUT_MS,
       );

--- a/spec/e2e/support/puppeteer-environment.js
+++ b/spec/e2e/support/puppeteer-environment.js
@@ -10,6 +10,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
       }),
     ]);
 
+    this.global.browser = browser;
     this.global.page = await browser.newPage();
   }
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates existing accessibility tests to run each page's analysis concurrently, using [Jest's `test.concurrent.each`](https://jestjs.io/docs/api#testconcurrenteachtablename-fn-timeout).

The goal of these changes is to reduce the time to complete the continuous integration build, which currently takes upwards of 10 minutes to complete, with most time spent at this step.

The impact is about **35% reduction in the e2e job time**, from around [6m45s](https://app.circleci.com/pipelines/github/18F/identity-site/5431/workflows/af243003-adf9-4a08-89ff-f20ceab10764?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) to [4m15s](https://app.circleci.com/pipelines/github/18F/identity-site/5430/workflows/943a9267-3c21-4aff-bd73-2bb7529a57d4).

The motivation was the long turnaround time in being able to merge [a recent time-sensitive revert](https://github.com/18F/identity-site/pull/1204).

I had also started to explore an [alternative approach which substituted Jest with Node.js' native test runner](https://github.com/18F/identity-site/compare/aduth-node-test-runner-accessibility-2), which may produce slightly better results. The changes proposed here are much simpler, and are slightly incremental in that direction if we wanted to pursue it down the line.

## 📜 Testing Plan

Build should pass.

Running `npm test` locally should also pass and show passing results for each page tested in the accessibility tests.