### PR TITLE
Change accessibility aids URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="https://www.gsa.gov/website-information/accessibility-aids" class="usa-identifier__required-link">
+            <a href="https://www.gsa.gov/website-information/accessibility-statement" class="usa-identifier__required-link">
               {{ site.data.[page.lang].settings.identifier.links.accessibility }}
             </a>
           </li>

--- a/_includes/partners/footer.html
+++ b/_includes/partners/footer.html
@@ -28,7 +28,7 @@
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a href="https://www.gsa.gov/website-information/accessibility-aids" class="usa-identifier__required-link">
+            <a href="https://www.gsa.gov/website-information/accessibility-statement" class="usa-identifier__required-link">
               {{ site.data.[page.lang].settings.identifier.links.accessibility }}
             </a>
           </li>


### PR DESCRIPTION
This PR updates the `accessibility-aids` url to the accessibility statement found on the GSA website