### PR TITLE
Use home npm cache directory for CircleCI dependencies cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "Gemfile.lock" }}
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
+            - dependencies-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
       - run:
           name: Switch Node.js version
           command: |
@@ -27,12 +24,9 @@ commands:
             bundle install --jobs=4 --retry=3
       - save_cache:
           paths:
+            - ~/.npm
             - ./vendor/bundle
-          key: v3-dependencies-{{ checksum "Gemfile.lock" }}
-      - save_cache:
-          paths:
-            - ./node_modules
-          key: v2-dependencies-{{ checksum "package-lock.json" }}
+          key: dependencies-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
   build-site:
     steps:
       - run:


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `install-dependencies` CircleCI command to improve the effectiveness and performance of dependency installation.

Specifically, it changes from caching the project's local `node_modules` directory to the `~/.npm` directory, which is the default global cache directory. It also combines the Bundler and NPM caches.

In practice, this results in a smaller cache size (faster to restore and save) and less time at the NPM installation step.

And since the `install-dependencies` command happens multiple times throughout workflows, the savings are multiplicative.

### Impact

#### TIming (Dependencies Install)

[**Before**](https://app.circleci.com/pipelines/github/18F/identity-site/5431/workflows/af243003-adf9-4a08-89ff-f20ceab10764/jobs/29918): 1s (Restore bundler cache) + 14s (Restore npm cache) + 26s (Install dependencies) = 41 seconds
[**After**](https://app.circleci.com/pipelines/github/18F/identity-site/5435/workflows/9420a7d7-e961-406f-a37c-5402331b8dcb/jobs/29959): 3s (Restore cache) + 17s (Install dependencies) = 20 seconds
**Diff**: -21 seconds (-48.8%)

#### Cache Size

[**Before**](https://app.circleci.com/pipelines/github/18F/identity-site/5431/workflows/af243003-adf9-4a08-89ff-f20ceab10764/jobs/29918): 23MB (`vendor/bundler`) + 250MB (`node_modules`) = 283MB
[**After**](https://app.circleci.com/pipelines/github/18F/identity-site/5435/workflows/9420a7d7-e961-406f-a37c-5402331b8dcb/jobs/29959): 121MB (`vendor/bundler` + `~/.npm`)
**Diff**: -162MB (-42.8%)

#### Build examples

- [Before (Warm)](https://app.circleci.com/pipelines/github/18F/identity-site/5431/workflows/af243003-adf9-4a08-89ff-f20ceab10764)
- [After (Warm)](https://app.circleci.com/pipelines/github/18F/identity-site/5435/workflows/9420a7d7-e961-406f-a37c-5402331b8dcb)

(Cold times not measured, but I'd expect it to be faster, specifically at "Saving cache", since the saved artifact size is smaller)

## 📜 Testing Plan

Build should pass.